### PR TITLE
Feature/configure aks starter workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,17 @@ Right click on your AKS cluster and click on **Browse CI/CD Workflows** to view 
 
 ### Install Azure Service Operator
 
-Right click on your AKS cluster and click on **Install Azure Service Operator** to easily deploy the latest version of Azure Service Operator (ASO) on your AKS cluster and provision and connect applications to Azure resources within Kubernetes. When you select this option, you'll be prompted for a service principal for ASO to use when performing Azure resource operations. This service principal must have appropriate permissions (typically Contributor at suitable scope). Fill out the service principal details and click **Submit** to kick off the installation of Azure Servic Operator.
+Right click on your AKS cluster and click on **Install Azure Service Operator** to easily deploy the latest version of Azure Service Operator (ASO) on your AKS cluster and provision and connect applications to Azure resources within Kubernetes. When you select this option, you'll be prompted for a service principal for ASO to use when performing Azure resource operations. This service principal must have appropriate permissions (typically Contributor at suitable scope). Fill out the service principal details and click **Submit** to kick off the installation of Azure Service Operator.
 
 > Install Azure Service Operator can only be performed on an AKS cluster that has never had ASO installed before. If you have already initiated the installation manually, follow the instructions on [Azure Service Operator](https://github.com/Azure/azure-service-operator) to complete.
 
 For more information on Azure Service Operator, visit [Azure Service Operator (for Kubernetes)](https://github.com/Azure/azure-service-operator). If you are experiencing issues with Azure Service Operator, visit [Azure Service Operator (ASO) troubleshooting](https://github.com/Azure/azure-service-operator/blob/master/docs/troubleshooting.md).
 
 ![Azure Service Operator Webview](resources/azure-service-operator-screenshot.png)
+
+### Configure AKS Starter Workflow
+
+Right click on your AKS cluster and click on **Configure AKS Starter Workflow** to easily open and create a workflow starter template. This helps in quick generation of the workflow templates with pre populates resource and clustername. [More details here](https://github.com/tbarnes94/starter-workflows/blob/partner_templates/deployments/azure-kubernetes-service.yml)
 
 ## Telemetry
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-containerservice": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "onView:kubernetes.cloudExplorer",
         "onCommand:aks.detectorDiagnostics",
         "onCommand:aks.periscope",
-        "onCommand:aks.installAzureServiceOperator"
+        "onCommand:aks.installAzureServiceOperator",
+        "onCommand:aks.deployStarterWorkflow"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -63,6 +64,10 @@
             {
                 "command": "aks.installAzureServiceOperator",
                 "title": "Install Azure Service Operator"
+            },
+            {
+                "command": "aks.deployStarterWorkflow",
+                "title": "Configure AKS Starter Workflow"
             }
         ],
         "menus": {
@@ -109,6 +114,11 @@
                 {
                     "command": "aks.installAzureServiceOperator",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i"
+                },
+                {
+                    "command": "aks.deployStarterWorkflow",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i"
+                
                 }
             ]
         }

--- a/resources/yaml/azure-kubernetes-service.yml
+++ b/resources/yaml/azure-kubernetes-service.yml
@@ -1,80 +1,96 @@
 # This workflow will build and push an application to a Azure Kubernetes Service (AKS) cluster when you push your code
 #
 # This workflow assumes you have already created the target AKS cluster and have created an Azure Container Registry (ACR)
-# For instructions see https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
-# https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
-# https://github.com/Azure/aks-create-action
+# For instructions see:
+#   - https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
+#   - https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
+#   - https://github.com/Azure/aks-create-action
 #
 # To configure this workflow:
 #
-# 1. Set the following secrets in your repository:
-#    - AZURE_CREDENTIALS (instructions for getting this https://github.com/Azure/login#configure-a-service-principal-with-a-secret)
+# 1. Set the following secrets in your repository (instructions for getting these 
+#    https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication):
+#    - AZURE_CLIENT_ID
+#    - AZURE_TENANT_ID
+#    - AZURE_SUBSCRIPTION_ID
 #
 # 2. Set the following environment variables (or replace the values below):
-#    - AZURE_CONTAINER_REGISTRY (name of your container registry)
-#    - PROJECT_NAME
-#    - RESOURCE_GROUP (where your cluster is deployed)
-#    - CLUSTER_NAME (name of your AKS cluster)
-#
-# 3. Choose the approrpiate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes helm, then set
-#    any needed environment variables such as:
-#    - CHART_PATH 
-#    - CHART_OVERRIDE_PATH
+#    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
+#    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
+#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
+#    - DEPLOYMENT_MANIFEST_PATH (path to the manifest yaml for your deployment)
 #
 # For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
-# For more options with the actions used below please see the folllowing
-# https://github.com/Azure/login
-# https://github.com/Azure/aks-set-context
-# https://github.com/marketplace/actions/azure-cli-action
-# https://github.com/Azure/k8s-bake
-# https://github.com/Azure/k8s-deploy   
+# For more options with the actions used below please refer to https://github.com/Azure/login
 
-on: [push]
+name: Build and deploy an app to AKS
+
+on:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+env:
+  AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
+  CONTAINER_NAME: "your-container-name"
+  RESOURCE_GROUP: "your-resource-group"
+  CLUSTER_NAME: "your-cluster-name"
+  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
+  DEPLOYMENT_MANIFEST_PATH: 'your-deployment-manifest-path'
 
 jobs:
   build:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     
-    - name: Azure Login
-      uses: azure/login@v1
+    - name: Azure login
+      uses: azure/login@v1.4.3
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: Build image on ACR
-      uses: azure/CLI@v1
-      with:
-        azcliversion: 2.29.1
-        inlineScript: |
-          az configure --defaults acr=${{ env.AZURE_CONTAINER_REGISTRY }}
-          az acr build -t  -t ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.PROJECT_NAME }}:${{ github.sha }}
-    
-    - name: Gets K8s context
-      uses: azure/aks-set-context@v1
-      with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          resource-group: <RESOURCE_GROUP>
-          cluster-name: <CLUSTER_NAME>
-      id: login
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      
+    - name: Build and push image to ACR
+      run: |
+        az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
 
