### PR TITLE
Upgrade deprecated azure-storage package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "0.0.9",
+            "version": "0.0.10",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-containerservice": "^7.0.1",
@@ -15,7 +15,6 @@
                 "@azure/arm-storage": "^15.2.0",
                 "@azure/arm-subscriptions": "^3.0.0",
                 "@azure/storage-blob": "^12.7.0",
-                "azure-storage": "^2.10.5",
                 "filemanager-webpack-plugin": "^4.0.0",
                 "handlebars": "^4.7.7",
                 "js-yaml": "^3.14.0",
@@ -36,7 +35,6 @@
                 "ts-loader": "^8.0.18",
                 "tslint": "^5.20.1",
                 "typescript": "^3.7.2",
-                "vscode": "^1.1.6",
                 "webpack": "^5.25.1",
                 "webpack-cli": "^4.5.0"
             },
@@ -706,15 +704,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@types/eslint": {
             "version": "7.2.7",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
@@ -1032,41 +1021,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/agent-base/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/agent-base/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1077,17 +1031,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-            "dependencies": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
             }
         },
         "node_modules/ajv-keywords": {
@@ -1279,22 +1222,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1366,72 +1293,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-        },
-        "node_modules/azure-storage": {
-            "version": "2.10.5",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
-            "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "browserify-mime": "~1.2.9",
-                "extend": "^3.0.2",
-                "json-edm-parser": "0.1.2",
-                "md5.js": "1.3.4",
-                "readable-stream": "~2.0.0",
-                "request": "^2.86.0",
-                "underscore": "^1.12.1",
-                "uuid": "^3.0.0",
-                "validator": "~13.6.0",
-                "xml2js": "0.2.8",
-                "xmlbuilder": "^9.0.7"
-            },
-            "engines": {
-                "node": ">= 0.8.26"
-            }
-        },
-        "node_modules/azure-storage/node_modules/readable-stream": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/azure-storage/node_modules/sax": {
-            "version": "0.5.8",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-            "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
-        },
-        "node_modules/azure-storage/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "node_modules/azure-storage/node_modules/xml2js": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-            "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
-            "dependencies": {
-                "sax": "0.5.x"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1469,14 +1330,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-        },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -1521,17 +1374,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
-        },
-        "node_modules/browserify-mime": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
-            "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
         },
         "node_modules/browserslist": {
             "version": "4.16.3",
@@ -1613,11 +1455,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
             "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
             "dev": true
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -1940,17 +1777,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/dayjs": {
             "version": "1.10.4",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
@@ -2192,15 +2018,6 @@
                 "domelementtype": "1"
             }
         },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "node_modules/electron-to-chromium": {
             "version": "1.3.687",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
@@ -2324,21 +2141,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "node_modules/es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "dependencies": {
-                "es6-promise": "^4.0.3"
             }
         },
         "node_modules/escalade": {
@@ -2587,11 +2389,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
         "node_modules/extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -2651,19 +2448,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "engines": [
-                "node >=0.6.0"
-            ]
-        },
-        "node_modules/fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "node_modules/fast-glob": {
             "version": "2.2.7",
@@ -2916,14 +2700,6 @@
             "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -2991,14 +2767,6 @@
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/glob": {
@@ -3074,15 +2842,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
-        "node_modules/growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.x"
-            }
-        },
         "node_modules/handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -3112,26 +2871,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-            "dependencies": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -3241,38 +2980,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/hash-base": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.6.0",
-                "safe-buffer": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/hash-base/node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/hash-base/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "node_modules/he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true,
-            "bin": {
-                "he": "bin/he"
-            }
-        },
         "node_modules/html-to-text": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
@@ -3315,93 +3022,6 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^3.1.1"
             }
-        },
-        "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dev": true,
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/https-proxy-agent/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/https-proxy-agent/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
@@ -3662,11 +3282,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "node_modules/is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3701,11 +3316,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "node_modules/jest-worker": {
             "version": "26.6.2",
