### PR TITLE
Add leftover starter workflow for AKS.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "0.0.14",
+            "version": "0.0.15",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-containerservice": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
         "onCommand:aks.installAzureServiceOperator",
         "onCommand:aks.configureStarterWorkflow",
         "onCommand:aks.aksCRUDDiagnostics",
-        "onCommand:aks.aksBestPracticesDiagnostics"
+        "onCommand:aks.aksBestPracticesDiagnostics",
+        "onCommand:aks.configureHelmStarterWorkflow",
+        "onCommand:aks.configureKomposeStarterWorkflow",
+        "onCommand:aks.configureKustomizeStarterWorkflow"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -61,7 +64,7 @@
             },
             {
                 "command": "aks.configureStarterWorkflow",
-                "title": "Create GitHub Starter Workflow"
+                "title": "Starter Workflow"
             },
             {
                 "command": "aks.aksCRUDDiagnostics",
@@ -74,6 +77,18 @@
             {
                 "command": "aks.aksIdentitySecurityDiagnostics",
                 "title": "Identity and Security"
+            },
+            {
+                "command": "aks.configureHelmStarterWorkflow",
+                "title": "Helm Workflow"
+            },
+            {
+                "command": "aks.configureKomposeStarterWorkflow",
+                "title": "Kompose Workflow"
+            },
+            {
+                "command": "aks.configureKustomizeStarterWorkflow",
+                "title": "Kustomize Workflow"
             }
         ],
         "menus": {
@@ -94,7 +109,6 @@
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "8@1"
                 },
-                
                 {
                     "command": "aks.periscope",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
@@ -105,9 +119,9 @@
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i"
                 },
                 {
-                    "command": "aks.configureStarterWorkflow",
-                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i"
-                
+                    "submenu": "aks.ghWorkflowSubMenu",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
+                    "group": "9@1"
                 }
             ],
             "aks.detectorsSubMenu": [
@@ -127,12 +141,34 @@
                   "command": "aks.aksIdentitySecurityDiagnostics",
                   "group": "navigation"
                 }
+            ],
+            "aks.ghWorkflowSubMenu": [
+                {
+                  "command": "aks.configureHelmStarterWorkflow",
+                  "group": "navigation"
+                },
+                {
+                  "command": "aks.configureKomposeStarterWorkflow",
+                  "group": "navigation"
+                },
+                {
+                  "command": "aks.configureKustomizeStarterWorkflow",
+                  "group": "navigation"
+                },
+                {
+                  "command": "aks.configureStarterWorkflow",
+                  "group": "navigation"
+                }
             ]
         },
         "submenus": [
             {
               "id": "aks.detectorsSubMenu",
               "label": "Run AKS Diagnostics"
+            },
+            {
+              "id": "aks.ghWorkflowSubMenu",
+              "label": "Create GitHub Workflow"
             }
           ]
     },

--- a/resources/yaml/azure-kubernetes-service-helm.yml
+++ b/resources/yaml/azure-kubernetes-service-helm.yml
@@ -17,7 +17,6 @@
 # 2. Set the following environment variables (or replace the values below):
 #    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
 #    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
-#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
 #
 # 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Helm.
 #    Set your helmChart, overrideFiles, overrides, and helm-version to suit your configuration.
@@ -41,7 +40,6 @@ env:
   CONTAINER_NAME: "your-container-name"
   RESOURCE_GROUP: "your-resource-group"
   CLUSTER_NAME: "your-cluster-name"
-  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
   CHART_PATH: "your-chart-path"
   CHART_OVERRIDE_PATH: "your-chart-override-path"
 
@@ -77,24 +75,10 @@ jobs:
         resource-group: <RESOURCE_GROUP>
         cluster-name: <CLUSTER_NAME>
 
-    # Retrieves the credentials for pulling images from your Azure Container Registry
-    - name: Get ACR credentials
+    # Attaches ACR to your AKS Cluster
+    - name: Attach ACR to AKS cluster
       run: |