-    - name: Configure deployment
-      uses: azure/k8s-bake@v1
+    - name: Gets K8s context
+      uses: azure/aks-set-context@v2.0
       with:
-        renderEngine: 'helm'
-        helmChart: ${{ env.CHART_PATH }}
-        overrideFiles: ${{ env.CHART_OVERRIDE_PATH }}
-        overrides: |     
-          replicas:2
-        helm-version: 'latest' 
-      id: bake
+        resource-group: <RESOURCE_GROUP>
+        cluster-name: <CLUSTER_NAME>
+
+    - name: Get ACR credentials
+      run: |
+        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
+        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
+        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
+        echo "::set-output name=username::${ACR_USERNAME}"
+        echo "::set-output name=password::${ACR_PASSWORD}"
+      id: get-acr-creds
+
+    - name: Create K8s secret for pulling image from ACR
+      uses: Azure/k8s-create-secret@v1.1
+      with:
+        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
+        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
+        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}  
 
     - name: Deploys application
-    - uses: Azure/k8s-deploy@v1
+      uses: Azure/k8s-deploy@v3.0
       with:
-        manifests: ${{ steps.bake.outputs.manifestsBundle }}
+        action: deploy
+        manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}
         images: |
-          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.PROJECT_NAME }}:${{ github.sha }}
+          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
         imagepullsecrets: |
