### PR TITLE
Revert "Fix arm-containerservice deprecated pacakages warning. (#23)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,80 +5,39 @@
     "requires": true,
     "dependencies": {
         "@azure/arm-containerservice": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-11.0.0.tgz",
-            "integrity": "sha512-njebKKSI67ydTDCzqYr/mu/ze7sjaW1ga9ssIhhGE2Jy5dkDJDoErzUGy7IrDw8pCSqPib5kKdlDIMFRfe9HRA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-7.0.1.tgz",
+            "integrity": "sha512-MPdd/7UENmU1Ki+enF2tgujIlb4WV0B/30ove/2v7ssx2JAOgyN9qKbtx0g6YgnaBNBLZm1t1S81RF9JEsS6bg==",
             "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-                }
+                "@azure/ms-rest-azure-js": "^1.3.2",
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.3"
             }
         },
         "@azure/ms-rest-azure-js": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.0.1.tgz",
-            "integrity": "sha512-5e+A710O7gRFISoV4KI/ZyLQbKmjXxQZ1L8Z/sx7jSUQqmswjTnN4yyIZxs5JzfLVkobU0rXxbi5/LVzaI8QXQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-1.3.3.tgz",
+            "integrity": "sha512-QCZBcPiqgEZo34v+R6Gf97N6KVqmm1432rucg+k0Fp2egejYsRho7i39N8mUbNUk/SPmyp3XtI7BqgS+/V8gJQ==",
             "requires": {
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-                }
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.2"
             }
         },
         "@azure/ms-rest-js": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.0.7.tgz",
-            "integrity": "sha512-rQpNxDhyOIyS4E+4sUCBMvjrtbNwB32wH06cC2SFoQM4TR29bIKaTlIC1tMe0K07w9c5tNk/2uUHs6/ld/Z3+A==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.1.tgz",
+            "integrity": "sha512-L2GQCeckQOzY/vIXC8ZNB3cH+4sflWHsViFc/sUzA38xXa2cbXCmiTLGb9XTGE9DIJhCrPng/KIb2797GAkMYg==",
             "requires": {
-                "@types/node-fetch": "^2.3.7",
-                "@types/tunnel": "0.0.1",
-                "abort-controller": "^3.0.0",
-                "form-data": "^2.5.0",
-                "node-fetch": "^2.6.0",
-                "tough-cookie": "^3.0.1",
-                "tslib": "^1.10.0",
+                "@types/tunnel": "0.0.0",
+                "axios": "^0.18.0",
+                "form-data": "^2.3.2",
+                "tough-cookie": "^2.4.3",
+                "tslib": "^1.9.2",
                 "tunnel": "0.0.6",
-                "uuid": "^3.3.2",
+                "uuid": "^3.2.1",
                 "xml2js": "^0.4.19"
             },
             "dependencies": {
-                "form-data": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-                    "requires": {
-                        "ip-regex": "^2.1.0",
-                        "psl": "^1.1.28",
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-                },
                 "tunnel": {
                     "version": "0.0.6",
                     "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -123,49 +82,12 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.9.tgz",
             "integrity": "sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw=="
         },
-        "@types/node-fetch": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-            "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-            "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            },
-            "dependencies": {
-                "combined-stream": {
-                    "version": "1.0.8",
-                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-                    "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-                    "requires": {
-                        "delayed-stream": "~1.0.0"
-                    }
-                },
-                "form-data": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-                    "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                }
-            }
-        },
         "@types/tunnel": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