-        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
-        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
-        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
-        echo "::set-output name=username::${ACR_USERNAME}"
-        echo "::set-output name=password::${ACR_PASSWORD}"
-      id: get-acr-creds
-
-    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
-    - name: Create K8s secret for pulling image from ACR
-      uses: Azure/k8s-create-secret@v1.1
-      with:
-        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
-        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
-        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
-        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+        az aks update -n ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} --attach-acr ${{ env.AZURE_CONTAINER_REGISTRY }}
 
     # Runs Helm to create manifest files
     - name: Bake deployment
@@ -116,5 +100,3 @@ jobs:
         manifests: ${{ steps.bake.outputs.manifestsBundle }}
         images: |
           ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-        imagepullsecrets: |
-          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service-helm.yml
+++ b/resources/yaml/azure-kubernetes-service-helm.yml
@@ -1,0 +1,120 @@
+# This workflow will build and push an application to a Azure Kubernetes Service (AKS) cluster when you push your code
+#
+# This workflow assumes you have already created the target AKS cluster and have created an Azure Container Registry (ACR)
+# For instructions see:
+#   - https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
+#   - https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
+#   - https://github.com/Azure/aks-create-action
+#
+# To configure this workflow:
+#
+# 1. Set the following secrets in your repository (instructions for getting these 
+#    https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication):
+#    - AZURE_CLIENT_ID
+#    - AZURE_TENANT_ID
+#    - AZURE_SUBSCRIPTION_ID
+#
+# 2. Set the following environment variables (or replace the values below):
+#    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
+#    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
+#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
+#
+# 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Helm.
+#    Set your helmChart, overrideFiles, overrides, and helm-version to suit your configuration.
+#    - CHART_PATH (path to your helm chart)
+#    - CHART_OVERRIDE_PATH (path to your helm chart with override values)
+#
+# For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
+# For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
+# For more options with the actions used below please refer to https://github.com/Azure/login
+
+name: Build and deploy an app to AKS with Helm
+
+on:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+env:
+  AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
+  CONTAINER_NAME: "your-container-name"
+  RESOURCE_GROUP: "your-resource-group"
+  CLUSTER_NAME: "your-cluster-name"
+  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
+  CHART_PATH: "your-chart-path"
+  CHART_OVERRIDE_PATH: "your-chart-override-path"
+
+jobs:
+  build:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      
+    runs-on: ubuntu-latest
+    steps:
+    # Checks out the repository this file is in
+    - uses: actions/checkout@v3
+    
+    # Logs in with your Azure credentials
+    - name: Azure login
+      uses: azure/login@v1.4.3
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    
+    # Builds and pushes an image up to your Azure Container Registry
+    - name: Build and push image to ACR
+      run: |
+        az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
+
+    # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
+    - name: Get K8s context
+      uses: azure/aks-set-context@v2.0
+      with:
+        resource-group: <RESOURCE_GROUP>
+        cluster-name: <CLUSTER_NAME>
+
+    # Retrieves the credentials for pulling images from your Azure Container Registry
+    - name: Get ACR credentials
+      run: |
+        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
+        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
+        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
+        echo "::set-output name=username::${ACR_USERNAME}"
+        echo "::set-output name=password::${ACR_PASSWORD}"
+      id: get-acr-creds
+
+    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
+    - name: Create K8s secret for pulling image from ACR
+      uses: Azure/k8s-create-secret@v1.1
+      with:
+        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
+        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
+        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+
+    # Runs Helm to create manifest files
+    - name: Bake deployment
+      uses: azure/k8s-bake@v2.1
+      with:
+        renderEngine: 'helm'
+        helmChart: ${{ env.CHART_PATH }}
+        overrideFiles: ${{ env.CHART_OVERRIDE_PATH }}
+        overrides: |     
+          replicas:2
+        helm-version: 'latest' 
+      id: bake
+
+    # Deploys application based on manifest files from previous step
+    - name: Deploy application
+      uses: Azure/k8s-deploy@v3.0
+      with:
+        action: deploy
+        manifests: ${{ steps.bake.outputs.manifestsBundle }}
+        images: |
+          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+        imagepullsecrets: |
+          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service-kompose.yml
+++ b/resources/yaml/azure-kubernetes-service-kompose.yml
@@ -17,7 +17,6 @@
 # 2. Set the following environment variables (or replace the values below):
 #    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
 #    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