-          ${{ env.PROJECT_NAME }}
+          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service.yml
+++ b/resources/yaml/azure-kubernetes-service.yml
@@ -1,0 +1,80 @@
+# This workflow will build and push an application to a Azure Kubernetes Service (AKS) cluster when you push your code
+#
+# This workflow assumes you have already created the target AKS cluster and have created an Azure Container Registry (ACR)
+# For instructions see https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
+# https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
+# https://github.com/Azure/aks-create-action
+#
+# To configure this workflow:
+#
+# 1. Set the following secrets in your repository:
+#    - AZURE_CREDENTIALS (instructions for getting this https://github.com/Azure/login#configure-a-service-principal-with-a-secret)
+#
+# 2. Set the following environment variables (or replace the values below):
+#    - AZURE_CONTAINER_REGISTRY (name of your container registry)
+#    - PROJECT_NAME
+#    - RESOURCE_GROUP (where your cluster is deployed)
+#    - CLUSTER_NAME (name of your AKS cluster)
+#
+# 3. Choose the approrpiate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes helm, then set
+#    any needed environment variables such as:
+#    - CHART_PATH 
+#    - CHART_OVERRIDE_PATH
+#
+# For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
+# For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
+# For more options with the actions used below please see the folllowing
+# https://github.com/Azure/login
+# https://github.com/Azure/aks-set-context
+# https://github.com/marketplace/actions/azure-cli-action
+# https://github.com/Azure/k8s-bake
+# https://github.com/Azure/k8s-deploy   
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    
+    - name: Build image on ACR
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.29.1
+        inlineScript: |
+          az configure --defaults acr=${{ env.AZURE_CONTAINER_REGISTRY }}
+          az acr build -t  -t ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.PROJECT_NAME }}:${{ github.sha }}
+    
+    - name: Gets K8s context
+      uses: azure/aks-set-context@v1
+      with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          resource-group: <RESOURCE_GROUP>
+          cluster-name: <CLUSTER_NAME>
+      id: login
+
+    - name: Configure deployment
+      uses: azure/k8s-bake@v1
+      with:
+        renderEngine: 'helm'
+        helmChart: ${{ env.CHART_PATH }}
+        overrideFiles: ${{ env.CHART_OVERRIDE_PATH }}
+        overrides: |     
+          replicas:2
+        helm-version: 'latest' 
+      id: bake
+
+    - name: Deploys application
+    - uses: Azure/k8s-deploy@v1
+      with:
+        manifests: ${{ steps.bake.outputs.manifestsBundle }}
+        images: |
+          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.PROJECT_NAME }}:${{ github.sha }}
+        imagepullsecrets: |
+          ${{ env.PROJECT_NAME }}

