### PR TITLE
Add ms marketplace version and ratings badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<a href="https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-aks-tools" alt="Click to visit marketplace">
+    <img src="https://vsmarketplacebadge.apphb.com/version-short/ms-kubernetes-tools.vscode-aks-tools.svg">
+    <img src="https://vsmarketplacebadge.apphb.com/rating-star/ms-kubernetes-tools.vscode-aks-tools.svg">
+</a>
+
 # Azure Kubernetes Service (AKS) Extension for Visual Studio Code (Preview)
 
 * View your AKS clusters in the Kubernetes extension cloud explorer


### PR DESCRIPTION
Following PR enables the `vscode-marketplace` badges for the repo.

The new changes will add these 2 details, I learned about this via this repo: https://github.com/microsoft/vscode-js-debug 

It looks like this: 

![image](https://user-images.githubusercontent.com/6233295/147799901-1970dd42-23f8-46a2-9b9e-6b4bbf456f93.png)

**Extra:**

Also might be if anyone keen why the `build` badge won't work is because:


Some details about this issue here: 

* https://github.com/microsoft/vscode-vsce/issues/183 
* https://github.com/isaacs/github/issues/316 
* https://stackoverflow.com/questions/13808020/include-an-svg-hosted-on-github-in-markdown/16462143#16462143


Thank you so much in advance: ☕️🙏cc: @squillace, @itowlson,  @lstocchi  and @rzhang628 and wish you all happy New Years. ❤️🙏