-#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
 #
 # 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Kompose.
 #    Set your dockerComposeFile and kompose-version to suit your configuration.
@@ -34,7 +33,6 @@ env:
   CONTAINER_NAME: "your-container-name"
   RESOURCE_GROUP: "your-resource-group"
   CLUSTER_NAME: "your-cluster-name"
-  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
   DOCKER_COMPOSE_FILE_PATH: "your-docker-compose-file-path"
 
 jobs:
@@ -69,24 +67,10 @@ jobs:
         resource-group: <RESOURCE_GROUP>
         cluster-name: <CLUSTER_NAME>
 
-    # Retrieves the credentials for pulling images from your Azure Container Registry
-    - name: Get ACR credentials
+   # Attaches ACR to your AKS Cluster
+    - name: Attach ACR to AKS cluster
       run: |
-        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
-        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
-        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
-        echo "::set-output name=username::${ACR_USERNAME}"
-        echo "::set-output name=password::${ACR_PASSWORD}"
-      id: get-acr-creds
-
-    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
-    - name: Create K8s secret for pulling image from ACR
-      uses: Azure/k8s-create-secret@v1.1
-      with:
-        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
-        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
-        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
-        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+        az aks update -n ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} --attach-acr ${{ env.AZURE_CONTAINER_REGISTRY }}
 
     # Runs Kompose to create manifest files
     - name: Bake deployment
@@ -105,5 +89,3 @@ jobs:
         manifests: ${{ steps.bake.outputs.manifestsBundle }}
         images: |
           ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-        imagepullsecrets: |