--- a/src/commands/aksStarterWorkflow/deployStarterWorkflow.ts
+++ b/src/commands/aksStarterWorkflow/deployStarterWorkflow.ts
@@ -2,10 +2,7 @@ import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { IActionContext } from 'vscode-azureextensionui';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
-import path = require('path');
-import { getExtensionPath } from '../utils/host';
-import * as fs from 'fs';
-const tmp = require('tmp');
+import { configureStarterConfigDataForAKS } from './deployStarterWorkflowHelper';
 
 export default async function deployStarterWorkflow(
     context: IActionContext,
@@ -37,39 +34,15 @@ export default async function deployStarterWorkflow(
         clusterExplorer.available) {
 
         const aksCluster = clusterTarget.cloudResource as AksClusterTreeItem;
-        // vscode.window.showTextDocument()
-        const extensionPath = getExtensionPath();
 
-        const pos1 = new vscode.Position(10, 4);
-        const yamlPathOnDisk = vscode.Uri.file(path.join(extensionPath!, 'resources', 'yaml', 'azure-kubernetes-service.yml'));
-        const openPath = vscode.Uri.file(yamlPathOnDisk.fsPath);
+        // Configure the starter workflow data.
+        const aksStarterWorkflowData = configureStarterConfigDataForAKS(clusterTarget.cloudResource.armId.split("/")[4], aksCluster.name);
 
-        const replacedDoc = fs.readFileSync(openPath.fsPath, 'utf8')
-                                .replace('<RESOURCE_GROUP>', clusterTarget.cloudResource.armId.split("/")[4])
-                                .replace('<CLUSTER_NAME>', aksCluster.name);
-
-        const templateYaml = tmp.fileSync({ prefix: "azure-kubernetes-service", postfix: `.yaml` });
-        fs.writeFileSync(templateYaml.name, replacedDoc);
-
-        const tmpFilePathOnDisk = vscode.Uri.file(path.join(templateYaml.name));
-        const openPath2 = vscode.Uri.file(tmpFilePathOnDisk.fsPath);
-
-        vscode.workspace.openTextDocument(openPath2).then((doc) =>
-        {
-            vscode.window.showTextDocument(doc).then((editor) =>
-            {
-                // Line added - by having a selection at the same position twice, the cursor jumps there
-                editor.selections = [new vscode.Selection(pos1, pos1)];
-
-                // And the visible range jumps there too
-                const range = new vscode.Range(pos1, pos1);
-                editor.revealRange(range);
-            });
-        });
-        vscode.window.showInformationMessage(`The AKS clusters ${aksCluster.name} was clicked.`);
-
-        // await install(kubectl.api, aksCluster);
-        clusterExplorer.api.refresh();
+        // Display it to the end-user in their vscode editor.
+        vscode.workspace.openTextDocument({
+            content: aksStarterWorkflowData,
+            language: "yaml"
+          });
     } else {
         vscode.window.showInformationMessage('This command only applies to AKS clusters.');
     }

--- a/src/commands/aksStarterWorkflow/deployStarterWorkflow.ts
+++ b/src/commands/aksStarterWorkflow/deployStarterWorkflow.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from 'vscode-azureextensionui';
+import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
+import path = require('path');
+import { getExtensionPath } from '../utils/host';
+import * as fs from 'fs';
+const tmp = require('tmp');
+
+export default async function deployStarterWorkflow(
+    context: IActionContext,
+    target: any
+): Promise<void> {
+    const kubectl = await k8s.extension.kubectl.v1;
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+    const clusterExplorer = await k8s.extension.clusterExplorer.v1;
+
+    if (!kubectl.available) {
+        vscode.window.showWarningMessage(`Kubectl is unavailable.`);
+        return undefined;
+    }
+
+    if (!cloudExplorer.available) {
+        vscode.window.showWarningMessage(`Cloud explorer is unavailable.`);
+        return undefined;
+    }
+
+    if (!clusterExplorer.available) {
+        vscode.window.showWarningMessage(`Cluster explorer is unavailable.`);
+        return undefined;
+    }
+
+    const clusterTarget = cloudExplorer.api.resolveCommandTarget(target);
+
+    if (clusterTarget && clusterTarget.cloudName === "Azure" &&
+        clusterTarget.nodeType === "resource" && clusterTarget.cloudResource.nodeType === "cluster" &&
+        clusterExplorer.available) {
+
+        const aksCluster = clusterTarget.cloudResource as AksClusterTreeItem;
+        // vscode.window.showTextDocument()
+        const extensionPath = getExtensionPath();
+
+        const pos1 = new vscode.Position(10, 4);
+        const yamlPathOnDisk = vscode.Uri.file(path.join(extensionPath!, 'resources', 'yaml', 'azure-kubernetes-service.yml'));
+        const openPath = vscode.Uri.file(yamlPathOnDisk.fsPath);
+
+        const replacedDoc = fs.readFileSync(openPath.fsPath, 'utf8')
+                                .replace('<RESOURCE_GROUP>', clusterTarget.cloudResource.armId.split("/")[4])
+                                .replace('<CLUSTER_NAME>', aksCluster.name);
+
+        const templateYaml = tmp.fileSync({ prefix: "azure-kubernetes-service", postfix: `.yaml` });
+        fs.writeFileSync(templateYaml.name, replacedDoc);
+
+        const tmpFilePathOnDisk = vscode.Uri.file(path.join(templateYaml.name));
+        const openPath2 = vscode.Uri.file(tmpFilePathOnDisk.fsPath);
+
+        vscode.workspace.openTextDocument(openPath2).then((doc) =>
+        {
+            vscode.window.showTextDocument(doc).then((editor) =>
+            {
+                // Line added - by having a selection at the same position twice, the cursor jumps there
+                editor.selections = [new vscode.Selection(pos1, pos1)];
+
+                // And the visible range jumps there too
+                const range = new vscode.Range(pos1, pos1);
+                editor.revealRange(range);
+            });
+        });
+        vscode.window.showInformationMessage(`The AKS clusters ${aksCluster.name} was clicked.`);
+
+        // await install(kubectl.api, aksCluster);
+        clusterExplorer.api.refresh();
+    } else {
+        vscode.window.showInformationMessage('This command only applies to AKS clusters.');
+    }
+}

--- a/src/commands/aksStarterWorkflow/deployStarterWorkflowHelper.ts
+++ b/src/commands/aksStarterWorkflow/deployStarterWorkflowHelper.ts
@@ -1,0 +1,19 @@
+import path = require("path");
+import * as fs from 'fs';
+import { getExtensionPath } from "../utils/host";
+import * as vscode from 'vscode';
+
+export function configureStarterConfigDataForAKS(
+    resourceName: string,
+    clusterName: string
+): string {
+    const extensionPath = getExtensionPath();
+
+    // Load vscode resoruce yaml file and replace content.
+    const yamlPathOnDisk = vscode.Uri.file(path.join(extensionPath!, 'resources', 'yaml', 'azure-kubernetes-service.yml'));
+    const starterFileAutoFillContent = fs.readFileSync(yamlPathOnDisk.fsPath, 'utf8')
+                                            .replace('<RESOURCE_GROUP>', resourceName)
+                                            .replace('<CLUSTER_NAME>', clusterName);
+
+    return starterFileAutoFillContent;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { configurePipeline } from './commands/deployAzurePipeline/configureCicdP
 import installAzureServiceOperator  from './commands/azureServiceOperators/installAzureServiceOperator';
 import { AzureServiceBrowser } from './commands/azureServiceOperators/ui/azureservicebrowser';
 import { setAssetContext } from './assets';
+import deployStarterWorkflow from './commands/aksStarterWorkflow/deployStarterWorkflow';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -38,6 +39,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('azure-deploy.configureCicdPipeline', configurePipeline);
         registerCommandWithTelemetry('azure-deploy.browseCicdPipeline', browsePipeline);
         registerCommandWithTelemetry('aks.installAzureServiceOperator', installAzureServiceOperator );
+        registerCommandWithTelemetry('aks.deployStarterWorkflow', deployStarterWorkflow );
 
         await registerAzureServiceNodes(context);
 

--- a/src/tests/suite/deploystarterworkflow.test.ts
+++ b/src/tests/suite/deploystarterworkflow.test.ts
@@ -1,0 +1,10 @@
+import * as deployStarterWorkflow  from '../../commands/aksStarterWorkflow/deployStarterWorkflowHelper';
+import 'sinon';
+import { expect } from 'chai';
+
+describe('Test Configure Starter Data Set returns replaced value.', () => {
+  it('should return some string', () => {
+    const result = deployStarterWorkflow.configureStarterConfigDataForAKS("test-resource", "test-cluster");
+    expect(result).to.contain("test-cluster");
+  });
+});


### PR DESCRIPTION
💡 This work is to enable a `new feature` for the `dev experienc`e for generation of a starter workflow for azure Kubernetes services workflow file which can be easily saved to respective projects for quick deployment.

Currently this work will serve user with a pre-baked copy of GitHub `starter workflow for AKS` and all user need to do is save and add left over secrets.

☕️ Please note: This work should not be merged until this PR becomes official: https://github.com/actions/starter-workflows/pull/1403

Thanks heaps, 🙏☕️❤️

cc: @gambtho , @rzhang628 , @peterbom 
FYi: @squillace for visibility.

Images below for more visibility of this feature.

<img width="397" alt="image" src="https://user-images.githubusercontent.com/6233295/155455739-c756dd5b-3352-40bd-a6f8-292a537db0c4.png">

![image](https://user-images.githubusercontent.com/6233295/155455790-61cf2b0d-80fc-4217-8914-059808aac86c.png)


