### PR TITLE
Fix for periscope feature and update depricated api version from beta1 to v1.

### DIFF
--- a/resources/yaml/aks-periscope.yaml
+++ b/resources/yaml/aks-periscope.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: aks-periscope
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: diagnostics.aks-periscope.azure.github.com
@@ -16,19 +16,21 @@ spec:
     - apd
     singular: diagnostic
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            dns:
-              type: string
-            networkoutbound:
-              type: string
-          type: object
-      type: object
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              dns:
+                type: string
+              networkoutbound:
+                type: string
+              networkconfig:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 ---
@@ -202,6 +204,6 @@ spec:
       - hostPath:
           path: /run/systemd/resolve
         name: resolvlog
-      - name: etcvmlog
-        hostPath:
+      - hostPath:
           path: /etc
+        name: etcvmlog


### PR DESCRIPTION
This PR fixes 2 things, 

* ~Firstly an ~ongoing issue~ (interesting thing is this validation is no-longer showing now so surely something to do with yaml validation triggered and silent now) within this extension and is happening with `aks-periscope` and just got bubbled around 24th Dec **more lengthy details** in periscope repo: https://github.com/Azure/aks-periscope/issues/141  - this validation was never happened before so surely something is changed which has probably bubbled the right error~.

* Secondly, This PR fixes the deprecation of `apiextensions.k8s.io/v1beta1` now moved to `v1`
    * More details here: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

Currently it is happening within the feature provided under this extension, hence opening this PR as solution.

Thanks heaps, 🙏❤️☕️

cc: @itowlson , @rzhang628 , @squillace or @lstocchi ❤️☕️ if anyone is around, I have tested this locally. if merged I can do a release for this fix. Thanks heaps.

![image](https://user-images.githubusercontent.com/6233295/147510735-c7ae1c4f-cbb3-4aa2-b89d-e98647197f48.png)
