### PR TITLE
Detector feature: Safe handling clunky embedded html responce from app lens api.

### DIFF
--- a/src/commands/detectorDiagnostics/helpers/networkconnectivityhtmlhelper.ts
+++ b/src/commands/detectorDiagnostics/helpers/networkconnectivityhtmlhelper.ts
@@ -18,7 +18,7 @@ export function convertHtmlJsonConfiguration(
     return htmlJsonDataSet;
   }
 
-  return;
+  return undefined;
 }
 
 export function htmlHandlerRegisterHelper() {

--- a/src/commands/detectorDiagnostics/helpers/networkconnectivityhtmlhelper.ts
+++ b/src/commands/detectorDiagnostics/helpers/networkconnectivityhtmlhelper.ts
@@ -5,17 +5,20 @@ export function convertHtmlJsonConfiguration(
   webviewClusterData: AppLensARMResponse["properties"],
   datasetIndex: number
 ): any {
-  // API returns thml embeded in json.
-  const htmlRawDataArray = webviewClusterData.dataset[datasetIndex].table.rows;
+  // ARM call returns html embed in json and at times some index values are not guranteed.
+  if (webviewClusterData.dataset.length >= datasetIndex) {
+    const htmlRawDataArray = webviewClusterData.dataset[datasetIndex].table?.rows;
 
-  const htmlJsonDataSet = {
-    subnet: {
-      subnetClass: htmlRawDataArray[0][0].toString().toLowerCase(),
-      subnetDataset: htmlRawDataArray
-    }
-  };
+    const htmlJsonDataSet = {
+      subnet: {
+        subnetClass: htmlRawDataArray[0][0].toString().toLowerCase(),
+        subnetDataset: htmlRawDataArray
+      }
+    };
+    return htmlJsonDataSet;
+  }
 
-  return htmlJsonDataSet;
+  return;
 }
 
 export function htmlHandlerRegisterHelper() {

--- a/src/commands/detectorDiagnostics/webviews/networkconnectivity/networkConnectivity.html
+++ b/src/commands/detectorDiagnostics/webviews/networkconnectivity/networkConnectivity.html
@@ -41,13 +41,17 @@
                     <div class="panel-heading data-container-heading">
                         <h5 class="panel-title">{{networkconfdata.renderingProperties.title}}</h5>
                     </div>
+                    {{#if networkconfdata}}
                     <div class="panel-body data-container-body">
                         {{#each networkconfdata.table.rows}}
                             {{{this}}}
                         {{/each}}
                     </div>
+                    {{/if}}
                 </div>
             </div>
+
+            {{#if allocatedoutdata.subnet.subnetDataset}}
             <div class="insight-container">
                 <div class="panel panel-default insight-panel {{allocatedoutdata.subnet.subnetClass}}">
                     <div class="panel-heading toggle">
@@ -70,7 +74,9 @@
                     </div>
                 </div>
             </div>
+            {{/if}}
 
+            {{#if subnetdata.subnet.subnetDataset}}
             <div class="insight-container">
                 <div class="panel panel-default insight-panel {{subnetdata.subnet.subnetClass}}">
                     <div class="panel-heading togglesubnet">
@@ -95,7 +101,9 @@
                     </div>
                 </div>
             </div>
+            {{/if}}
 
+            {{#if subneterrordata.subnet.subnetDataset}}
             <div class="insight-container">
                 <div class="panel panel-default insight-panel {{subneterrordata.subnet.subnetClass}}">
                     <div class="panel-heading">
@@ -121,7 +129,9 @@
                     {{/if}}
                 </div>
             </div>
+            {{/if}}
 
+            {{#if domaindata.subnet.subnetDataset}}
             <div class="insight-container">
                 <div class="panel panel-default insight-panel {{domaindata.subnet.subnetClass}}">
                     <div class="panel-heading toggledomaindata">
@@ -146,5 +156,6 @@
                     </div>
                 </div>
             </div>
+            {{/if}}
 </body>
 </html>


### PR DESCRIPTION
I noticed a behaviour that for a cluster once that app lens API was returning data but it was empty for a dataset `(I cannot replicate it, because it was one-off data glitch)`  for some fields and it started working on the second go, so this handle will help in guaranteeing that at least the HTML handling display.

* Added `.length` check to make sure actually the data exist for that index before, read any existing value.
* Added `handlebar` if statements to handle the `html` display` 

Adding them as pro-active checks.

Thanks,