-            "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
+            "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
             "requires": {
                 "@types/node": "*"
-            }
-        },
-        "abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "requires": {
-                "event-target-shim": "^5.0.0"
             }
         },
         "adal-node": {
@@ -292,6 +214,31 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
+        "axios": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+            "requires": {
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+                }
+            }
+        },
+        "azure-arm-containerservice": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/azure-arm-containerservice/-/azure-arm-containerservice-7.0.0.tgz",
+            "integrity": "sha512-9p1K7SBUi84Y4R05O52+Yp8QgxttHVkZW8EDXJOuB6z8WMcCJuZQ3/HotGa9At8xEYOsb7YcvgJWHWrNvtA0cA==",
+            "requires": {
+                "ms-rest": "^2.5.0",
+                "ms-rest-azure": "^2.5.5"
+            }
+        },
         "azure-arm-resource": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-7.3.0.tgz",
@@ -409,7 +356,8 @@
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
@@ -448,7 +396,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -587,11 +534,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
-        "event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -611,6 +553,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -804,11 +754,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ip-regex": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
         },
         "is-buffer": {
             "version": "1.1.6",
@@ -1018,8 +963,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "ms-rest": {
             "version": "2.5.0",
@@ -1053,11 +997,6 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
             "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-        },
-        "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -1208,7 +1147,8 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
         },
         "source-map-support": {
             "version": "0.5.12",
@@ -1294,8 +1234,7 @@
         "tslib": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-            "dev": true
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
         },
         "tslint": {
             "version": "5.20.1",
@@ -1491,18 +1430,18 @@
             "dev": true
         },
         "xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xmldom": {
             "version": "0.1.27",

--- a/package.json
+++ b/package.json
@@ -81,10 +81,13 @@
         "vscode": "^1.1.6"
     },
     "dependencies": {
-        "@azure/arm-containerservice": "11.0.0",
+        "@azure/arm-containerservice": "^7.0.1",
+        "azure-arm-containerservice": "^7.0.0",
         "azure-arm-resource": "^7.3.0",
         "handlebars": "^4.7.6",
         "js-yaml": "^3.13.1",
+        "ms-rest": "^2.5.0",
+        "ms-rest-azure": "^2.6.0",
         "vscode-azureextensionui": "^0.27.1",
         "vscode-kubernetes-tools-api": "^1.0.0"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import * as azcs from '@azure/arm-containerservice';
-import * as msRestJs from "@azure/ms-rest-js";
+import * as azcs from 'azure-arm-containerservice';  // deprecated, but @azure/arm-containerservice doesn't play nicely with AzureAccount, so...
 
 import { parseResource } from './azure-api-utils';
 import AksClusterTreeItem from './tree/aksClusterTreeItem';
@@ -48,8 +47,7 @@ async function getClusterKubeconfig(target: AksClusterTreeItem): Promise<string 
         vscode.window.showErrorMessage(`Invalid ARM id ${target.id}`);
         return;
     }
-
-    const client = new azcs.ContainerServiceClient(restJSCredentialsFrom(target), target.root.subscriptionId);  // TODO: safely
+    const client = new azcs.ContainerServiceClient(target.root.credentials, target.root.subscriptionId);  // TODO: safely
     try {
         const accessProfile = await client.managedClusters.getAccessProfile(resourceGroupName, name, 'clusterUser');
         const kubeconfig = accessProfile.kubeConfig!.toString();  // TODO: safely
@@ -58,8 +56,4 @@ async function getClusterKubeconfig(target: AksClusterTreeItem): Promise<string 
         vscode.window.showErrorMessage(`Can't get kubeconfig: ${e}`);
         return undefined;
     }
-}
-
-function restJSCredentialsFrom(target: AksClusterTreeItem) {
-    return <msRestJs.ServiceClientCredentials><unknown>target.root.credentials;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6",
-            "DOM"
+            "es6"
         ],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
This reverts commit 292e4b7f91a842a70c1bf27b7958f000f954d83c. (Which is the update of `@azure/containerservices`, we cannot update this package at the moment because we depend on various packages which underneath still on `ms-rest`.

**If anyone keen for details** (readers beside who are already known to issue) 

* Please refer our detail discussion here: https://github.com/Azure/vscode-aks-tools/issues/14#issuecomment-641612514 

Reverting this fixes our `merge + save kubeconfig functionality`

Thanks