### PR TITLE
Fix download spelling.

### DIFF
--- a/resources/webviews/periscope/periscope.html
+++ b/resources/webviews/periscope/periscope.html
@@ -99,7 +99,7 @@
                                 <tr>
                                     <th>Timestamp</th>
                                     <th>Node Name</th>
-                                    <th>Downloade Now</th>
+                                    <th>Download Now</th>
                                     <th>7-day Shareable Link</th>
                                 </tr>
                                 {{#each downloadAndShareNodeLogsList}}


### PR DESCRIPTION
* Fix the spelling of `Download` not `Downloade`. 

cc: @itowlson, thank you.