-          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service-kompose.yml
+++ b/resources/yaml/azure-kubernetes-service-kompose.yml
@@ -1,0 +1,109 @@
+# This workflow will build and push an application to a Azure Kubernetes Service (AKS) cluster when you push your code
+#
+# This workflow assumes you have already created the target AKS cluster and have created an Azure Container Registry (ACR)
+# For instructions see:
+#   - https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
+#   - https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
+#   - https://github.com/Azure/aks-create-action
+#
+# To configure this workflow:
+#
+# 1. Set the following secrets in your repository (instructions for getting these 
+#    https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication):
+#    - AZURE_CLIENT_ID
+#    - AZURE_TENANT_ID
+#    - AZURE_SUBSCRIPTION_ID
+#
+# 2. Set the following environment variables (or replace the values below):
+#    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
+#    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
+#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
+#
+# 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Kompose.
+#    Set your dockerComposeFile and kompose-version to suit your configuration.
+#    - DOCKER_COMPOSE_FILE_PATH (the path where your Kompose deployment manifest is located)
+#
+# For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
+# For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
+# For more options with the actions used below please refer to https://github.com/Azure/login
+
+name: Build and deploy an app to AKS with Kompose
+
+env:
+  AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
+  CONTAINER_NAME: "your-container-name"
+  RESOURCE_GROUP: "your-resource-group"
+  CLUSTER_NAME: "your-cluster-name"
+  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
+  DOCKER_COMPOSE_FILE_PATH: "your-docker-compose-file-path"
+
+jobs:
+  build:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      
+    runs-on: ubuntu-latest
+    steps:
+    # Checks out the repository this file is in
+    - uses: actions/checkout@v3
+    
+    # Logs in with your Azure credentials
+    - name: Azure login
+      uses: azure/login@v1.4.3
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      
+    # Builds and pushes an image up to your Azure Container Registry
+    - name: Build and push image to ACR
+      run: |
+        az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
+
+    # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
+    - name: Get K8s context
+      uses: azure/aks-set-context@v2.0
+      with:
+        resource-group: <RESOURCE_GROUP>
+        cluster-name: <CLUSTER_NAME>
+
+    # Retrieves the credentials for pulling images from your Azure Container Registry
+    - name: Get ACR credentials
+      run: |
+        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
+        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
+        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
+        echo "::set-output name=username::${ACR_USERNAME}"
+        echo "::set-output name=password::${ACR_PASSWORD}"
+      id: get-acr-creds
+
+    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
+    - name: Create K8s secret for pulling image from ACR
+      uses: Azure/k8s-create-secret@v1.1
+      with:
+        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
+        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
+        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+
+    # Runs Kompose to create manifest files
+    - name: Bake deployment
+      uses: azure/k8s-bake@v2.1
+      with:
+        renderEngine: 'kompose'
+        dockerComposeFile: ${{ env.DOCKER_COMPOSE_FILE_PATH }}
+        kompose-version: 'latest'   
+      id: bake
+
+    # Deploys application based on manifest files from previous step
+    - name: Deploy application
+      uses: Azure/k8s-deploy@v3.0
+      with:
+        action: deploy
+        manifests: ${{ steps.bake.outputs.manifestsBundle }}
+        images: |
+          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+        imagepullsecrets: |
+          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service-kustomize.yml
+++ b/resources/yaml/azure-kubernetes-service-kustomize.yml
@@ -1,0 +1,115 @@
+# This workflow will build and push an application to a Azure Kubernetes Service (AKS) cluster when you push your code
+#
+# This workflow assumes you have already created the target AKS cluster and have created an Azure Container Registry (ACR)
+# For instructions see:
+#   - https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal
+#   - https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal
+#   - https://github.com/Azure/aks-create-action
+#
+# To configure this workflow:
+#
+# 1. Set the following secrets in your repository (instructions for getting these 
+#    https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication):
+#    - AZURE_CLIENT_ID
+#    - AZURE_TENANT_ID
+#    - AZURE_SUBSCRIPTION_ID
+#
+# 2. Set the following environment variables (or replace the values below):
+#    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
+#    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
+#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
+#
+# 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Kustomize.
+#    Set your kustomizationPath and kubectl-version to suit your configuration.
+#    - KUSTOMIZE_PATH (the path where your Kustomize manifests are located)
+#
+# For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
+# For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
+# For more options with the actions used below please refer to https://github.com/Azure/login
+
+name: Build and deploy an app to AKS with Kustomize
+
+on:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+env:
+  AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
+  CONTAINER_NAME: "your-container-name"
+  RESOURCE_GROUP: "your-resource-group"
+  CLUSTER_NAME: "your-cluster-name"
+  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
+  KUSTOMIZE_PATH: "your-kustomize-path"
+
+jobs:
+  build:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      
+    runs-on: ubuntu-latest
+    steps:
+    # Checks out the repository this file is in
+    - uses: actions/checkout@v3
+
+    # Logs in with your Azure credentials
+    - name: Azure login
+      uses: azure/login@v1.4.3
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      
+    # Builds and pushes an image up to your Azure Container Registry
+    - name: Build and push image to ACR
+      run: |
+        az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
+
+    # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
+    - name: Get K8s context
+      uses: azure/aks-set-context@v2.0
+      with:
+        resource-group: <RESOURCE_GROUP>
+        cluster-name: <CLUSTER_NAME>
+
+    # Retrieves the credentials for pulling images from your Azure Container Registry
+    - name: Get ACR credentials
+      run: |
+        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
+        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
+        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
+        echo "::set-output name=username::${ACR_USERNAME}"
+        echo "::set-output name=password::${ACR_PASSWORD}"
+      id: get-acr-creds
+
+    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
+    - name: Create K8s secret for pulling image from ACR
+      uses: Azure/k8s-create-secret@v1.1
+      with:
+        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
+        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
+        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+
+    # Runs Kustomize to create manifest files
+    - name: Bake deployment
+      uses: azure/k8s-bake@v2.1
+      with:
+        renderEngine: 'kustomize'
+        kustomizationPath: ${{ env.KUSTOMIZE_PATH }}
+        kubectl-version: latest
+      id: bake
+
+    # Deploys application based on manifest files from previous step
+    - name: Deploy application
+      uses: Azure/k8s-deploy@v3.0
+      with:
+        action: deploy
+        manifests: ${{ steps.bake.outputs.manifestsBundle }}
+        images: |
+          ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+        imagepullsecrets: |
+          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service-kustomize.yml
+++ b/resources/yaml/azure-kubernetes-service-kustomize.yml
@@ -17,7 +17,6 @@
 # 2. Set the following environment variables (or replace the values below):
 #    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
 #    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
