### PR TITLE
fix periscope deprecated beta tag.

### DIFF
--- a/resources/yaml/aks-periscope.yaml
+++ b/resources/yaml/aks-periscope.yaml
@@ -195,7 +195,7 @@ spec:
           name: etcvmlog
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: aks-periscope-service-account
       volumes:
       - hostPath:


### PR DESCRIPTION
This PR fix deprecated message for deployment: `Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]` 

* https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-os-deprecated 

Thanks,
cc: @peterbom  