### PR TITLE
Telemetry wrapper for register command.

### DIFF
--- a/src/commands/periscope/periscope.ts
+++ b/src/commands/periscope/periscope.ts
@@ -14,7 +14,6 @@ import {
 } from './helpers/periscopehelper';
 import { PeriscopeStorage } from './models/storage';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
-import { reporter } from '../utils/reporter';
 
 export default async function periscope(
     context: IActionContext,
@@ -22,8 +21,6 @@ export default async function periscope(
 ): Promise<void> {
     const kubectl = await k8s.extension.kubectl.v1;
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
-    // ToDo: Generalise this for other feature as wrapper.
-    reporter.sendTelemetryEvent("command", { command: "aks.periscope" });
 
     if (cloudExplorer.available && kubectl.available) {
         const clusterTarget = cloudExplorer.api.resolveCommandTarget(target);

--- a/src/commands/utils/host.ts
+++ b/src/commands/utils/host.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import { registerCommand } from 'vscode-azureextensionui';
+import { reporter } from '../utils/reporter';
 
 const meta = require('../../../package.json');
 
@@ -19,4 +21,13 @@ export function getExtensionPath(): string | undefined {
         return;
     }
     return vscodeExtensionPath;
+}
+
+export function registerCommandWithTelemetry(
+    commandId: string,
+    callback: any
+) {
+
+    reporter.sendTelemetryEvent("command", { command: commandId });
+    registerCommand(commandId, callback);
 }

--- a/src/commands/utils/host.ts
+++ b/src/commands/utils/host.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode';
-import { registerCommand } from 'vscode-azureextensionui';
-import { reporter } from '../utils/reporter';
 
 const meta = require('../../../package.json');
 
@@ -21,13 +19,4 @@ export function getExtensionPath(): string | undefined {
         return;
     }
     return vscodeExtensionPath;
-}
-
-export function registerCommandWithTelemetry(
-    commandId: string,
-    callback: any
-) {
-
-    reporter.sendTelemetryEvent("command", { command: commandId });
-    registerCommand(commandId, callback);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,12 +2,13 @@ import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import AksClusterTreeItem from './tree/aksClusterTreeItem';
 import AzureAccountTreeItem from './tree/azureAccountTreeItem';
-import { createTelemetryReporter, registerUIExtensionVariables, AzExtTreeDataProvider, AzureUserInput, registerCommand } from 'vscode-azureextensionui';
+import { createTelemetryReporter, registerUIExtensionVariables, AzExtTreeDataProvider, AzureUserInput } from 'vscode-azureextensionui';
 import selectSubscriptions from './commands/selectSubscriptions';
 import detectorDiagnostics from './commands/detectorDiagnostics/detectorDiagnostics';
 import periscope from './commands/periscope/periscope';
 import * as clusters from './commands/utils/clusters';
 import { Reporter } from './commands/utils/reporter';
+import { registerCommandWithTelemetry } from './commands/utils/host';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -27,9 +28,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
         registerUIExtensionVariables(uiExtensionVariables);
 
-        registerCommand('aks.selectSubscriptions', selectSubscriptions);
-        registerCommand('aks.detectorDiagnostics', detectorDiagnostics);
-        registerCommand('aks.periscope', periscope);
+        registerCommandWithTelemetry('aks.selectSubscriptions', selectSubscriptions);
+        registerCommandWithTelemetry('aks.detectorDiagnostics', detectorDiagnostics);
+        registerCommandWithTelemetry('aks.periscope', periscope);
 
         const azureAccountTreeItem = new AzureAccountTreeItem();
         context.subscriptions.push(azureAccountTreeItem);


### PR DESCRIPTION
Draft PR to get some thoughts on generalising the `telemetry` with the `registerCommand`. 

This work creates a helper for `registerCommand` + `EnableTelemetry` ==> `registerCommandWithTelemetry` and everytime user will run any feature under this extension telemetry data will also be part of it.

I have tested the following the changes locally and they appear the `VSCodeExt` db for telemetry. 

* Associated work item: https://github.com/Azure/vscode-aks-tools/issues/34 

Thanks heaps, cc: @itowlson 🙏😊
