### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
         npm install
         npm run compile
     - name: Package Extension
-      if: matrix.os == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
       run: |
         npm install -g vsce
         vsce package
         mkdir vsix
         mv *.vsix vsix
     - name: Archive Extension
-      if: matrix.os == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v1
       with:
         name: vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
         npm install
         npm run compile
     - name: Package Extension
-      if: ${{ matrix.os == ubuntu-latest }}
+      if: matrix.os == ubuntu-latest
       run: |
         npm install -g vsce
         vsce package
     - name: Archive Extension
-      if: ${{ matrix.os == ubuntu-latest }}
+      if: matrix.os == ubuntu-latest
       uses: actions/upload-artifact@v1
       with:
         name: vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - name: Checkout Branch
+      uses: actions/checkout@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        version: 12
+    - name: Build Extension
+      run: |
+        npm install
+        npm run compile
+    - name: Package Extension
+      if: ${{ matrix.os == ubuntu-latest }}
+      run: |
+        npm install -g vsce
+        vsce package
+    - name: Archive Extension
+      if: ${{ matrix.os == ubuntu-latest }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: vsix
+        path: "*.vsix"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
         npm install
         npm run compile
     - name: Package Extension
-      if: matrix.os == "ubuntu-latest"
+      if: matrix.os == 'ubuntu-latest'
       run: |
         npm install -g vsce
         vsce package
     - name: Archive Extension
-      if: matrix.os == "ubuntu-latest"
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v1
       with:
         name: vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,11 @@ jobs:
       run: |
         npm install -g vsce
         vsce package
+        mkdir vsix
+        mv *.vsix vsix
     - name: Archive Extension
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v1
       with:
         name: vsix
-        path: "*.vsix"
+        path: vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
         npm install
         npm run compile
     - name: Package Extension
-      if: matrix.os == ubuntu-latest
+      if: matrix.os == "ubuntu-latest"
       run: |
         npm install -g vsce
         vsce package
     - name: Archive Extension
-      if: matrix.os == ubuntu-latest
+      if: matrix.os == "ubuntu-latest"
       uses: actions/upload-artifact@v1
       with:
         name: vsix

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out
 node_modules
+vsix
 .vscode-test/
 *.vsix


### PR DESCRIPTION
Adds a basic CI and PR validation workflow, with builds initiated on PRs (to `master` branch) and VSIX packaging/archival initiated on commits (to `master` branch). Builds are performed across the three supported platforms to help catch platform-specific issues as well as to serve as a foundation for future unit/integration test execution.