@@ -3760,39 +3370,16 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "node_modules/json-edm-parser": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
-            "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
-            "dependencies": {
-                "jsonparse": "~1.2.0"
-            }
-        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
-        "node_modules/json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "node_modules/json5": {
             "version": "2.2.0",
@@ -3821,28 +3408,6 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonparse": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-            "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=",
-            "engines": [
-                "node >= 0.2.0"
-            ]
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
             }
         },
         "node_modules/junk": {
@@ -4014,15 +3579,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/md5.js": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-            "dependencies": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
-            }
-        },
         "node_modules/memory-fs": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -4161,76 +3717,6 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
-        "node_modules/mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-            "dev": true,
-            "dependencies": {
-                "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
-            },
-            "bin": {
-                "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/mocha/node_modules/commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-            "dev": true
-        },
-        "node_modules/mocha/node_modules/diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/mocha/node_modules/supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4304,14 +3790,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/object-copy": {
@@ -4648,11 +4126,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
         "node_modules/picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -4708,11 +4181,6 @@
                 "node": ">= 0.6.0"
             }
         },
-        "node_modules/process-nextick-args": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
         "node_modules/prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -4730,14 +4198,6 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/queue-microtask": {
@@ -4813,36 +4273,6 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/resolve": {
@@ -4928,11 +4358,6 @@
             "dependencies": {
                 "ret": "~0.1.10"
             }
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sax": {
             "version": "1.2.4",
@@ -5271,16 +4696,6 @@
                 "urix": "^0.1.0"
             }
         },
-        "node_modules/source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-            "dev": true,
-            "dependencies": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
-            }
-        },
         "node_modules/source-map-url": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
@@ -5301,25 +4716,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        },
-        "node_modules/sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/stack-chain": {
             "version": "1.3.7",
@@ -5830,22 +5226,6 @@
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
         "node_modules/typescript": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
@@ -6006,49 +5386,6 @@
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
-        "node_modules/validator": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-            "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "node_modules/vscode": {
-            "version": "1.1.37",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-            "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
-            "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.2",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "mocha": "^5.2.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "vscode-test": "^0.4.1"
-            },
-            "bin": {
-                "vscode-install": "bin/install"
-            },
-            "engines": {
-                "node": ">=8.9.3"
-            }
-        },
         "node_modules/vscode-azureextensionui": {
             "version": "0.39.4",
             "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.4.tgz",
@@ -6196,57 +5533,6 @@
             },
             "engines": {
                 "vscode": "^1.19.1"
-            }
-        },
-        "node_modules/vscode-test": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-            "dev": true,
-            "dependencies": {
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.9.3"
-            }
-        },
-        "node_modules/vscode-test/node_modules/agent-base": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-            "dev": true,
-            "dependencies": {
-                "es6-promisify": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/vscode-test/node_modules/http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
-            }
-        },
-        "node_modules/vscode-test/node_modules/https-proxy-agent": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/watchpack": {
@@ -7085,12 +6371,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.2.tgz",
             "integrity": "sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww=="
         },
-        "@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "7.2.7",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
@@ -7395,32 +6675,6 @@
             "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
             "dev": true
         },
-        "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "requires": {
-                "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
-            }
-        },
         "aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -7428,17 +6682,6 @@
             "requires": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
-            }
-        },
-        "ajv": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-            "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
             }
         },
         "ajv-keywords": {
@@ -7596,19 +6839,6 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
-        "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -7659,67 +6889,6 @@
                 "array-filter": "^1.0.0"
             }
         },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-        },
