### PR TITLE
remove retry policy for detector server error.

### DIFF
--- a/src/commands/utils/detectors.ts
+++ b/src/commands/utils/detectors.ts
@@ -48,7 +48,7 @@ export async function getDetectorInfo(
     detectorName: string
 ): Promise<Errorable<AppLensARMResponse>> {
     try {
-        const client = new ResourceManagementClient(target.root.credentials, target.root.subscriptionId);
+        const client = new ResourceManagementClient(target.root.credentials, target.root.subscriptionId, { noRetryPolicy: true });
         // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
         const resourceGroup = target.armId.split("/")[4];
         const detectorInfo = await client.resources.get(


### PR DESCRIPTION
Fix for vscode side of things slowness caused by internal server error in detector. Thank you @peterbom.

cc: @rzhang628 - now its quicker.

THanks!