### PR TITLE
Read changelog from right place.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,10 @@ jobs:
       id: package_version
       uses: martinbeentjes/npm-get-version-action@v1.1.0
     - name: Check version is mentioned in Changelog
-      uses: mindsers/changelog-reader-action@v2.0.0
+      id: changelog_reader
+      uses: mindsers/changelog-reader-action@v2
       with:
+        validation_depth: 10
         version: ${{ steps.package_version.outputs.current-version }}
         path: 'CHANGELOG.md'
     - name: Create a Release
@@ -35,7 +37,7 @@ jobs:
       with:
         tag_name : ${{ steps.package_version.outputs.current-version}}
         release_name: ${{ steps.package_version.outputs.current-version}}
-        body: Publish ${{ steps.package_version.outputs.changes}}
+        body: Publish ${{ steps.changelog_reader.outputs.changes }}
     - name: Create vsix and publish to marketplace
       id: create_vsix
       uses: HaaLeo/publish-vscode-extension@v0


### PR DESCRIPTION
This PR fixes the empty `publish` field in release tag. 

The changelog was never getting read from changelog reader but from package reader hence it was empty. It is fixed now.

* Changes made according to this `underlying GH action` : https://github.com/mindsers/changelog-reader-action 

Thanks cc: @peterbom and @rzhang628 for review thanks guys! ❤️🙏☕️