-        "azure-storage": {
-            "version": "2.10.5",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
-            "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
-            "requires": {
-                "browserify-mime": "~1.2.9",
-                "extend": "^3.0.2",
-                "json-edm-parser": "0.1.2",
-                "md5.js": "1.3.4",
-                "readable-stream": "~2.0.0",
-                "request": "^2.86.0",
-                "underscore": "^1.12.1",
-                "uuid": "^3.0.0",
-                "validator": "~13.6.0",
-                "xml2js": "0.2.8",
-                "xmlbuilder": "^9.0.7"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "sax": {
-                    "version": "0.5.8",
-                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-                    "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "xml2js": {
-                    "version": "0.2.8",
-                    "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-                    "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
-                    "requires": {
-                        "sax": "0.5.x"
-                    }
-                }
-            }
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -7753,14 +6922,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "big.js": {
             "version": "5.2.2",
@@ -7801,17 +6962,6 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
-        },
-        "browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
-        },
-        "browserify-mime": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
-            "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
         },
         "browserslist": {
             "version": "4.16.3",
@@ -7878,11 +7028,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
             "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
             "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
             "version": "2.4.2",
@@ -8142,14 +7287,6 @@
                 "which": "^2.0.1"
             }
         },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "dayjs": {
             "version": "1.10.4",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
@@ -8347,15 +7484,6 @@
                 "domelementtype": "1"
             }
         },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "electron-to-chromium": {
             "version": "1.3.687",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
@@ -8455,21 +7583,6 @@
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
-            }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "^4.0.3"
             }
         },
         "escalade": {
@@ -8656,11 +7769,6 @@
                 }
             }
         },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -8707,16 +7815,6 @@
                     "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
                 }
             }
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
-        "fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "fast-glob": {
             "version": "2.2.7",
@@ -8928,11 +8026,6 @@
             "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
         "form-data": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -8986,14 +8079,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "glob": {
             "version": "7.1.3",
@@ -9060,12 +8145,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
-        "growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true
-        },
         "handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -9088,20 +8167,6 @@
                     "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                     "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
                 }
-            }
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-            "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -9188,34 +8253,6 @@
                 }
             }
         },
-        "hash-base": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-            "requires": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.6.0",
-                "safe-buffer": "^5.2.0"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
-        },
         "html-to-text": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
@@ -9250,71 +8287,6 @@
                 "entities": "^1.1.1",
                 "inherits": "^2.0.1",
                 "readable-stream": "^3.1.1"
-            }
-        },
-        "http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dev": true,
-            "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
-        },
-        "https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
-            "requires": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "human-signals": {
@@ -9501,11 +8473,6 @@
                 "has-symbols": "^1.0.1"
             }
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -9531,11 +8498,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jest-worker": {
             "version": "26.6.2",
@@ -9580,39 +8542,16 @@
                 "esprima": "^4.0.0"
             }
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "json-edm-parser": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
-            "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
-            "requires": {
-                "jsonparse": "~1.2.0"
-            }
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "json5": {
             "version": "2.2.0",
@@ -9637,22 +8576,6 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "jsonparse": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-            "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
             }
         },
         "junk": {
@@ -9795,15 +8718,6 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "md5.js": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-            "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
-            }
-        },
         "memory-fs": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -9917,62 +8831,6 @@
                 "minimist": "0.0.8"
             }
         },
-        "mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-            "dev": true,
-            "requires": {
-                "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.15.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-                    "dev": true
-                },
-                "diff": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-                    "dev": true
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -10035,11 +8893,6 @@
             "requires": {
                 "path-key": "^3.0.0"
             }
-        },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -10295,11 +9148,6 @@
                 }
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -10334,11 +9182,6 @@
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
-        "process-nextick-args": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -10354,11 +9197,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "queue-microtask": {
             "version": "1.2.2",
@@ -10419,33 +9257,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-        },
-        "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            }
         },
         "resolve": {
             "version": "1.13.1",
@@ -10514,11 +9325,6 @@
             "requires": {
                 "ret": "~0.1.10"
             }
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
             "version": "1.2.4",
@@ -10796,16 +9602,6 @@
                 "urix": "^0.1.0"
             }
         },
-        "source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
-            }
-        },
         "source-map-url": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
