### PR TITLE
Remove github build badge due to github SVG issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml)
-
 # Azure Kubernetes Service (AKS) Extension for Visual Studio Code (Preview)
 
 * View your AKS clusters in the Kubernetes extension cloud explorer


### PR DESCRIPTION
This is to remove the build badge because gihutb has security issue regarding this: 

Some details about this issue here: 

* https://github.com/microsoft/vscode-vsce/issues/183 
* https://github.com/isaacs/github/issues/316 
* https://stackoverflow.com/questions/13808020/include-an-svg-hosted-on-github-in-markdown/16462143#16462143

Thanks heaps, @itowlson 🙏