-#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
 #
 # 3. Choose the appropriate render engine for the bake step https://github.com/Azure/k8s-bake. The config below assumes Kustomize.
 #    Set your kustomizationPath and kubectl-version to suit your configuration.
@@ -40,7 +39,6 @@ env:
   CONTAINER_NAME: "your-container-name"
   RESOURCE_GROUP: "your-resource-group"
   CLUSTER_NAME: "your-cluster-name"
-  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
   KUSTOMIZE_PATH: "your-kustomize-path"
 
 jobs:
@@ -75,24 +73,10 @@ jobs:
         resource-group: <RESOURCE_GROUP>
         cluster-name: <CLUSTER_NAME>
 
-    # Retrieves the credentials for pulling images from your Azure Container Registry
-    - name: Get ACR credentials
+    # Attaches ACR to your AKS Cluster
+    - name: Attach ACR to AKS cluster
       run: |
-        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
-        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
-        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
-        echo "::set-output name=username::${ACR_USERNAME}"
-        echo "::set-output name=password::${ACR_PASSWORD}"
-      id: get-acr-creds
-
-    # Creates a kubernetes secret on your Azure Kubernetes Service cluster that matches up to the credentials from the last step
-    - name: Create K8s secret for pulling image from ACR
-      uses: Azure/k8s-create-secret@v1.1
-      with:
-        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
-        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
-        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
-        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}
+        az aks update -n ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} --attach-acr ${{ env.AZURE_CONTAINER_REGISTRY }}
 
     # Runs Kustomize to create manifest files
     - name: Bake deployment
@@ -111,5 +95,3 @@ jobs:
         manifests: ${{ steps.bake.outputs.manifestsBundle }}
         images: |
           ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-        imagepullsecrets: |
-          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/resources/yaml/azure-kubernetes-service.yml
+++ b/resources/yaml/azure-kubernetes-service.yml
@@ -17,7 +17,6 @@
 # 2. Set the following environment variables (or replace the values below):
 #    - AZURE_CONTAINER_REGISTRY (name of your container registry / ACR)
 #    - CONTAINER_NAME (name of the container image you would like to push up to your ACR)
-#    - SECRET_NAME (name of the secret associated with pulling your ACR image)
 #    - DEPLOYMENT_MANIFEST_PATH (path to the manifest yaml for your deployment)
 #
 # For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
@@ -37,7 +36,6 @@ env:
   CONTAINER_NAME: "your-container-name"
   RESOURCE_GROUP: "your-resource-group"
   CLUSTER_NAME: "your-cluster-name"
-  IMAGE_PULL_SECRET_NAME: "your-image-pull-secret-name"
   DEPLOYMENT_MANIFEST_PATH: 'your-deployment-manifest-path'
 
 jobs:
@@ -49,8 +47,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    # Checks out the repository this file is in
+    - uses: actions/checkout@v3
     
+    # Logs in with your Azure credentials
     - name: Azure login
       uses: azure/login@v1.4.3
       with:
@@ -58,33 +58,24 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       
+    # Builds and pushes an image up to your Azure Container Registry
     - name: Build and push image to ACR
       run: |
         az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
 
-    - name: Gets K8s context
+    # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
+    - name: Get K8s context
       uses: azure/aks-set-context@v2.0
       with:
         resource-group: <RESOURCE_GROUP>
         cluster-name: <CLUSTER_NAME>
 
-    - name: Get ACR credentials
+    # Attaches ACR to your AKS Cluster
+    - name: Attach ACR to AKS cluster
       run: |
-        az acr update -n ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} --admin-enabled true
-        ACR_USERNAME=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query username -o tsv)
-        ACR_PASSWORD=$(az acr credential show -g ${{ env.RESOURCE_GROUP }} -n ${{ env.AZURE_CONTAINER_REGISTRY }} --query passwords[0].value -o tsv)
-        echo "::set-output name=username::${ACR_USERNAME}"
-        echo "::set-output name=password::${ACR_PASSWORD}"
-      id: get-acr-creds
+        az aks update -n ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} --attach-acr ${{ env.AZURE_CONTAINER_REGISTRY }}
 