@@ -10823,22 +9619,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        },
-        "sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
         },
         "stack-chain": {
             "version": "1.3.7",
@@ -11257,19 +10037,6 @@
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
         "typescript": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
@@ -11395,36 +10162,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
-        },
-        "validator": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-            "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "vscode": {
-            "version": "1.1.37",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-            "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "mocha": "^5.2.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "vscode-test": "^0.4.1"
-            }
         },
         "vscode-azureextensionui": {
             "version": "0.39.4",
@@ -11554,47 +10291,6 @@
             "integrity": "sha512-5uqMeg7sjsu1/QkmuRtBOXtZnnrCXAMEihbOSxan3bk2NdA/nZvhfhfLh8gd9FlBBL56QH69I8Zn25B2yGPRng==",
             "requires": {
                 "tas-client": "0.1.16"
-            }
-        },
-        "vscode-test": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1"
-            },
-            "dependencies": {
-                "agent-base": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-                    "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-                    "dev": true,
-                    "requires": {
-                        "es6-promisify": "^5.0.0"
-                    }
-                },
-                "http-proxy-agent": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-                    "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "4",
-                        "debug": "3.1.0"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "^4.3.0",
-                        "debug": "^3.1.0"
-                    }
-                }
             }
         },
         "watchpack": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
         "ts-loader": "^8.0.18",
         "tslint": "^5.20.1",
         "typescript": "^3.7.2",
-        "vscode": "^1.1.6",
         "webpack": "^5.25.1",
         "webpack-cli": "^4.5.0"
     },
@@ -146,7 +145,6 @@
         "@azure/arm-storage": "^15.2.0",
         "@azure/arm-subscriptions": "^3.0.0",
         "@azure/storage-blob": "^12.7.0",
-        "azure-storage": "^2.10.5",
         "filemanager-webpack-plugin": "^4.0.0",
         "handlebars": "^4.7.7",
         "js-yaml": "^3.14.0",

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -17,7 +17,7 @@ const tmp = require('tmp');
 const {
     BlobServiceClient,
     StorageSharedKeyCredential
-} = require("@azure/storage-blob"); 
+} = require("@azure/storage-blob");
 
 export async function getClusterDiagnosticSettings(
     cluster: AksClusterTreeItem

--- a/src/commands/utils/azurestorage.ts
+++ b/src/commands/utils/azurestorage.ts
@@ -41,10 +41,9 @@ export function getSASKey(
 
     const permissionsForSas = sasPermission(linkDuration);
 
-    // Please refer to the new implementation of azure-storage api here: https://github.com/Azure/azure-storage-node 
-    // Constans used to be available externallbut not in new packages they dont.
-    // https://github.com/Azure/azure-storage-node/blob/master/lib/common/util/constants.js#L179
-    const cerds = new storage.StorageSharedKeyCredential(storageAccount, storageKey);
+    // The Azure storage client doesn't export constants.
+    // The ones we declare here are copied from https://github.com/Azure/azure-storage-node/blob/c4226315f037f2791f7c938e900b3497c9c0a67a/lib/common/util/constants.js#L179
+    const creds = new storage.StorageSharedKeyCredential(storageAccount, storageKey);
     const accountSharedAccessSignature = storage.generateAccountSASQueryParameters({
         expiresOn : expiryDate,
         permissions: storage.AccountSASPermissions.parse(permissionsForSas),
@@ -52,7 +51,7 @@ export function getSASKey(
         resourceTypes: storage.AccountSASResourceTypes.parse("sco").toString(),
         services: storage.AccountSASServices.parse("b").toString(),
         startsOn: startDate
-    }, cerds).toString();
+    }, creds).toString();
 
     // Generate SAS.
     const sas = "?" + accountSharedAccessSignature;


### PR DESCRIPTION
This PR is continuation for the dependency fix, but this is final of it, reason being left over packages which are showing as dependency alert for this repository is actually just the decency of `@azure/` packages which are new storage packages. 

Following changes moves this code base 100 % away from the use of deprecated `azure-storage` package and use `@azure/storage-xxx` packages. more detail here: https://github.com/Azure/azure-storage-node or https://www.npmjs.com/package/azure-storage 

I have smoke tested this locally, adding PR for a quick look for more experienced eyes.

Thank you so much. ❤️🙏☕️

fyi: with new `storage` API they have removed the `Const` hence the `string` values are used like they have reopened in their sample API.

<img width="912" alt="Screen Shot 2021-11-01 at 10 57 56 AM" src="https://user-images.githubusercontent.com/6233295/139602901-fed3fcde-eac9-48ad-a456-5c3b53a43d6d.png">


