### PR TITLE
Handle sceanrio when api-resource returns empty for all cluster without ASO installed.

### DIFF
--- a/src/commands/azureServiceOperators/ui/azureservicebrowser.ts
+++ b/src/commands/azureServiceOperators/ui/azureservicebrowser.ts
@@ -1,10 +1,15 @@
 import * as k8s from 'vscode-kubernetes-tools-api';
 import * as vscode from 'vscode';
+import { Errorable } from '../../utils/errorable';
 
 interface AzureServiceKind {
     readonly displayName: string;
     readonly manifestKind: string;
     readonly abbreviation: string;
+}
+
+enum ASOInstallation {
+    ASONotInstalled = 'ASONotInstalled'
 }
 
 export async function AzureServiceBrowser(explorer: k8s.ClusterExplorerV1): Promise<k8s.ClusterExplorerV1.NodeContributor> {
@@ -16,25 +21,33 @@ export async function AzureServiceBrowser(explorer: k8s.ClusterExplorerV1): Prom
 }
 
 async function allServiceKinds(): Promise<AzureServiceKind[] | undefined> {
+    const apiResult = await getAPIResourceCommandResult();
+
+    if (apiResult.succeeded) {
+        return apiResult.result;
+    } else if (apiResult.error !== ASOInstallation.ASONotInstalled) {
+        vscode.window.showWarningMessage(apiResult.error);
+    }
+    return undefined;
+}
+
+async function getAPIResourceCommandResult(): Promise<Errorable<AzureServiceKind[]>> {
     const kubectl = await k8s.extension.kubectl.v1;
 
     if (!kubectl.available) {
-        vscode.window.showWarningMessage(`Kubectl is unavailable.`);
-        return undefined;
+        return { succeeded: false, error: `Kubectl is unavailable.` };
     }
     const asoAPIResourceCommandResult = await kubectl.api.invokeCommand("api-resources --api-group azure.microsoft.com --no-headers");
 
-    if (!asoAPIResourceCommandResult) { // Fail to invoke command
-        vscode.window.showWarningMessage(`Azure Service Operator api-resources failed to invoke command.`);
-        return undefined;
+    if (!asoAPIResourceCommandResult) { // Fail to invoke command.
+        return { succeeded: false, error: `Azure Service Operator api-resources failed to invoke command.` };
     } else if (asoAPIResourceCommandResult.code !== 0 && !asoAPIResourceCommandResult.stdout) { // Error result and Faild execution.
-        vscode.window.showWarningMessage(`Azure Service Operator api-resources command failed with following error: ${asoAPIResourceCommandResult?.stderr}.`);
-        return undefined;
+        return { succeeded: false, error: `Azure Service Operator api-resources command failed with following error: ${asoAPIResourceCommandResult?.stderr}.` };
     } else if (asoAPIResourceCommandResult.code === 0 && !asoAPIResourceCommandResult.stdout) { // No ASO installed.
-        return undefined;
-    } else {
+        return { succeeded: false, error: ASOInstallation.ASONotInstalled };
+    } else { // success sceanrio.
         const treeResourceItems = asoAPIResourceCommandResult.stdout.split("\n").map((line: string) => line.trim()).filter((line: string | any[]) => line.length > 0);
-        return treeResourceItems.map((item: string) => parseServiceResource(item)!);
+        return { succeeded: true, result: treeResourceItems.map((item: string) => parseServiceResource(item)!) };
     }
 }
 

--- a/src/commands/azureServiceOperators/ui/azureservicebrowser.ts
+++ b/src/commands/azureServiceOperators/ui/azureservicebrowser.ts
@@ -23,7 +23,12 @@ async function allServiceKinds(): Promise<AzureServiceKind[] | undefined> {
         return undefined;
     }
     const asoAPIResourceCommandResult = await kubectl.api.invokeCommand("api-resources --api-group azure.microsoft.com --no-headers");
-    if (!asoAPIResourceCommandResult || (asoAPIResourceCommandResult.code !== 0 && !asoAPIResourceCommandResult.stdout)) {
+
+    if (!asoAPIResourceCommandResult) {
+        return undefined;
+    }
+
+    if (asoAPIResourceCommandResult.code !== 0 && !asoAPIResourceCommandResult.stdout) {
         vscode.window.showWarningMessage(`Azure Service Operator api-resources command failed with following error: ${asoAPIResourceCommandResult?.stderr}.`);
         return undefined;
     }


### PR DESCRIPTION
I found this last night when I was just playing around with this feature in extension, that `api-resources --api-group azure.microsoft.com --no-headers` always return `Empty` result, with `exit code == 0` when the ASO service is not installed. This can only be re-pro when you follow specific steps mentioned below.

**For example:** (I created new acs-cluster which has ASO not installed, and ran : kubectl for aspi-resource), this is what I get as result. Essentially when the resource is installed,  the kubectl will return something.

<img width="692" alt="Screen Shot 2021-02-23 at 10 04 06 AM" src="https://user-images.githubusercontent.com/6233295/108770828-af965380-75bf-11eb-8256-6f72e44b9b4c.png">

**Specific steps to repro in Extension** 

* Create new aks-cluster and then set it as current context.
* Now close the extension and re-open it, what will happen is that the `registerNode` function will trigger and hit this line of code where is `return` of `api-resource` is empty it will fire a false warning message.

The easiest fix is that if the `kubectl` returns empty for the `api-resource` we do nothing. 

Thank you for taking time and reviewing This.
