### PR TITLE
update azure-storage package to fix npm vsce error.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@azure/arm-subscriptions": "^3.0.0",
                 "@azure/storage-blob": "^12.7.0",
                 "axios": "^0.19.2",
-                "azure-storage": "^2.10.3",
+                "azure-storage": "^2.10.5",
                 "filemanager-webpack-plugin": "^4.0.0",
                 "handlebars": "^4.7.6",
                 "js-yaml": "^3.14.0",
@@ -1390,9 +1390,10 @@
             }
         },
         "node_modules/azure-storage": {
-            "version": "2.10.4",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.4.tgz",
-            "integrity": "sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==",
+            "version": "2.10.5",
+            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
+            "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "browserify-mime": "~1.2.9",
                 "extend": "^3.0.2",
@@ -1400,9 +1401,9 @@
                 "md5.js": "1.3.4",
                 "readable-stream": "~2.0.0",
                 "request": "^2.86.0",
-                "underscore": "~1.8.3",
+                "underscore": "^1.12.1",
                 "uuid": "^3.0.0",
-                "validator": "~9.4.1",
+                "validator": "~13.6.0",
                 "xml2js": "0.2.8",
                 "xmlbuilder": "^9.0.7"
             },
@@ -6080,9 +6081,9 @@
             "dev": true
         },
         "node_modules/validator": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-            "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==",
+            "version": "13.6.0",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+            "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -7751,9 +7752,9 @@
             }
         },
         "azure-storage": {
-            "version": "2.10.4",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.4.tgz",
-            "integrity": "sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==",
+            "version": "2.10.5",
+            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
+            "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
             "requires": {
                 "browserify-mime": "~1.2.9",
                 "extend": "^3.0.2",
@@ -7761,9 +7762,9 @@
                 "md5.js": "1.3.4",
                 "readable-stream": "~2.0.0",
                 "request": "^2.86.0",
-                "underscore": "~1.8.3",
+                "underscore": "^1.12.1",
                 "uuid": "^3.0.0",
-                "validator": "~9.4.1",
+                "validator": "~13.6.0",
                 "xml2js": "0.2.8",
                 "xmlbuilder": "^9.0.7"
             },
@@ -11541,9 +11542,9 @@
             "dev": true
         },
         "validator": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-            "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+            "version": "13.6.0",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+            "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
         },
         "verror": {
             "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "@azure/arm-subscriptions": "^3.0.0",
         "@azure/storage-blob": "^12.7.0",
         "axios": "^0.19.2",
-        "azure-storage": "^2.10.3",
+        "azure-storage": "^2.10.5",
         "filemanager-webpack-plugin": "^4.0.0",
         "handlebars": "^4.7.6",
         "js-yaml": "^3.14.0",


### PR DESCRIPTION
This PR fixes the ubuntu `vice package` error, just involve updating of `azure-storage` package to the latest.

Screenshot of successful run in WSL. Thanks 🙏

![image](https://user-images.githubusercontent.com/6233295/138005312-771873c6-3ba1-44c2-b2b3-0684f885eac6.png)