-    - name: Create K8s secret for pulling image from ACR
-      uses: Azure/k8s-create-secret@v1.1
-      with:
-        container-registry-url: ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io
-        container-registry-username: ${{ steps.get-acr-creds.outputs.username }}
-        container-registry-password: ${{ steps.get-acr-creds.outputs.password }}
-        secret-name: ${{ env.IMAGE_PULL_SECRET_NAME }}  
-
+    # Deploys application based on given manifest file
     - name: Deploys application
       uses: Azure/k8s-deploy@v3.0
       with:
@@ -92,5 +83,3 @@ jobs:
         manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}
         images: |
           ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-        imagepullsecrets: |
-          ${{ env.IMAGE_PULL_SECRET_NAME }}

--- a/src/commands/aksHelmStarterWorkflow/configureHelmStarterWorkflow.ts
+++ b/src/commands/aksHelmStarterWorkflow/configureHelmStarterWorkflow.ts
@@ -5,7 +5,7 @@ import { getAksClusterTreeItem } from '../utils/clusters';
 import { configureStarterConfigDataForAKS } from '../utils/configureWorkflowHelper';
 import { failed } from '../utils/errorable';
 
-export default async function configureStarterWorkflow(
+export default async function configureHelmStarterWorkflow(
     _context: IActionContext,
     target: any
 ): Promise<void> {
@@ -18,7 +18,7 @@ export default async function configureStarterWorkflow(
     }
 
     // Configure the starter workflow data.
-    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service");
+    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service-helm");
     if (failed(aksStarterWorkflowData)) {
         vscode.window.showErrorMessage(aksStarterWorkflowData.error);
         return;

--- a/src/commands/aksKomposeStarterWorkflow/configureKomposeStarterWorkflow.ts
+++ b/src/commands/aksKomposeStarterWorkflow/configureKomposeStarterWorkflow.ts
@@ -5,7 +5,7 @@ import { getAksClusterTreeItem } from '../utils/clusters';
 import { configureStarterConfigDataForAKS } from '../utils/configureWorkflowHelper';
 import { failed } from '../utils/errorable';
 
-export default async function configureStarterWorkflow(
+export default async function configureKomposeStarterWorkflow(
     _context: IActionContext,
     target: any
 ): Promise<void> {
@@ -18,7 +18,7 @@ export default async function configureStarterWorkflow(
     }
 
     // Configure the starter workflow data.
-    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service");
+    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service-kompose");
     if (failed(aksStarterWorkflowData)) {
         vscode.window.showErrorMessage(aksStarterWorkflowData.error);
         return;

--- a/src/commands/aksKustomizeStarterWorkflow/configureKustomizeStarterWorkflow.ts
+++ b/src/commands/aksKustomizeStarterWorkflow/configureKustomizeStarterWorkflow.ts
@@ -5,7 +5,7 @@ import { getAksClusterTreeItem } from '../utils/clusters';
 import { configureStarterConfigDataForAKS } from '../utils/configureWorkflowHelper';
 import { failed } from '../utils/errorable';
 
-export default async function configureStarterWorkflow(
+export default async function configureKustomizeStarterWorkflow(
     _context: IActionContext,
     target: any
 ): Promise<void> {
@@ -18,7 +18,7 @@ export default async function configureStarterWorkflow(
     }
 
     // Configure the starter workflow data.
-    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service");
+    const aksStarterWorkflowData = configureStarterConfigDataForAKS(cluster.result.armId.split("/")[4], cluster.result.name, "azure-kubernetes-service-kustomize");
     if (failed(aksStarterWorkflowData)) {
         vscode.window.showErrorMessage(aksStarterWorkflowData.error);
         return;

--- a/src/commands/utils/configureWorkflowHelper.ts
+++ b/src/commands/utils/configureWorkflowHelper.ts
@@ -1,12 +1,13 @@
 import path = require("path");
 import * as fs from 'fs';
-import { getExtensionPath } from "../utils/host";
+import { getExtensionPath } from "./host";
 import * as vscode from 'vscode';
-import { Errorable, failed } from "../utils/errorable";
+import { Errorable, failed } from "./errorable";
 
 export function configureStarterConfigDataForAKS(
     resourceName: string,
-    clusterName: string
+    clusterName: string,
+    workflowName: string
 ): Errorable<string> {
     const extensionPath = getExtensionPath();
     if (failed(extensionPath)) {
@@ -14,7 +15,7 @@ export function configureStarterConfigDataForAKS(
     }
 
       // Load vscode resoruce yaml file and replace content.
-    const yamlPathOnDisk = vscode.Uri.file(path.join(extensionPath.result, 'resources', 'yaml', 'azure-kubernetes-service.yml'));
+    const yamlPathOnDisk = vscode.Uri.file(path.join(extensionPath.result, 'resources', 'yaml', `${workflowName}.yml`));
     const starterFileAutoFillContent = fs.readFileSync(yamlPathOnDisk.fsPath, 'utf8')
                                             .replace('<RESOURCE_GROUP>', resourceName)
                                             .replace('<CLUSTER_NAME>', clusterName);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,9 @@ import aksCRUDDiagnostics from './commands/aksCRUDDiagnostics/aksCRUDDiagnostics
 import { failed } from './commands/utils/errorable';
 import aksBestPracticesDiagnostics from './commands/aksBestPractices/aksBestPractices';
 import aksIdentitySecurityDiagnostics from './commands/aksIdentitySecurity/aksIdentitySecurity';
+import configureKustomizeStarterWorkflow from './commands/aksKustomizeStarterWorkflow/configureKustomizeStarterWorkflow';
+import configureKomposeStarterWorkflow from './commands/aksKomposeStarterWorkflow/configureKomposeStarterWorkflow';
+import configureHelmStarterWorkflow from './commands/aksHelmStarterWorkflow/configureHelmStarterWorkflow';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -43,6 +46,9 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksCRUDDiagnostics', aksCRUDDiagnostics );
         registerCommandWithTelemetry('aks.aksBestPracticesDiagnostics', aksBestPracticesDiagnostics );
         registerCommandWithTelemetry('aks.aksIdentitySecurityDiagnostics', aksIdentitySecurityDiagnostics );
+        registerCommandWithTelemetry('aks.configureHelmStarterWorkflow', configureHelmStarterWorkflow );
+        registerCommandWithTelemetry('aks.configureKomposeStarterWorkflow', configureKomposeStarterWorkflow );
+        registerCommandWithTelemetry('aks.configureKustomizeStarterWorkflow', configureKustomizeStarterWorkflow );
 
         await registerAzureServiceNodes(context);
 

--- a/src/tests/suite/deploystarterworkflow.test.ts
+++ b/src/tests/suite/deploystarterworkflow.test.ts
@@ -1,11 +1,11 @@
-import * as configureStarterWorkflow  from '../../commands/aksStarterWorkflow/configureStarterWorkflowHelper';
+import * as configureStarterWorkflow  from '../../commands/utils/configureWorkflowHelper';
 import 'sinon';
 import { expect } from 'chai';
 import { Succeeded, succeeded } from '../../commands/utils/errorable';
 
 describe('Test Configure Starter Data Set returns replaced value.', () => {
   it('should return some string', () => {
-    const result = configureStarterWorkflow.configureStarterConfigDataForAKS("test-resource", "test-cluster");
+    const result = configureStarterWorkflow.configureStarterConfigDataForAKS("test-resource", "test-cluster", "azure-kubernetes-service");
     expect(succeeded(result)).to.be.true;
     expect((result as Succeeded<string>).result).to.contain("test-cluster");
   });


### PR DESCRIPTION
This PR enables all the leftover `AKS Starter workflow` to be pre-configured with `cluster-name and resource-name` for the user.

This PR enables: 

* Submenu for starter workflow.
* 3 new workflows are enabled aka, Helm, Compose, Customise.

Thanks heaps guys, @palma21, @qpetraroia , @rzhang628 , @gambtho & @peterbom ❤️☕️🙏 once approved we can plan a release next week.

![image](https://user-images.githubusercontent.com/6233295/162146117-185a2f79-ca8b-4f95-98e2-b465d964f672.png)
