### PR TITLE
Enable navigation to azure portal feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "0.0.17",
+            "version": "0.0.18",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-containerservice": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "onCommand:aks.aksBestPracticesDiagnostics",
         "onCommand:aks.configureHelmStarterWorkflow",
         "onCommand:aks.configureKomposeStarterWorkflow",
-        "onCommand:aks.configureKustomizeStarterWorkflow"
+        "onCommand:aks.configureKustomizeStarterWorkflow",
+        "onCommand:aks.showInPortal"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -97,6 +98,10 @@
             {
                 "command": "aks.configureKustomizeStarterWorkflow",
                 "title": "Kustomize Workflow"
+            },
+            {
+                "command": "aks.showInPortal",
+                "title": "Show In Portal"
             }
         ],
         "menus": {
@@ -121,6 +126,11 @@
                     "command": "aks.periscope",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "8@2"
+                },
+                {
+                    "command": "aks.showInPortal",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
+                    "group": "8@3"
                 },
                 {
                     "command": "aks.installAzureServiceOperator",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
             },
             {
                 "command": "aks.showInPortal",
-                "title": "Show In Portal"
+                "title": "Show In Azure Portal"
             }
         ],
         "menus": {

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -24,5 +24,5 @@ export default async function aksNavToPortal(
     }
 
     // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
-    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#resource${cluster.armId}/overview`));
+    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#resource${cluster.result.armId}/overview`));
 }

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from "vscode-azureextensionui";
+import { getAksClusterTreeItem } from '../utils/clusters';
+import { getExtensionPath }  from '../utils/host';
+import { failed } from '../utils/errorable';
+
+export default async function aksNavToPortal(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const cluster = getAksClusterTreeItem(target, cloudExplorer);
+    if (failed(cluster)) {
+      vscode.window.showErrorMessage(cluster.error);
+      return;
+    }
+
+    const extensionPath = getExtensionPath();
+    if (failed(extensionPath)) {
+      vscode.window.showErrorMessage(extensionPath.error);
+      return;
+    }
+
+    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#resource${target.value.id}/overview`));
+}

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -23,5 +23,6 @@ export default async function aksNavToPortal(
       return;
     }
 
-    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#resource${target.value.id}/overview`));
+    // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
+    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#resource${cluster.armId}/overview`));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import aksBestPracticesDiagnostics from './commands/aksBestPractices/aksBestPrac
 import aksIdentitySecurityDiagnostics from './commands/aksIdentitySecurity/aksIdentitySecurity';
 import aksNodeHealth from './commands/aksNodeHealth/aksNodeHealth';
 import aksKnownIssuesAvailabilityPerformanceDiagnostics from './commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance';
+import aksNavToPortal from './commands/aksNavToPortal/aksNavToPortal';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -50,6 +51,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.configureKustomizeStarterWorkflow', configureKustomizeStarterWorkflow );
         registerCommandWithTelemetry('aks.aksNodeHealthDiagnostics', aksNodeHealth );
         registerCommandWithTelemetry('aks.aksKnownIssuesAvailabilityPerformanceDiagnostics', aksKnownIssuesAvailabilityPerformanceDiagnostics );
+        registerCommandWithTelemetry('aks.showInPortal', aksNavToPortal );
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR enables the navigation to specific cluster issue, now user can `right-click` and choose `Show in Azure Portal` for their cluster and browser will be called for the portal to open the `cluster overview` page. I know this will make @peterbom really happy, as he shared the real use-case.

* **Use case:** Imagine you have too many clusters and it gets really hard if you are logging into the azure portal and your recent history has lost your cluster only way you could search is via search resource or navigating inside AKS in Azure portal, this way simplifies all this into just one-click and navigate to the AKS cluster azure portal page.

Thanks you so much guys! cc: @peterbom,  @gambtho and @rzhang628 + @qpetraroia ❤️🙏

**Working Screenshots:**

![image](https://user-images.githubusercontent.com/6233295/167076460-6c92f270-08e6-4bdb-92f3-7b5f911e9035.png)


![image](https://user-images.githubusercontent.com/6233295/167074189-bcaac453-64fc-4257-bec3-7d517f09bf7a.png)
