### PR TITLE
Fix for rbac save-kubeconfig by using ListClusterUserCredentials.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,8 +49,9 @@ async function getClusterKubeconfig(target: AksClusterTreeItem): Promise<string 
     }
     const client = new azcs.ContainerServiceClient(target.root.credentials, target.root.subscriptionId);  // TODO: safely
     try {
-        const accessProfile = await client.managedClusters.getAccessProfile(resourceGroupName, name, 'clusterUser');
-        const kubeconfig = accessProfile.kubeConfig!.toString();  // TODO: safely
+        const clusterUserCredentials = await client.managedClusters.listClusterUserCredentials(resourceGroupName, name);
+        const kubeconfigList = clusterUserCredentials.kubeconfigs!.filter((kubeInfo) => kubeInfo.name === "clusterUser");  // TODO: safely
+        const kubeconfig = kubeconfigList[0].value?.toString();
         return kubeconfig;
     } catch (e) {
         vscode.window.showErrorMessage(`Can't get kubeconfig: ${e}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,8 +50,8 @@ async function getClusterKubeconfig(target: AksClusterTreeItem): Promise<string 
     const client = new azcs.ContainerServiceClient(target.root.credentials, target.root.subscriptionId);  // TODO: safely
     try {
         const clusterUserCredentials = await client.managedClusters.listClusterUserCredentials(resourceGroupName, name);
-        const kubeconfigList = clusterUserCredentials.kubeconfigs!.filter((kubeInfo) => kubeInfo.name === "clusterUser");  // TODO: safely
-        const kubeconfig = kubeconfigList[0].value?.toString();
+        const kubeconfigCredResult = clusterUserCredentials.kubeconfigs!.find((kubeInfo) => kubeInfo.name === "clusterUser");
+        const kubeconfig = kubeconfigCredResult?.value?.toString();
         return kubeconfig;
     } catch (e) {
         vscode.window.showErrorMessage(`Can't get kubeconfig: ${e}`);


### PR DESCRIPTION
This PR is to fix `rbac related save-kubeconfig` issue: https://github.com/Azure/vscode-aks-tools/issues/4

Also seems like it is recommended to use `listClusterUserCredentials` instead of `getaccessprofiler` here https://docs.microsoft.com/en-us/rest/api/aks/managedclusters/getaccessprofile 

Opening this as a draft for Ivan to take a quick look. Thanks.

cc: @itowlson 