### PR TITLE
Navigate to create AKS cluster portal.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
         "onCommand:aks.configureKomposeStarterWorkflow",
         "onCommand:aks.configureKustomizeStarterWorkflow",
         "onCommand:aks.showInPortal",
-        "onCommand:aks.clusterProperties"
+        "onCommand:aks.clusterProperties",
+        "onCommand:aks.createClusterNavToAzurePortal"
+
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -135,6 +137,10 @@
             {
                 "command": "aks.clusterProperties",
                 "title": "Show Properties"
+            },
+            {
+                "command": "aks.createClusterNavToAzurePortal",
+                "title": "Create Cluster From Azure Portal"
             }
         ],
         "menus": {
@@ -178,6 +184,10 @@
                     "submenu": "aks.ghWorkflowSubMenu",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "9@1"
+                },
+                {
+                    "command": "aks.createClusterNavToAzurePortal",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.subscription/i"
                 }
             ],
             "aks.detectorsSubMenu": [

--- a/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
+++ b/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from "vscode-azureextensionui";
+import { getAksClusterSubscriptionItem } from '../utils/clusters';
+import { failed } from '../utils/errorable';
+
+export default async function aksCreateClusterNavToAzurePortal(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const cluster = getAksClusterSubscriptionItem(target, cloudExplorer);
+    if (failed(cluster)) {
+      vscode.window.showErrorMessage(cluster.error);
+      return;
+    }
+
+    vscode.env.openExternal(vscode.Uri.parse(`https://portal.azure.com/#create/microsoft.aks`));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import aksNodeHealth from './commands/aksNodeHealth/aksNodeHealth';
 import aksKnownIssuesAvailabilityPerformanceDiagnostics from './commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance';
 import aksNavToPortal from './commands/aksNavToPortal/aksNavToPortal';
 import aksClusterProperties from './commands/aksClusterProperties/aksClusterProperties';
+import aksCreateClusterNavToAzurePortal from './commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -54,6 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKnownIssuesAvailabilityPerformanceDiagnostics', aksKnownIssuesAvailabilityPerformanceDiagnostics );
         registerCommandWithTelemetry('aks.showInPortal', aksNavToPortal );
         registerCommandWithTelemetry('aks.clusterProperties', aksClusterProperties);
+        registerCommandWithTelemetry('aks.createClusterNavToAzurePortal', aksCreateClusterNavToAzurePortal);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR enables the new `AKS Subscription` level command to open `create cluster from azure portal` screenshots below can show the real flow of screens.

This will help vscode audience to quickly create cluster transitioning from this extension to the portal.

Thank you and cc: @peterbom and @rzhang628 for reviews and eyeing this please. ❤️🙏☕️

<img width="369" alt="Screen Shot 2022-05-27 at 11 16 05 AM" src="https://user-images.githubusercontent.com/6233295/170594770-1a6d23d6-d537-449e-bca3-e7edc07d7fa7.png">


<img width="1156" alt="Screen Shot 2022-05-27 at 11 16 35 AM" src="https://user-images.githubusercontent.com/6233295/170594758-5abb582a-751f-4134-9a7c-98a68a73e31e.png">
