### PR TITLE
Revert extensionui update and start-stop feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,12 @@
             "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/arm-containerservice": "^16.1.0",
+                "@azure/arm-containerservice": "^7.0.1",
                 "@azure/arm-monitor": "^6.0.0",
                 "@azure/arm-resources": "^3.0.0",
-                "@azure/arm-resources-subscriptions": "^2.0.1",
                 "@azure/arm-storage": "^15.2.0",
-                "@azure/arm-subscriptions": "^5.0.1",
-                "@azure/identity": "^2.1.0",
-                "@azure/ms-rest-azure-env": "^2.0.0",
+                "@azure/arm-subscriptions": "^3.0.0",
                 "@azure/storage-blob": "^12.7.0",
-                "@microsoft/vscode-azext-azureutils": "^0.3.1",
-                "@microsoft/vscode-azext-utils": "^0.3.8",
                 "@sinonjs/fake-timers": "^6.0.1",
                 "@types/chai": "^4.2.21",
                 "@types/sinon": "^10.0.6",
@@ -34,6 +29,7 @@
                 "tslib": "^2.1.0",
                 "underscore": "^1.13.1",
                 "util": "^0.12.3",
+                "vscode-azureextensionui": "^0.39.4",
                 "vscode-extension-telemetry": "^0.1.6",
                 "vscode-kubernetes-tools-api": "^1.0.0",
                 "vscode-test": "^1.5.2"
@@ -50,7 +46,7 @@
                 "sinon": "^12.0.1",
                 "ts-loader": "^8.0.18",
                 "tslint": "^5.20.1",
-                "typescript": "^3.9.10",
+                "typescript": "^3.7.2",
                 "webpack": "^5.25.1",
                 "webpack-cli": "^4.5.0"
             },
@@ -72,21 +68,19 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/arm-containerservice": {
-            "version": "16.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-16.1.0.tgz",
-            "integrity": "sha512-I8pjVSThLYBdCLE5emqKVCwlASTVDV5JLEcZxbPiSVC8zRd+jk7veuYIHRS7BhbsuNGV33kkFF+eZYpjsOwSCQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-7.0.1.tgz",
+            "integrity": "sha512-MPdd/7UENmU1Ki+enF2tgujIlb4WV0B/30ove/2v7ssx2JAOgyN9qKbtx0g6YgnaBNBLZm1t1S81RF9JEsS6bg==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
+                "@azure/ms-rest-azure-js": "^1.3.2",
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.3"
             }
+        },
+        "node_modules/@azure/arm-containerservice/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/arm-monitor": {
             "version": "6.0.0",
@@ -134,6 +128,19 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@azure/arm-monitor/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
         "node_modules/@azure/arm-monitor/node_modules/tough-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -160,85 +167,6 @@
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
                 "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-profile-2020-09-01-hybrid/-/arm-resources-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-6Ku548pHIQULuXzQrxe4zBCxi2g+JBf4bk4HZyYwmyV1ai4ZawDzS8pN/gREhSxeV/t6KtpmHMADi5oxc7wqaA==",
-            "deprecated": "Please note, versions of this package with version numbers 1.1.1 and below have been deprecated as of 31-March-2022. We strongly encourage you to upgrade to version 2.0.0 or above to continue receiving updates. Refer to our deprecation policy: https://azure.github.io/azure-sdk/policies_support.html for more details.",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/@azure/ms-rest-azure-js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
-            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/@azure/ms-rest-js": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-            "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "abort-controller": "^3.0.0",
-                "form-data": "^2.5.0",
-                "node-fetch": "^2.6.7",
-                "tough-cookie": "^3.0.1",
-                "tslib": "^1.10.0",
-                "tunnel": "0.0.6",
-                "uuid": "^8.3.2",
-                "xml2js": "^0.4.19"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/tough-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-            "dependencies": {
-                "ip-regex": "^2.1.0",
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/@azure/arm-resources-subscriptions": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.0.1.tgz",
-            "integrity": "sha512-K/WTPFQz12eTdpR/VgB56R0qQ/MFJmsYuBAw5k/hLmMAZNIqBTy96YMRPzFLjpDZRs/HpLV61vpUGldBQL9iUw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/@azure/arm-resources/node_modules/@azure/ms-rest-azure-js": {
@@ -277,6 +205,19 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@azure/arm-resources/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
         "node_modules/@azure/arm-resources/node_modules/tough-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -303,70 +244,6 @@
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
                 "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-GgsnN8eWctoOvix0vr1RQI/DrBpcR5mIOZ/4FIdJgsIapg6ZWPIYmLYfAyvelfC+KVsEqOGRMTQY5UZ4b9et/A==",
-            "deprecated": "Please note, versions of this package with version numbers 1.1.1 and below have been deprecated as of 31-March-2022. We strongly encourage you to upgrade to version 2.0.0 or above to continue receiving updates. Refer to our deprecation policy: https://azure.github.io/azure-sdk/policies_support.html for more details.",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid/node_modules/@azure/ms-rest-azure-js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
-            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid/node_modules/@azure/ms-rest-js": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-            "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "abort-controller": "^3.0.0",
-                "form-data": "^2.5.0",
-                "node-fetch": "^2.6.7",
-                "tough-cookie": "^3.0.1",
-                "tslib": "^1.10.0",
-                "tunnel": "0.0.6",
-                "uuid": "^8.3.2",
-                "xml2js": "^0.4.19"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid/node_modules/tough-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-            "dependencies": {
-                "ip-regex": "^2.1.0",
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@azure/arm-storage/node_modules/@azure/ms-rest-azure-js": {
@@ -405,6 +282,19 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@azure/arm-storage/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
         "node_modules/@azure/arm-storage/node_modules/tough-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -424,21 +314,81 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/arm-subscriptions": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-5.0.1.tgz",
-            "integrity": "sha512-7GC+WJ46w692udXAhsu0PvOSGxyHMqIO4rn+kT9OrfEGN69cCKP4IUWrEcnZltaKcR68jO2D3BaloUTuFaHr+w==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-3.0.0.tgz",
+            "integrity": "sha512-EIPbFJsjLtp6sEDyCJqqt9UIwYm4sAcMEA5pDVXQmEwKPtUckxmqalmFUN9754crv63QRR+Vy01gccJZDR5m1Q==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/@azure/ms-rest-azure-js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
+            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/@azure/ms-rest-js": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.3.tgz",
+            "integrity": "sha512-sXOhOu/37Tr8428f32Jwuwga975Xw64pYg1UeUwOBMhkNgtn5vUuNRa3fhmem+I6f8EKoi6hOsYDFlaHeZ52jA==",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@types/node-fetch": "^2.3.7",
+                "@types/tunnel": "0.0.1",
+                "abort-controller": "^3.0.0",
+                "form-data": "^2.5.0",
+                "node-fetch": "^2.6.0",
+                "tough-cookie": "^3.0.1",
+                "tslib": "^1.10.0",
+                "tunnel": "0.0.6",
+                "uuid": "^3.3.2",
+                "xml2js": "^0.4.19"
+            }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/@types/tunnel": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+            "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">= 0.12"
             }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/tough-cookie": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+            "dependencies": {
+                "ip-regex": "^2.1.0",
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@azure/arm-subscriptions/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/core-asynciterator-polyfill": {
             "version": "1.0.0",
@@ -457,33 +407,10 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/core-client": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.0.tgz",
-            "integrity": "sha512-YhSf4cb61ApSjItscp9XoaLq8KRnacPDAhmjAZSMnn/gs6FhFbZNfOBOErG2dDj7JRknVtCmJ5mLmfR2sLa11A==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.5.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-client/node_modules/@azure/core-tracing": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
+        "node_modules/@azure/core-auth/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/core-http": {
             "version": "2.1.0",
@@ -518,6 +445,17 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@azure/core-http/node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/@azure/core-http/node_modules/form-data": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -549,6 +487,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@azure/core-http/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
         "node_modules/@azure/core-http/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -571,67 +514,20 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@azure/core-lro/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
         "node_modules/@azure/core-paging": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.3.0.tgz",
-            "integrity": "sha512-H6Tg9eBm0brHqLy0OSAGzxIh1t4UL8eZVrSUMJ60Ra9cwq2pOskFqVpz2pYoHDsBY1jZ4V/P8LRGb5D5pmC6rg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+            "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
             "dependencies": {
-                "tslib": "^2.2.0"
+                "@azure/core-asynciterator-polyfill": "^1.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
-            "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "form-data": "^4.0.0",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
+                "node": ">=8.0.0"
             }
         },
         "node_modules/@azure/core-tracing": {
@@ -646,61 +542,10 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@azure/core-util": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0.tgz",
-            "integrity": "sha512-yWshY9cdPthlebnb3Zuz/j0Lv4kjU6u7PR5sW7A9FF7EX+0irMRJAtyTq5TPiDHJfjH8gTSlnIYFj9m7Ed76IQ==",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/identity": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.1.0.tgz",
-            "integrity": "sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^2.26.0",
-                "@azure/msal-common": "^7.0.0",
-                "@azure/msal-node": "^1.10.0",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "open": "^8.0.0",
-                "stoppable": "^1.1.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/@azure/core-tracing": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-            "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/identity/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
+        "node_modules/@azure/core-tracing/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@azure/logger": {
             "version": "1.0.2",
@@ -713,50 +558,49 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/@azure/logger/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
-        "node_modules/@azure/msal-browser": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.27.0.tgz",
-            "integrity": "sha512-PyATq2WvK+x32waRqqikym8wvn939iO9UhpFqhLwitNrfLa3PHUgJuuI9oLSQOS3/UzjYb8aqN+XzchU3n/ZuQ==",
+        "node_modules/@azure/ms-rest-azure-js": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-1.3.3.tgz",
+            "integrity": "sha512-QCZBcPiqgEZo34v+R6Gf97N6KVqmm1432rucg+k0Fp2egejYsRho7i39N8mUbNUk/SPmyp3XtI7BqgS+/V8gJQ==",
             "dependencies": {
-                "@azure/msal-common": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=0.8.0"
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.2"
             }
         },
-        "node_modules/@azure/msal-common": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.1.0.tgz",
-            "integrity": "sha512-WyfqE5mY/rggjqvq0Q5DxLnA33KSb0vfsUjxa95rycFknI03L5GPYI4HTU9D+g0PL5TtsQGnV3xzAGq9BFCVJQ==",
-            "engines": {
-                "node": ">=0.8.0"
-            }
+        "node_modules/@azure/ms-rest-azure-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
-        "node_modules/@azure/msal-node": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.11.0.tgz",
-            "integrity": "sha512-KW/XEexfCrPzdYbjY7NVmhq9okZT3Jvck55CGXpz9W5asxeq3EtrP45p+ZXtQVEfko0YJdolpCNqWUyXvanWZg==",
+        "node_modules/@azure/ms-rest-js": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.11.2.tgz",
+            "integrity": "sha512-2AyQ1IKmLGKW7DU3/x3TsTBzZLcbC9YRI+yuDPuXAQrv3zar340K9wsxU413kHFIDjkWNCo9T0w5VtwcyWxhbQ==",
             "dependencies": {
-                "@azure/msal-common": "^7.1.0",
-                "jsonwebtoken": "^8.5.1",
-                "uuid": "^8.3.0"
-            },
-            "engines": {
-                "node": "10 || 12 || 14 || 16 || 18"
+                "@azure/core-auth": "^1.1.4",
+                "axios": "^0.21.1",
+                "form-data": "^2.3.2",
+                "tough-cookie": "^2.4.3",
+                "tslib": "^1.9.2",
+                "tunnel": "0.0.6",
+                "uuid": "^3.2.1",
+                "xml2js": "^0.4.19"
             }
         },
-        "node_modules/@azure/msal-node/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
+        "node_modules/@azure/ms-rest-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/storage-blob": {
             "version": "12.7.0",
@@ -775,6 +619,11 @@
             "engines": {
                 "node": ">=8.0.0"
             }
+        },
+        "node_modules/@azure/storage-blob/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.5.5",
@@ -804,330 +653,6 @@
             "engines": {
                 "node": ">=10.0.0"
             }
-        },
-        "node_modules/@microsoft/1ds-core-js": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.4.tgz",
-            "integrity": "sha512-ZkbCb63JF7hN+YQ8e/4nRe6vAIBMpoF8PQNiYiXSzYtdhXZ/pM3jB9/7g0O5LR4h/2IU1amAq0kpBgPbd6NWqg==",
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": "2.8.5",
-                "@microsoft/applicationinsights-shims": "^2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            }
-        },
-        "node_modules/@microsoft/1ds-post-js": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.4.tgz",
-            "integrity": "sha512-SblhGNkd8C6kzewq+Gc/ViN2oYp1/TJFw0Y4rOfHXCr6siznInBggm5ehqZd/QPXh/7MYqCx4Gpw9Rra18fO0g==",
-            "dependencies": {
-                "@microsoft/1ds-core-js": "3.2.4",
-                "@microsoft/applicationinsights-shims": "^2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.5.tgz",
-            "integrity": "sha512-7/EgK6r8GiDVluo84skCMNthgnPa6P7TXiJqHBJbuCf11N4YqkZoGjKs+Fo7h6XIPuYMUHVMNLpBObI7oS7HsQ==",
-            "dependencies": {
-                "@microsoft/applicationinsights-shims": "2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-shims": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-            "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-        },
-        "node_modules/@microsoft/dynamicproto-js": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
-            "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.3.1.tgz",
-            "integrity": "sha512-kR8ven3vtedOhHLySgowma5yWpV3GhWyrPmMS4Evb64ocShsRYBmw8qq91geoX6S33yzsaZULld8en1W7vdYWg==",
-            "dependencies": {
-                "@azure/arm-resources": "^5.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-resources-subscriptions": "^1.0.0",
-                "@azure/arm-storage": "^17.0.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
-                "@microsoft/vscode-azext-utils": "^0.3.0",
-                "semver": "^7.3.7",
-                "uuid": "^8.3.2",
-                "vscode-nls": "^5.0.1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-resources": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
-            "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-resources-subscriptions": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
-            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
-            "deprecated": "Please note, versions of this package with version numbers 1.0.1 and below have been deprecated as of 31-March-2022. We strongly encourage you to upgrade to version 2.0.0 or above to continue receiving updates. Refer to our deprecation policy: https://azure.github.io/azure-sdk/policies_support.html for more details.",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-resources-subscriptions/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-storage": {
-            "version": "17.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
-            "integrity": "sha512-J2jmTPv8ZraSHDTz9l2Bx8gNL3ktfDDWo2mxWfzarn64O9Fjhb+l85YWyubGy2xUdeGuZPKzvQLltGv8bSu8eQ==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/ms-rest-azure-js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
-            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/ms-rest-azure-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/ms-rest-js": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-            "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "abort-controller": "^3.0.0",
-                "form-data": "^2.5.0",
-                "node-fetch": "^2.6.7",
-                "tough-cookie": "^3.0.1",
-                "tslib": "^1.10.0",
-                "tunnel": "0.0.6",
-                "uuid": "^8.3.2",
-                "xml2js": "^0.4.19"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/ms-rest-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/tough-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-            "dependencies": {
-                "ip-regex": "^2.1.0",
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/vscode-nls": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-            "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
-        },
-        "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.8.tgz",
-            "integrity": "sha512-ilT/Kb7ql0wgfST/7mVhHRvzWo+FftcK8KraCTwcT5XRZPaYylhlmxa5XjL4ub2j8ZZLlBu+eC8qUuOlLJ52Tg==",
-            "dependencies": {
-                "@vscode/extension-telemetry": "^0.6.2",
-                "dayjs": "^1.11.2",
-                "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^8.2.0",
-                "open": "^8.0.4",
-                "semver": "^7.3.7",
-                "vscode-nls": "^5.0.1",
-                "vscode-tas-client": "^0.1.47"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-            "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/domelementtype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ]
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-            "dependencies": {
-                "domelementtype": "^2.2.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-            "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/html-to-text": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.0.tgz",
-            "integrity": "sha512-CLXExYn1b++Lgri+ZyVvbUEFwzkLZppjjZOwB7X1qv2jIi8MrMEvxWX5KQ7zATAzTvcqgmtO00M2kCRMtEdOKQ==",
-            "dependencies": {
-                "@selderee/plugin-htmlparser2": "^0.6.0",
-                "deepmerge": "^4.2.2",
-                "he": "^1.2.0",
-                "htmlparser2": "^6.1.0",
-                "minimist": "^1.2.6",
-                "selderee": "^0.6.0"
-            },
-            "bin": {
-                "html-to-text": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=10.23.2"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/htmlparser2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.5.2",
-                "entities": "^2.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/vscode-nls": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-            "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.4",
@@ -1175,43 +700,6 @@
             "integrity": "sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww==",
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@selderee/plugin-htmlparser2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-            "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
-            "dependencies": {
-                "domhandler": "^4.2.0",
-                "selderee": "^0.6.0"
-            },
-            "funding": {
-                "url": "https://ko-fi.com/killymxi"
-            }
-        },
-        "node_modules/@selderee/plugin-htmlparser2/node_modules/domelementtype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ]
-        },
-        "node_modules/@selderee/plugin-htmlparser2/node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-            "dependencies": {
-                "domelementtype": "^2.2.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -1336,6 +824,17 @@
                 "form-data": "^3.0.0"
             }
         },
+        "node_modules/@types/node-fetch/node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/@types/node-fetch/node_modules/form-data": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -1387,18 +886,6 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
-        },
-        "node_modules/@vscode/extension-telemetry": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-            "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
-            "dependencies": {
-                "@microsoft/1ds-core-js": "^3.2.3",
-                "@microsoft/1ds-post-js": "^3.2.3"
-            },
-            "engines": {
-                "vscode": "^1.60.0"
-            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -1863,6 +1350,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2029,11 +1524,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.1",
@@ -2254,9 +1744,9 @@
             "dev": true
         },
         "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2344,9 +1834,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+            "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
         },
         "node_modules/debug": {
             "version": "4.3.3",
@@ -2386,22 +1876,6 @@
             },
             "engines": {
                 "node": ">=0.12"
-            }
-        },
-        "node_modules/deepmerge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/define-properties": {
@@ -2537,10 +2011,55 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/discontinuous-range": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+        "node_modules/dom-serializer": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/domelementtype": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "node_modules/domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dependencies": {
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "dependencies": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
         },
         "node_modules/duplexer2": {
             "version": "0.1.4",
@@ -2570,14 +2089,6 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -2639,6 +2150,11 @@
             "engines": {
                 "node": ">=8.6"
             }
+        },
+        "node_modules/entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "node_modules/envinfo": {
             "version": "7.7.4",
@@ -3032,9 +2548,9 @@
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
         "node_modules/form-data": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -3048,6 +2564,19 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
+        "node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -3241,6 +2770,36 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/html-to-text": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
+            "integrity": "sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==",
+            "dependencies": {
+                "he": "^1.2.0",
+                "htmlparser2": "^3.10.1",
+                "lodash": "^4.17.11",
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "html-to-text": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "dependencies": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -3391,20 +2950,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3552,6 +3097,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3647,44 +3200,12 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^5.6.0"
-            },
-            "engines": {
-                "node": ">=4",
-                "npm": ">=1.4.28"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-            "dependencies": {
-                "jwa": "^1.4.1",
-                "safe-buffer": "^5.0.1"
+        "node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/just-extend": {
@@ -3692,25 +3213,6 @@
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
             "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
             "dev": true
-        },
-        "node_modules/jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -3793,6 +3295,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "node_modules/lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -3814,40 +3321,10 @@
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-        },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
         },
         "node_modules/lodash.union": {
             "version": "4.6.0",
@@ -3944,6 +3421,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -4262,11 +3740,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/moo": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-            "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
-        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4282,27 +3755,6 @@
             },
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/nearley": {
-            "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-            "dependencies": {
-                "commander": "^2.19.0",
-                "moo": "^0.5.0",
-                "railroad-diagrams": "^1.0.0",
-                "randexp": "0.4.6"
-            },
-            "bin": {
-                "nearley-railroad": "bin/nearley-railroad.js",
-                "nearley-test": "bin/nearley-test.js",
-                "nearley-unparse": "bin/nearley-unparse.js",
-                "nearleyc": "bin/nearleyc.js"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://nearley.js.org/#give-to-nearley"
             }
         },
         "node_modules/neo-async": {
@@ -4434,28 +3886,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+        "node_modules/opn": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+            "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+            "deprecated": "The package has been renamed to `open`",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/open/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dependencies": {
-                "is-docker": "^2.0.0"
+                "is-wsl": "^1.1.0"
             },
             "engines": {
                 "node": ">=8"
@@ -4495,18 +3932,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parseley": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-            "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
-            "dependencies": {
-                "moo": "^0.5.1",
-                "nearley": "^2.20.1"
-            },
-            "funding": {
-                "url": "https://ko-fi.com/killymxi"
             }
         },
         "node_modules/path-exists": {
@@ -4655,23 +4080,6 @@
                 }
             ]
         },
-        "node_modules/railroad-diagrams": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-        },
-        "node_modules/randexp": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-            "dependencies": {
-                "discontinuous-range": "1.0.0",
-                "ret": "~0.1.10"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4775,14 +4183,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ret": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4874,17 +4274,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "node_modules/selderee": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-            "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
-            "dependencies": {
-                "parseley": "^0.7.0"
-            },
-            "funding": {
-                "url": "https://ko-fi.com/killymxi"
-            }
         },
         "node_modules/semver": {
             "version": "5.7.0",
@@ -5039,15 +4428,6 @@
             "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
             "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
         },
-        "node_modules/stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-            "engines": {
-                "node": ">=4",
-                "npm": ">=6"
-            }
-        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5168,19 +4548,11 @@
             }
         },
         "node_modules/tas-client": {
-            "version": "0.1.45",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.45.tgz",
-            "integrity": "sha512-IG9UmCpDbDPK23UByQ27rLybkRZYEx2eC9EkieXdwPKKjZPD2zPwfQmyGnZrZet4FUt3yj0ytkwz+liR9Nz/nA==",
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.16.tgz",
+            "integrity": "sha512-ZMGg7dGXiYVJHYusDpUb/Ilg+iPNYZdKJSIA2ADn0f2RovHWM0TpNVe2YHPEc0hdFMsUwWKS5pCRzLnlUqcqGg==",
             "dependencies": {
-                "axios": "^0.26.1"
-            }
-        },
-        "node_modules/tas-client/node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.8"
+                "axios": "^0.21.1"
             }
         },
         "node_modules/terser": {
@@ -5282,6 +4654,23 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dependencies": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tough-cookie/node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "node_modules/tr46": {
             "version": "0.0.3",
@@ -5425,9 +4814,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
         "node_modules/tslint": {
             "version": "5.20.1",
@@ -5500,9 +4889,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+            "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5620,6 +5009,120 @@
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
+        "node_modules/vscode-azureextensionui": {
+            "version": "0.39.4",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.4.tgz",
+            "integrity": "sha512-ht7ZSzMXSKHDSwGA3nWtisqrNom3kg5HaeZfRp0rDdx47HNlldxtsKieLyWy7E4AeS6+BFX4px9GRXcGhnGoQQ==",
+            "dependencies": {
+                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-storage": "^15.0.0",
+                "@azure/arm-subscriptions": "^2.0.0",
+                "@azure/ms-rest-azure-env": "^2.0.0",
+                "@azure/ms-rest-js": "^2.2.1",
+                "dayjs": "^1.9.3",
+                "escape-string-regexp": "^2.0.0",
+                "fs-extra": "^8.0.0",
+                "html-to-text": "^5.1.1",
+                "opn": "^6.0.0",
+                "semver": "^5.7.1",
+                "vscode-extension-telemetry": "^0.1.5",
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.17"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@azure/arm-subscriptions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "dependencies": {
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@azure/ms-rest-azure-js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
+            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@azure/ms-rest-js": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.3.tgz",
+            "integrity": "sha512-sXOhOu/37Tr8428f32Jwuwga975Xw64pYg1UeUwOBMhkNgtn5vUuNRa3fhmem+I6f8EKoi6hOsYDFlaHeZ52jA==",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@types/node-fetch": "^2.3.7",
+                "@types/tunnel": "0.0.1",
+                "abort-controller": "^3.0.0",
+                "form-data": "^2.5.0",
+                "node-fetch": "^2.6.0",
+                "tough-cookie": "^3.0.1",
+                "tslib": "^1.10.0",
+                "tunnel": "0.0.6",
+                "uuid": "^3.3.2",
+                "xml2js": "^0.4.19"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@types/tunnel": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+            "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/form-data": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/tough-cookie": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+            "dependencies": {
+                "ip-regex": "^2.1.0",
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/vscode-extension-telemetry": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz",
@@ -5639,12 +5142,17 @@
                 "vscode": "^1.31.0"
             }
         },
+        "node_modules/vscode-nls": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+            "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
+        },
         "node_modules/vscode-tas-client": {
-            "version": "0.1.47",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.47.tgz",
-            "integrity": "sha512-SlEPDi+0gwxor4ANzBtXwqROPQdQkClHeVJgnkvdDF5Xnl407htCsabTPAq4Di8muObORtLchqQS/k1ocaGDEg==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.17.tgz",
+            "integrity": "sha512-5uqMeg7sjsu1/QkmuRtBOXtZnnrCXAMEihbOSxan3bk2NdA/nZvhfhfLh8gd9FlBBL56QH69I8Zn25B2yGPRng==",
             "dependencies": {
-                "tas-client": "0.1.45"
+                "tas-client": "0.1.16"
             },
             "engines": {
                 "vscode": "^1.19.1"
@@ -5971,7 +5479,8 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -6057,17 +5566,20 @@
             }
         },
         "@azure/arm-containerservice": {
-            "version": "16.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-16.1.0.tgz",
-            "integrity": "sha512-I8pjVSThLYBdCLE5emqKVCwlASTVDV5JLEcZxbPiSVC8zRd+jk7veuYIHRS7BhbsuNGV33kkFF+eZYpjsOwSCQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-7.0.1.tgz",
+            "integrity": "sha512-MPdd/7UENmU1Ki+enF2tgujIlb4WV0B/30ove/2v7ssx2JAOgyN9qKbtx0g6YgnaBNBLZm1t1S81RF9JEsS6bg==",
             "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure/ms-rest-azure-js": "^1.3.2",
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
             }
         },
         "@azure/arm-monitor": {
@@ -6114,6 +5626,16 @@
                     "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
                     "requires": {
                         "@types/node": "*"
+                    }
+                },
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "tough-cookie": {
@@ -6179,58 +5701,14 @@
                         "@types/node": "*"
                     }
                 },
-                "tough-cookie": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
                     "requires": {
-                        "ip-regex": "^2.1.0",
-                        "psl": "^1.1.28",
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@azure/arm-resources-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-profile-2020-09-01-hybrid/-/arm-resources-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-6Ku548pHIQULuXzQrxe4zBCxi2g+JBf4bk4HZyYwmyV1ai4ZawDzS8pN/gREhSxeV/t6KtpmHMADi5oxc7wqaA==",
-            "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            },
-            "dependencies": {
-                "@azure/ms-rest-azure-js": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
-                    "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
-                    "requires": {
-                        "@azure/core-auth": "^1.1.4",
-                        "@azure/ms-rest-js": "^2.2.0",
-                        "tslib": "^1.10.0"
-                    }
-                },
-                "@azure/ms-rest-js": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-                    "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
-                    "requires": {
-                        "@azure/core-auth": "^1.1.4",
-                        "abort-controller": "^3.0.0",
-                        "form-data": "^2.5.0",
-                        "node-fetch": "^2.6.7",
-                        "tough-cookie": "^3.0.1",
-                        "tslib": "^1.10.0",
-                        "tunnel": "0.0.6",
-                        "uuid": "^8.3.2",
-                        "xml2js": "^0.4.19"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "tough-cookie": {
@@ -6247,24 +5725,7 @@
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
                     "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
-            }
-        },
-        "@azure/arm-resources-subscriptions": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.0.1.tgz",
-            "integrity": "sha512-K/WTPFQz12eTdpR/VgB56R0qQ/MFJmsYuBAw5k/hLmMAZNIqBTy96YMRPzFLjpDZRs/HpLV61vpUGldBQL9iUw==",
-            "requires": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
             }
         },
         "@azure/arm-storage": {
@@ -6313,6 +5774,16 @@
                         "@types/node": "*"
                     }
                 },
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
                 "tough-cookie": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -6330,14 +5801,13 @@
                 }
             }
         },
-        "@azure/arm-storage-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-GgsnN8eWctoOvix0vr1RQI/DrBpcR5mIOZ/4FIdJgsIapg6ZWPIYmLYfAyvelfC+KVsEqOGRMTQY5UZ4b9et/A==",
+        "@azure/arm-subscriptions": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-3.0.0.tgz",
+            "integrity": "sha512-EIPbFJsjLtp6sEDyCJqqt9UIwYm4sAcMEA5pDVXQmEwKPtUckxmqalmFUN9754crv63QRR+Vy01gccJZDR5m1Q==",
             "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
                 "tslib": "^1.10.0"
             },
             "dependencies": {
@@ -6352,19 +5822,39 @@
                     }
                 },
                 "@azure/ms-rest-js": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-                    "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.3.tgz",
+                    "integrity": "sha512-sXOhOu/37Tr8428f32Jwuwga975Xw64pYg1UeUwOBMhkNgtn5vUuNRa3fhmem+I6f8EKoi6hOsYDFlaHeZ52jA==",
                     "requires": {
                         "@azure/core-auth": "^1.1.4",
+                        "@types/node-fetch": "^2.3.7",
+                        "@types/tunnel": "0.0.1",
                         "abort-controller": "^3.0.0",
                         "form-data": "^2.5.0",
-                        "node-fetch": "^2.6.7",
+                        "node-fetch": "^2.6.0",
                         "tough-cookie": "^3.0.1",
                         "tslib": "^1.10.0",
                         "tunnel": "0.0.6",
-                        "uuid": "^8.3.2",
+                        "uuid": "^3.3.2",
                         "xml2js": "^0.4.19"
+                    }
+                },
+                "@types/tunnel": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+                    "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "tough-cookie": {
@@ -6381,26 +5871,7 @@
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
                     "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
-            }
-        },
-        "@azure/arm-subscriptions": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-5.0.1.tgz",
-            "integrity": "sha512-7GC+WJ46w692udXAhsu0PvOSGxyHMqIO4rn+kT9OrfEGN69cCKP4IUWrEcnZltaKcR68jO2D3BaloUTuFaHr+w==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
             }
         },
         "@azure/core-asynciterator-polyfill": {
@@ -6415,29 +5886,12 @@
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
-            }
-        },
-        "@azure/core-client": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.0.tgz",
-            "integrity": "sha512-YhSf4cb61ApSjItscp9XoaLq8KRnacPDAhmjAZSMnn/gs6FhFbZNfOBOErG2dDj7JRknVtCmJ5mLmfR2sLa11A==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.5.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
             },
             "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-                    "requires": {
-                        "tslib": "^2.2.0"
-                    }
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
                 }
             }
         },
@@ -6471,6 +5925,14 @@
                         "@types/node": "*"
                     }
                 },
+                "combined-stream": {
+                    "version": "1.0.8",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+                    "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
                 "form-data": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -6496,6 +5958,11 @@
                         "universalify": "^0.1.2"
                     }
                 },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6512,56 +5979,21 @@
                 "@azure/core-tracing": "1.0.0-preview.13",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
             }
         },
         "@azure/core-paging": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.3.0.tgz",
-            "integrity": "sha512-H6Tg9eBm0brHqLy0OSAGzxIh1t4UL8eZVrSUMJ60Ra9cwq2pOskFqVpz2pYoHDsBY1jZ4V/P8LRGb5D5pmC6rg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+            "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
             "requires": {
-                "tslib": "^2.2.0"
-            }
-        },
-        "@azure/core-rest-pipeline": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.9.0.tgz",
-            "integrity": "sha512-uvM3mY+Vegk0F2r4Eh0yPdsXTUyafTQkeX0USnz1Eyangxm2Bib0w0wkJVZW8fpks7Lcv0ztIdCFTrN7H8uptg==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "form-data": "^4.0.0",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
-            },
-            "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-                    "requires": {
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-                }
+                "@azure/core-asynciterator-polyfill": "^1.0.0"
             }
         },
         "@azure/core-tracing": {
@@ -6571,51 +6003,12 @@
             "requires": {
                 "@opentelemetry/api": "^1.0.1",
                 "tslib": "^2.2.0"
-            }
-        },
-        "@azure/core-util": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0.tgz",
-            "integrity": "sha512-yWshY9cdPthlebnb3Zuz/j0Lv4kjU6u7PR5sW7A9FF7EX+0irMRJAtyTq5TPiDHJfjH8gTSlnIYFj9m7Ed76IQ==",
-            "requires": {
-                "tslib": "^2.2.0"
-            }
-        },
-        "@azure/identity": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.1.0.tgz",
-            "integrity": "sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==",
-            "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^2.26.0",
-                "@azure/msal-common": "^7.0.0",
-                "@azure/msal-node": "^1.10.0",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "open": "^8.0.0",
-                "stoppable": "^1.1.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
             },
             "dependencies": {
-                "@azure/core-tracing": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-                    "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-                    "requires": {
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
                 }
             }
         },
@@ -6625,6 +6018,13 @@
             "integrity": "sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==",
             "requires": {
                 "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
             }
         },
         "@azure/ms-rest-azure-env": {
@@ -6632,33 +6032,41 @@
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
-        "@azure/msal-browser": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.27.0.tgz",
-            "integrity": "sha512-PyATq2WvK+x32waRqqikym8wvn939iO9UhpFqhLwitNrfLa3PHUgJuuI9oLSQOS3/UzjYb8aqN+XzchU3n/ZuQ==",
+        "@azure/ms-rest-azure-js": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-1.3.3.tgz",
+            "integrity": "sha512-QCZBcPiqgEZo34v+R6Gf97N6KVqmm1432rucg+k0Fp2egejYsRho7i39N8mUbNUk/SPmyp3XtI7BqgS+/V8gJQ==",
             "requires": {
-                "@azure/msal-common": "^7.1.0"
-            }
-        },
-        "@azure/msal-common": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.1.0.tgz",
-            "integrity": "sha512-WyfqE5mY/rggjqvq0Q5DxLnA33KSb0vfsUjxa95rycFknI03L5GPYI4HTU9D+g0PL5TtsQGnV3xzAGq9BFCVJQ=="
-        },
-        "@azure/msal-node": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.11.0.tgz",
-            "integrity": "sha512-KW/XEexfCrPzdYbjY7NVmhq9okZT3Jvck55CGXpz9W5asxeq3EtrP45p+ZXtQVEfko0YJdolpCNqWUyXvanWZg==",
-            "requires": {
-                "@azure/msal-common": "^7.1.0",
-                "jsonwebtoken": "^8.5.1",
-                "uuid": "^8.3.0"
+                "@azure/ms-rest-js": "^1.8.1",
+                "tslib": "^1.9.2"
             },
             "dependencies": {
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@azure/ms-rest-js": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.11.2.tgz",
+            "integrity": "sha512-2AyQ1IKmLGKW7DU3/x3TsTBzZLcbC9YRI+yuDPuXAQrv3zar340K9wsxU413kHFIDjkWNCo9T0w5VtwcyWxhbQ==",
+            "requires": {
+                "@azure/core-auth": "^1.1.4",
+                "axios": "^0.21.1",
+                "form-data": "^2.3.2",
+                "tough-cookie": "^2.4.3",
+                "tslib": "^1.9.2",
+                "tunnel": "0.0.6",
+                "uuid": "^3.2.1",
+                "xml2js": "^0.4.19"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -6675,6 +6083,13 @@
                 "@azure/logger": "^1.0.0",
                 "events": "^3.0.0",
                 "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                }
             }
         },
         "@babel/code-frame": {
@@ -6702,275 +6117,6 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
             "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
             "dev": true
-        },
-        "@microsoft/1ds-core-js": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.4.tgz",
-            "integrity": "sha512-ZkbCb63JF7hN+YQ8e/4nRe6vAIBMpoF8PQNiYiXSzYtdhXZ/pM3jB9/7g0O5LR4h/2IU1amAq0kpBgPbd6NWqg==",
-            "requires": {
-                "@microsoft/applicationinsights-core-js": "2.8.5",
-                "@microsoft/applicationinsights-shims": "^2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            }
-        },
-        "@microsoft/1ds-post-js": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.4.tgz",
-            "integrity": "sha512-SblhGNkd8C6kzewq+Gc/ViN2oYp1/TJFw0Y4rOfHXCr6siznInBggm5ehqZd/QPXh/7MYqCx4Gpw9Rra18fO0g==",
-            "requires": {
-                "@microsoft/1ds-core-js": "3.2.4",
-                "@microsoft/applicationinsights-shims": "^2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            }
-        },
-        "@microsoft/applicationinsights-core-js": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.5.tgz",
-            "integrity": "sha512-7/EgK6r8GiDVluo84skCMNthgnPa6P7TXiJqHBJbuCf11N4YqkZoGjKs+Fo7h6XIPuYMUHVMNLpBObI7oS7HsQ==",
-            "requires": {
-                "@microsoft/applicationinsights-shims": "2.0.1",
-                "@microsoft/dynamicproto-js": "^1.1.6"
-            }
-        },
-        "@microsoft/applicationinsights-shims": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-            "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-        },
-        "@microsoft/dynamicproto-js": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
-            "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
-        },
-        "@microsoft/vscode-azext-azureutils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.3.1.tgz",
-            "integrity": "sha512-kR8ven3vtedOhHLySgowma5yWpV3GhWyrPmMS4Evb64ocShsRYBmw8qq91geoX6S33yzsaZULld8en1W7vdYWg==",
-            "requires": {
-                "@azure/arm-resources": "^5.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-resources-subscriptions": "^1.0.0",
-                "@azure/arm-storage": "^17.0.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
-                "@microsoft/vscode-azext-utils": "^0.3.0",
-                "semver": "^7.3.7",
-                "uuid": "^8.3.2",
-                "vscode-nls": "^5.0.1"
-            },
-            "dependencies": {
-                "@azure/arm-resources": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
-                    "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
-                    "requires": {
-                        "@azure/abort-controller": "^1.0.0",
-                        "@azure/core-auth": "^1.3.0",
-                        "@azure/core-client": "^1.5.0",
-                        "@azure/core-lro": "^2.2.0",
-                        "@azure/core-paging": "^1.2.0",
-                        "@azure/core-rest-pipeline": "^1.8.0",
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "@azure/arm-resources-subscriptions": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
-                    "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
-                    "requires": {
-                        "@azure/core-auth": "^1.1.4",
-                        "@azure/ms-rest-azure-js": "^2.1.0",
-                        "@azure/ms-rest-js": "^2.2.0",
-                        "tslib": "^1.10.0"
-                    },
-                    "dependencies": {
-                        "tslib": {
-                            "version": "1.14.1",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                        }
-                    }
-                },
-                "@azure/arm-storage": {
-                    "version": "17.2.1",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
-                    "integrity": "sha512-J2jmTPv8ZraSHDTz9l2Bx8gNL3ktfDDWo2mxWfzarn64O9Fjhb+l85YWyubGy2xUdeGuZPKzvQLltGv8bSu8eQ==",
-                    "requires": {
-                        "@azure/abort-controller": "^1.0.0",
-                        "@azure/core-auth": "^1.3.0",
-                        "@azure/core-client": "^1.5.0",
-                        "@azure/core-lro": "^2.2.0",
-                        "@azure/core-paging": "^1.2.0",
-                        "@azure/core-rest-pipeline": "^1.8.0",
-                        "tslib": "^2.2.0"
-                    }
-                },
-                "@azure/ms-rest-azure-js": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
-                    "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
-                    "requires": {
-                        "@azure/core-auth": "^1.1.4",
-                        "@azure/ms-rest-js": "^2.2.0",
-                        "tslib": "^1.10.0"
-                    },
-                    "dependencies": {
-                        "tslib": {
-                            "version": "1.14.1",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                        }
-                    }
-                },
-                "@azure/ms-rest-js": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz",
-                    "integrity": "sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==",
-                    "requires": {
-                        "@azure/core-auth": "^1.1.4",
-                        "abort-controller": "^3.0.0",
-                        "form-data": "^2.5.0",
-                        "node-fetch": "^2.6.7",
-                        "tough-cookie": "^3.0.1",
-                        "tslib": "^1.10.0",
-                        "tunnel": "0.0.6",
-                        "uuid": "^8.3.2",
-                        "xml2js": "^0.4.19"
-                    },
-                    "dependencies": {
-                        "tslib": {
-                            "version": "1.14.1",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                        }
-                    }
-                },
-                "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-                    "requires": {
-                        "ip-regex": "^2.1.0",
-                        "psl": "^1.1.28",
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-                },
-                "vscode-nls": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-                    "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
-                }
-            }
-        },
-        "@microsoft/vscode-azext-utils": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.8.tgz",
-            "integrity": "sha512-ilT/Kb7ql0wgfST/7mVhHRvzWo+FftcK8KraCTwcT5XRZPaYylhlmxa5XjL4ub2j8ZZLlBu+eC8qUuOlLJ52Tg==",
-            "requires": {
-                "@vscode/extension-telemetry": "^0.6.2",
-                "dayjs": "^1.11.2",
-                "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^8.2.0",
-                "open": "^8.0.4",
-                "semver": "^7.3.7",
-                "vscode-nls": "^5.0.1",
-                "vscode-tas-client": "^0.1.47"
-            },
-            "dependencies": {
-                "dom-serializer": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-                    "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-                    "requires": {
-                        "domelementtype": "^2.0.1",
-                        "domhandler": "^4.2.0",
-                        "entities": "^2.0.0"
-                    }
-                },
-                "domelementtype": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-                    "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-                },
-                "domhandler": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-                    "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-                    "requires": {
-                        "domelementtype": "^2.2.0"
-                    }
-                },
-                "domutils": {
-                    "version": "2.8.0",
-                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-                    "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-                    "requires": {
-                        "dom-serializer": "^1.0.1",
-                        "domelementtype": "^2.2.0",
-                        "domhandler": "^4.2.0"
-                    }
-                },
-                "entities": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-                    "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-                },
-                "escape-string-regexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                },
-                "html-to-text": {
-                    "version": "8.2.0",
-                    "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.0.tgz",
-                    "integrity": "sha512-CLXExYn1b++Lgri+ZyVvbUEFwzkLZppjjZOwB7X1qv2jIi8MrMEvxWX5KQ7zATAzTvcqgmtO00M2kCRMtEdOKQ==",
-                    "requires": {
-                        "@selderee/plugin-htmlparser2": "^0.6.0",
-                        "deepmerge": "^4.2.2",
-                        "he": "^1.2.0",
-                        "htmlparser2": "^6.1.0",
-                        "minimist": "^1.2.6",
-                        "selderee": "^0.6.0"
-                    }
-                },
-                "htmlparser2": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-                    "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-                    "requires": {
-                        "domelementtype": "^2.0.1",
-                        "domhandler": "^4.0.0",
-                        "domutils": "^2.5.2",
-                        "entities": "^2.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "vscode-nls": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
-                    "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
-                }
-            }
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
@@ -7006,30 +6152,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.2.tgz",
             "integrity": "sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww=="
-        },
-        "@selderee/plugin-htmlparser2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-            "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
-            "requires": {
-                "domhandler": "^4.2.0",
-                "selderee": "^0.6.0"
-            },
-            "dependencies": {
-                "domelementtype": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-                    "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-                },
-                "domhandler": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-                    "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-                    "requires": {
-                        "domelementtype": "^2.2.0"
-                    }
-                }
-            }
         },
         "@sinonjs/commons": {
             "version": "1.8.3",
@@ -7150,6 +6272,14 @@
                 "form-data": "^3.0.0"
             },
             "dependencies": {
+                "combined-stream": {
+                    "version": "1.0.8",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+                    "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
                 "form-data": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -7202,15 +6332,6 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
-        },
-        "@vscode/extension-telemetry": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-            "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
-            "requires": {
-                "@microsoft/1ds-core-js": "^3.2.3",
-                "@microsoft/1ds-post-js": "^3.2.3"
-            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -7600,6 +6721,14 @@
                 "array-filter": "^1.0.0"
             }
         },
+        "axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "requires": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -7706,11 +6835,6 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-        },
-        "buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -7873,9 +6997,9 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -7945,9 +7069,9 @@
             }
         },
         "dayjs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-            "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+            "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
         },
         "debug": {
             "version": "4.3.3",
@@ -7971,16 +7095,6 @@
             "requires": {
                 "type-detect": "^4.0.0"
             }
-        },
-        "deepmerge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-        },
-        "define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
         },
         "define-properties": {
             "version": "1.1.3",
@@ -8076,10 +7190,48 @@
             "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
             "dev": true
         },
-        "discontinuous-range": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+        "dom-serializer": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+                    "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+                },
+                "entities": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+                    "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
         },
         "duplexer2": {
             "version": "0.1.4",
@@ -8111,14 +7263,6 @@
                         "safe-buffer": "~5.1.0"
                     }
                 }
-            }
-        },
-        "ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "requires": {
-                "safe-buffer": "^5.0.1"
             }
         },
         "electron-to-chromium": {
@@ -8171,6 +7315,11 @@
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "envinfo": {
             "version": "7.7.4",
@@ -8450,9 +7599,9 @@
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
         "form-data": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -8463,6 +7612,16 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -8600,6 +7759,30 @@
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
         },
+        "html-to-text": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
+            "integrity": "sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==",
+            "requires": {
+                "he": "^1.2.0",
+                "htmlparser2": "^3.10.1",
+                "lodash": "^4.17.11",
+                "minimist": "^1.2.0"
+            }
+        },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            }
+        },
         "http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -8694,11 +7877,6 @@
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
         },
-        "is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8792,6 +7970,11 @@
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -8868,42 +8051,12 @@
                 "minimist": "^1.2.5"
             }
         },
-        "jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^5.6.0"
-            },
-            "dependencies": {
-                "jwa": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-                    "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-                    "requires": {
-                        "buffer-equal-constant-time": "1.0.1",
-                        "ecdsa-sig-formatter": "1.0.11",
-                        "safe-buffer": "^5.0.1"
-                    }
-                },
-                "jws": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-                    "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-                    "requires": {
-                        "jwa": "^1.4.1",
-                        "safe-buffer": "^5.0.1"
-                    }
-                }
+                "graceful-fs": "^4.1.6"
             }
         },
         "just-extend": {
@@ -8911,25 +8064,6 @@
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
             "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
             "dev": true
-        },
-        "jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "requires": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
         },
         "kind-of": {
             "version": "6.0.3",
@@ -8999,6 +8133,11 @@
                 "p-locate": "^4.1.0"
             }
         },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9020,40 +8159,10 @@
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
-        "lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-        },
-        "lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-        },
-        "lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-        },
-        "lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-        },
         "lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
-        },
-        "lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
         },
         "lodash.union": {
             "version": "4.6.0",
@@ -9125,6 +8234,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -9361,11 +8471,6 @@
                 }
             }
         },
-        "moo": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-            "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
-        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9376,17 +8481,6 @@
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
             "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true
-        },
-        "nearley": {
-            "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-            "requires": {
-                "commander": "^2.19.0",
-                "moo": "^0.5.0",
-                "railroad-diagrams": "^1.0.0",
-                "randexp": "0.4.6"
-            }
         },
         "neo-async": {
             "version": "2.6.1",
@@ -9487,24 +8581,12 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+        "opn": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+            "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
             "requires": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "dependencies": {
-                "is-wsl": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-                    "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-                    "requires": {
-                        "is-docker": "^2.0.0"
-                    }
-                }
+                "is-wsl": "^1.1.0"
             }
         },
         "p-limit": {
@@ -9530,15 +8612,6 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
-        },
-        "parseley": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-            "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
-            "requires": {
-                "moo": "^0.5.1",
-                "nearley": "^2.20.1"
-            }
         },
         "path-exists": {
             "version": "4.0.0",
@@ -9641,20 +8714,6 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
             "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
         },
-        "railroad-diagrams": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-        },
-        "randexp": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-            "requires": {
-                "discontinuous-range": "1.0.0",
-                "ret": "~0.1.10"
-            }
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9734,11 +8793,6 @@
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
         },
-        "ret": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-        },
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9796,14 +8850,6 @@
                     "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
                     "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
                 }
-            }
-        },
-        "selderee": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-            "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
-            "requires": {
-                "parseley": "^0.7.0"
             }
         },
         "semver": {
@@ -9930,11 +8976,6 @@
             "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
             "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
         },
-        "stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-        },
         "string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10027,21 +9068,11 @@
             }
         },
         "tas-client": {
-            "version": "0.1.45",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.45.tgz",
-            "integrity": "sha512-IG9UmCpDbDPK23UByQ27rLybkRZYEx2eC9EkieXdwPKKjZPD2zPwfQmyGnZrZet4FUt3yj0ytkwz+liR9Nz/nA==",
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.16.tgz",
+            "integrity": "sha512-ZMGg7dGXiYVJHYusDpUb/Ilg+iPNYZdKJSIA2ADn0f2RovHWM0TpNVe2YHPEc0hdFMsUwWKS5pCRzLnlUqcqGg==",
             "requires": {
-                "axios": "^0.26.1"
-            },
-            "dependencies": {
-                "axios": {
-                    "version": "0.26.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.8"
-                    }
-                }
+                "axios": "^0.21.1"
             }
         },
         "terser": {
@@ -10114,6 +9145,22 @@
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "requires": {
                 "is-number": "^7.0.0"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
             }
         },
         "tr46": {
@@ -10217,9 +9264,9 @@
             }
         },
         "tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
         "tslint": {
             "version": "5.20.1",
@@ -10278,9 +9325,9 @@
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
         },
         "typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+            "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
             "dev": true
         },
         "uglify-js": {
@@ -10380,6 +9427,110 @@
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
+        "vscode-azureextensionui": {
+            "version": "0.39.4",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.4.tgz",
+            "integrity": "sha512-ht7ZSzMXSKHDSwGA3nWtisqrNom3kg5HaeZfRp0rDdx47HNlldxtsKieLyWy7E4AeS6+BFX4px9GRXcGhnGoQQ==",
+            "requires": {
+                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-storage": "^15.0.0",
+                "@azure/arm-subscriptions": "^2.0.0",
+                "@azure/ms-rest-azure-env": "^2.0.0",
+                "@azure/ms-rest-js": "^2.2.1",
+                "dayjs": "^1.9.3",
+                "escape-string-regexp": "^2.0.0",
+                "fs-extra": "^8.0.0",
+                "html-to-text": "^5.1.1",
+                "opn": "^6.0.0",
+                "semver": "^5.7.1",
+                "vscode-extension-telemetry": "^0.1.5",
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.17"
+            },
+            "dependencies": {
+                "@azure/arm-subscriptions": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+                    "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+                    "requires": {
+                        "@azure/ms-rest-azure-js": "^2.0.1",
+                        "@azure/ms-rest-js": "^2.0.4",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "@azure/ms-rest-azure-js": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
+                    "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
+                    "requires": {
+                        "@azure/core-auth": "^1.1.4",
+                        "@azure/ms-rest-js": "^2.2.0",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "@azure/ms-rest-js": {
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.3.tgz",
+                    "integrity": "sha512-sXOhOu/37Tr8428f32Jwuwga975Xw64pYg1UeUwOBMhkNgtn5vUuNRa3fhmem+I6f8EKoi6hOsYDFlaHeZ52jA==",
+                    "requires": {
+                        "@azure/core-auth": "^1.1.4",
+                        "@types/node-fetch": "^2.3.7",
+                        "@types/tunnel": "0.0.1",
+                        "abort-controller": "^3.0.0",
+                        "form-data": "^2.5.0",
+                        "node-fetch": "^2.6.0",
+                        "tough-cookie": "^3.0.1",
+                        "tslib": "^1.10.0",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.3.2",
+                        "xml2js": "^0.4.19"
+                    }
+                },
+                "@types/tunnel": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+                    "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+                },
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "tough-cookie": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+                    "requires": {
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
         "vscode-extension-telemetry": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz",
@@ -10393,12 +9544,17 @@
             "resolved": "https://registry.npmjs.org/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.3.0.tgz",
             "integrity": "sha512-5+4OdwrRinoTsE8i6s8pPY+BbGh5U7DNAA/3pn5wlOhvQpivaBMdi89bRKfdAffPjt/bvHodje4BFm5GSNjFxQ=="
         },
+        "vscode-nls": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+            "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
+        },
         "vscode-tas-client": {
-            "version": "0.1.47",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.47.tgz",
-            "integrity": "sha512-SlEPDi+0gwxor4ANzBtXwqROPQdQkClHeVJgnkvdDF5Xnl407htCsabTPAq4Di8muObORtLchqQS/k1ocaGDEg==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.17.tgz",
+            "integrity": "sha512-5uqMeg7sjsu1/QkmuRtBOXtZnnrCXAMEihbOSxan3bk2NdA/nZvhfhfLh8gd9FlBBL56QH69I8Zn25B2yGPRng==",
             "requires": {
-                "tas-client": "0.1.45"
+                "tas-client": "0.1.16"
             }
         },
         "vscode-test": {
@@ -10633,7 +9789,8 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "yargs": {
             "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "onCommand:aks.showInPortal",
         "onCommand:aks.clusterProperties",
         "onCommand:aks.createClusterNavToAzurePortal"
+
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -270,22 +271,17 @@
         "sinon": "^12.0.1",
         "ts-loader": "^8.0.18",
         "tslint": "^5.20.1",
-        "typescript": "^3.9.10",
+        "typescript": "^3.7.2",
         "webpack": "^5.25.1",
         "webpack-cli": "^4.5.0"
     },
     "dependencies": {
-        "@azure/arm-containerservice": "^16.1.0",
+        "@azure/arm-containerservice": "^7.0.1",
         "@azure/arm-monitor": "^6.0.0",
         "@azure/arm-resources": "^3.0.0",
-        "@azure/arm-resources-subscriptions": "^2.0.1",
         "@azure/arm-storage": "^15.2.0",
-        "@azure/arm-subscriptions": "^5.0.1",
-        "@azure/identity": "^2.1.0",
-        "@azure/ms-rest-azure-env": "^2.0.0",
+        "@azure/arm-subscriptions": "^3.0.0",
         "@azure/storage-blob": "^12.7.0",
-        "@microsoft/vscode-azext-azureutils": "^0.3.1",
-        "@microsoft/vscode-azext-utils": "^0.3.8",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/chai": "^4.2.21",
         "@types/sinon": "^10.0.6",
@@ -300,6 +296,7 @@
         "tslib": "^2.1.0",
         "underscore": "^1.13.1",
         "util": "^0.12.3",
+        "vscode-azureextensionui": "^0.39.4",
         "vscode-extension-telemetry": "^0.1.6",
         "vscode-kubernetes-tools-api": "^1.0.0",
         "vscode-test": "^1.5.2"

--- a/resources/webviews/aksclusterproperties/clusterproperties.html
+++ b/resources/webviews/aksclusterproperties/clusterproperties.html
@@ -7,30 +7,6 @@
     <title>AKS Cluster Properties</title>
     <!-- Link to the css file -->
     <link rel="stylesheet" href="{{cssuri}}">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <script src="https://use.fontawesome.com/7dddd54b5c.js"></script>
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"
-        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-
-    <script>
-        $(document).ready(function () {
-            // https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-a-webview-to-an-extension
-            const vscode = acquireVsCodeApi();
-
-            $('#Startcluster').click(function () {
-                $(".spinner").show();
-                $(this).hide();
-                vscode.postMessage({ command: "startCluster" });
-            });
-
-            $('#Stopcluster').click(function () {
-                $(".spinner").show();
-                $(this).hide();
-                vscode.postMessage({ command: "stopCluster" });
-            });
-        });
-
-    </script>
 </head>
 
 <body>
@@ -62,24 +38,6 @@
                                 <tr>
                                     <td>Kubernetes Version</td>
                                     <td>{{clusterData.kubernetesVersion}}</td>
-                                </tr>
-                                <tr>
-                                    <td>Power State</td>
-                                    <td>{{clusterData.powerState.code}}
-                                        <span style="padding-left: 50px;"></span>
-                                        <div class="tooltip">  <i class="fa fa-info-circle" style="font-size:20px;color:blue"></i>
-                                            <span class="tooltiptext">It is important that you don't repeatedly start/stop your cluster. Repeatedly starting/stopping your cluster may result in errors. Once your cluster is stopped, you should wait 15-30 minutes before starting it up again.
-                                                <a href="https://docs.microsoft.com/en-au/azure/aks/start-stop-cluster?tabs=azure-cli#start-an-aks-cluster">Learn more</a>
-                                            </span>
-                                        </div>
-                                        {{#if (showStartStopButton clusterState)}}
-                                        <button class="btn" id="{{startStopClusterValue clusterState}}cluster">
-                                            {{startStopClusterValue clusterState}} Cluster
-                                        </button>
-                                        {{else}}
-                                            Cluster is in {{clusterState}} state
-                                        {{/if}}
-                                    </td>
                                 </tr>
                             </tbody>
                         </table>

--- a/resources/webviews/common/detector.css
+++ b/resources/webviews/common/detector.css
@@ -155,36 +155,3 @@ body {
     text-align:left;
     height:50px;
 }
-
-.tooltip {
-    position: relative;
-    display: inline-block;
-    border-bottom: 1px dotted black;
-  }
-  
-  .tooltip .tooltiptext {
-    visibility: hidden;
-    width: 220px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-  
-    /* Position the tooltip */
-    position: absolute;
-    z-index: 1;
-  }
-  
-  .tooltip:hover .tooltiptext {
-    visibility: visible;
-  }
-
-.btn {
-    background-color: DodgerBlue;
-    border: none;
-    color: white;
-    padding: 10px 12px;
-    font-size: 14px;
-    cursor: pointer;
-}

--- a/src/azure-api-utils.ts
+++ b/src/azure-api-utils.ts
@@ -1,3 +1,5 @@
+import { ISubscriptionContext } from "vscode-azureextensionui";
+import { SubscriptionModels } from '@azure/arm-subscriptions';
 
 export interface PartialList<T> extends Array<T> {
     nextLink?: string;
@@ -21,4 +23,12 @@ export function parseResource(armId: string): { resourceGroupName: string | unde
 function bitAfter(bits: string[], after: string): string | undefined {
     const afterIndex = bits.indexOf(after);
     return bits[afterIndex + 1];
+}
+
+export function toSubscription(context: ISubscriptionContext): SubscriptionModels.Subscription {
+    return {
+        id: context.subscriptionPath,
+        subscriptionId: context.subscriptionId,
+        displayName: context.subscriptionDisplayName
+    };
 }

--- a/src/commands/aksBestPractices/aksBestPractices.ts
+++ b/src/commands/aksBestPractices/aksBestPractices.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { AppLensARMResponse, getDetectorInfo, getDetectorListData, getPortalUrl } from '../utils/detectors';
@@ -48,7 +48,7 @@ async function loadDetector(
           return;
         }
 
-        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
         webview.html = getWebviewContent(detectorInfo.result, detectorMap.result, extensionPath);
       }
     );

--- a/src/commands/aksCRUDDiagnostics/aksCRUDDiagnostics.ts
+++ b/src/commands/aksCRUDDiagnostics/aksCRUDDiagnostics.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { AppLensARMResponse, getDetectorInfo, getDetectorListData, getPortalUrl } from '../utils/detectors';
@@ -48,7 +48,7 @@ async function loadDetector(
           return;
         }
 
-        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
         webview.html = getWebviewContent(detectorInfo.result, detectorMap.result, extensionPath);
       }
     );

--- a/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
+++ b/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterSubscriptionItem } from '../utils/clusters';
 import { failed } from '../utils/errorable';
 

--- a/src/commands/aksIdentitySecurity/aksIdentitySecurity.ts
+++ b/src/commands/aksIdentitySecurity/aksIdentitySecurity.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { AppLensARMResponse, getDetectorInfo, getDetectorListData, getPortalUrl } from '../utils/detectors';
@@ -48,7 +48,7 @@ async function loadDetector(
           return;
         }
 
-        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
         webview.html = getWebviewContent(detectorInfo.result, detectorMap.result, extensionPath);
       }
     );

--- a/src/commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance.ts
+++ b/src/commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { AppLensARMResponse, getDetectorInfo, getDetectorListData, getPortalUrl } from '../utils/detectors';
@@ -48,7 +48,7 @@ async function loadDetector(
           return;
         }
 
-        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
         webview.html = getWebviewContent(detectorInfo.result, detectorMap.result, extensionPath);
       }
     );

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath }  from '../utils/host';
 import { failed } from '../utils/errorable';

--- a/src/commands/aksNodeHealth/aksNodeHealth.ts
+++ b/src/commands/aksNodeHealth/aksNodeHealth.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { AppLensARMResponse, getDetectorInfo, getDetectorListData, getPortalUrl } from '../utils/detectors';
@@ -48,7 +48,7 @@ async function loadDetector(
           return;
         }
 
-        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+        const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
         webview.html = getWebviewContent(detectorInfo.result, detectorMap.result, extensionPath);
       }
     );

--- a/src/commands/aksStarterWorkflow/configureStarterWorkflow.ts
+++ b/src/commands/aksStarterWorkflow/configureStarterWorkflow.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { IActionContext } from 'vscode-azureextensionui';
 import { getAksClusterTreeItem } from '../utils/clusters';
 import { getWorkflowYaml, substituteClusterInWorkflowYaml } from '../utils/configureWorkflowHelper';
 import { failed } from '../utils/errorable';

--- a/src/commands/azureServiceOperators/installAzureServiceOperator.ts
+++ b/src/commands/azureServiceOperators/installAzureServiceOperator.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { IActionContext } from 'vscode-azureextensionui';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
 import { startInstallation } from './helpers/azureservicehelper';
 import {
@@ -57,7 +57,7 @@ export async function install(
     // Get user input upfront.
     // Get Service Principal AppId and Password from user.
     // Then start the installation process.
-    const webview = createWebView('Azure Service Operator', `Azure service Operator: ${installationResponse.clusterName}`).webview;
+    const webview = createWebView('Azure Service Operator', `Azure service Operator: ${installationResponse.clusterName}`);
 
     const extensionPath = getExtensionPath();
     if (failed(extensionPath)) {
@@ -72,7 +72,7 @@ export async function install(
     webview.onDidReceiveMessage(
         async (message) => {
             if (message.appid && message.password) {
-                const cloudName = convertAzureCloudEnv(aksCluster.subscription.environment.name);
+                const cloudName = convertAzureCloudEnv(aksCluster.root.environment.name);
 
                 if (!cloudName) {
                     vscode.window.showWarningMessage(`Cloud environment name ${cloudName} is not supported.`);
@@ -80,7 +80,7 @@ export async function install(
                 }
 
                 const operatorSettingsInfo = {
-                    tenantId: aksCluster.subscription.tenantId,
+                    tenantId: aksCluster.root.tenantId,
                     subId: aksCluster.subscription.subscriptionId!,
                     appId: message.appid,
                     clientSecret: message.password,

--- a/src/commands/networkAndConnectivityDiagnostics/networkAndConnectivityDiagnostics.ts
+++ b/src/commands/networkAndConnectivityDiagnostics/networkAndConnectivityDiagnostics.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 import { AppLensARMResponse, getDetectorInfo, getPortalUrl } from '../utils/detectors';
 import { convertHtmlJsonConfiguration }  from './helpers/networkconnectivityhtmlhelper';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
@@ -43,7 +43,7 @@ async function loadNetworkConnectivityDetector(
         return;
       }
 
-      const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`).webview;
+      const webview = createWebView('AKS Diagnostics', `AKS diagnostics view for: ${clustername}`);
       webview.html = getWebviewContent(detectorInfo.result, extensionPath);
     }
   );

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -25,7 +25,7 @@ export async function getClusterDiagnosticSettings(
 ): Promise<amon.MonitorManagementModels.DiagnosticSettingsCategoryResourceCollection | undefined> {
     try {
         // Get daignostic setting via diagnostic monitor
-        const diagnosticMonitor = new amon.MonitorManagementClient(cluster.subscription.credentials, cluster.subscription.subscriptionId);
+        const diagnosticMonitor = new amon.MonitorManagementClient(cluster.root.credentials, cluster.root.subscriptionId);
         const diagnosticSettings = await diagnosticMonitor.diagnosticSettings.list(cluster.id!);
 
         return diagnosticSettings;
@@ -95,7 +95,7 @@ export async function getStorageInfo(
         }
 
         // Get keys from storage client.
-        const storageClient = new ast.StorageManagementClient(cluster.subscription.credentials, cluster.subscription.subscriptionId);
+        const storageClient = new ast.StorageManagementClient(cluster.root.credentials, cluster.root.subscriptionId);
         const storageAccKeyList = await storageClient.storageAccounts.listKeys(resourceGroupName, accountName);
         const storageKey = storageAccKeyList.keys?.find((it) => it.keyName === "key1")?.value!;
 
@@ -231,7 +231,7 @@ export function getWebviewContent(
         downloadAndShareNodeLogsList: downloadAndShareNodeLogsList,
         noDiagnosticSettings: !hasDiagnosticSettings,
     };
-
+  
     return getRenderedContent(templateUri, data);
 }
 
@@ -262,8 +262,8 @@ async function getClusterInfo(kubectl: k8s.APIAvailable<k8s.KubectlV1>, clusterK
     const runCommandResult = await tmpfile.withOptionalTempFile<Errorable<k8s.KubectlV1.ShellResult>>(
         clusterKubeConfig,
         "YAML",
-        (kubeConfigFile) => invokeKubectlCommand(kubectl, kubeConfigFile, 'cluster-info'));
-
+        kubeConfigFile => invokeKubectlCommand(kubectl, kubeConfigFile, 'cluster-info'));
+    
     if (failed(runCommandResult)) return runCommandResult;
 
     return { succeeded: true, result: runCommandResult.result.stdout };

--- a/src/commands/periscope/periscope.ts
+++ b/src/commands/periscope/periscope.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { IActionContext } from 'vscode-azureextensionui';
 import * as tmpfile from '../utils/tempfile';
 import { getAksClusterTreeItem, getKubeconfigYaml } from '../utils/clusters';
 import { getKustomizeConfig } from '../utils/config';
@@ -128,7 +128,7 @@ async function createPeriscopeWebView(
     periscopeStorageInfo: PeriscopeStorage | undefined,
     hasDiagnosticSettings = true
 ): Promise<void | undefined> {
-    const webview = createWebView('AKS Periscope', `AKS Periscope: ${clusterName}`).webview;
+    const webview = createWebView('AKS Periscope', `AKS Periscope: ${clusterName}`);
 
     const extensionPath = getExtensionPath();
     if (failed(extensionPath)) {

--- a/src/commands/selectSubscriptions.ts
+++ b/src/commands/selectSubscriptions.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { IActionContext } from "vscode-azureextensionui";
 
 export default async function selectSubscriptions(context: IActionContext, target: any): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;

--- a/src/commands/utils/detectors.ts
+++ b/src/commands/utils/detectors.ts
@@ -49,7 +49,7 @@ export async function getDetectorInfo(
     detectorName: string
 ): Promise<Errorable<AppLensARMResponse>> {
     try {
-        const client = new ResourceManagementClient(target.subscription.credentials, target.subscription.subscriptionId, { noRetryPolicy: true });
+        const client = new ResourceManagementClient(target.root.credentials, target.root.subscriptionId, { noRetryPolicy: true });
         // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
         const resourceGroup = target.armId.split("/")[4];
         const detectorInfo = await client.resources.get(

--- a/src/commands/utils/webviews.ts
+++ b/src/commands/utils/webviews.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as htmlhandlers from "handlebars";
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ClusterStartStopState } from './clusters';
 
 //
 // Register the custom HTML handlers. Having these registered the first time the module is imported means
@@ -65,7 +64,7 @@ htmlhandlers.registerHelper("setStyleVar", (varValue) => {
         return styleString;
 });
 
-export function createWebView(viewType: string, title: string): vscode.WebviewPanel {
+export function createWebView(viewType: string, title: string): vscode.Webview {
     const panel = vscode.window.createWebviewPanel(
         viewType,
         title,
@@ -76,7 +75,7 @@ export function createWebView(viewType: string, title: string): vscode.WebviewPa
         }
     );
 
-    return panel;
+    return panel.webview;
 }
 
 export function getResourceUri(vscodeExtensionPath: string, folder: string, filename: string): vscode.Uri {
@@ -90,23 +89,4 @@ export function getRenderedContent(templateUri: vscode.Uri, data: object): strin
 
     const template = htmlhandlers.compile(templateContent);
     return template(data);
-}
-
-htmlhandlers.registerHelper('showStartStopButton', (value: any): boolean => {
-    if (value === ClusterStartStopState.Starting || value === ClusterStartStopState.Stopping ) {
-        return false;
-    }
-
-    return true;
-});
-
-htmlhandlers.registerHelper('startStopClusterValue', (value: any): string => {
-    if (value === ClusterStartStopState.Stopped) {
-        return "Start";
-    }
-    return "Stop";
-});
-
-export function delay(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import AksClusterTreeItem from './tree/aksClusterTreeItem';
 import AzureAccountTreeItem from './tree/azureAccountTreeItem';
-import { createAzExtOutputChannel, AzExtTreeDataProvider, registerCommand, IActionContext } from '@microsoft/vscode-azext-utils';
+import { createAzExtOutputChannel, registerUIExtensionVariables, AzExtTreeDataProvider, AzureUserInput, registerCommand, IActionContext } from 'vscode-azureextensionui';
 import selectSubscriptions from './commands/selectSubscriptions';
 import networkAndConnectivityDiagnostics from './commands/networkAndConnectivityDiagnostics/networkAndConnectivityDiagnostics';
 import periscope from './commands/periscope/periscope';
@@ -21,7 +21,6 @@ import aksKnownIssuesAvailabilityPerformanceDiagnostics from './commands/aksKnow
 import aksNavToPortal from './commands/aksNavToPortal/aksNavToPortal';
 import aksClusterProperties from './commands/aksClusterProperties/aksClusterProperties';
 import aksCreateClusterNavToAzurePortal from './commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal';
-import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -34,12 +33,12 @@ export async function activate(context: vscode.ExtensionContext) {
             context,
             ignoreBundle: false,
             outputChannel: createAzExtOutputChannel('Azure Identity', ''),
-            prefix: ''
+            ui: new AzureUserInput(context.globalState)
         };
 
         context.subscriptions.push(uiExtensionVariables.outputChannel);
 
-        registerAzureUtilsExtensionVariables(uiExtensionVariables);
+        registerUIExtensionVariables(uiExtensionVariables);
 
         registerCommandWithTelemetry('aks.selectSubscriptions', selectSubscriptions);
         registerCommandWithTelemetry('aks.networkAndConnectivityDiagnostics', networkAndConnectivityDiagnostics);

--- a/src/tree/aksClusterTreeItem.ts
+++ b/src/tree/aksClusterTreeItem.ts
@@ -1,9 +1,9 @@
-import { AzExtParentTreeItem, AzExtTreeItem , ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { AzExtParentTreeItem, AzureTreeItem, ISubscriptionContext } from "vscode-azureextensionui";
 import { CloudExplorerV1 } from "vscode-kubernetes-tools-api";
-import { Subscription } from '@azure/arm-subscriptions';
+import { SubscriptionModels } from '@azure/arm-subscriptions';
+import { toSubscription } from "../azure-api-utils";
 import { Resource } from "@azure/arm-resources/esm/models";
 import { assetUri } from "../assets";
-import { parseResource } from "../azure-api-utils";
 
 // The de facto API of tree nodes that represent individual AKS clusters.
 // Tree items should implement this interface to maintain backward compatibility with previous versions of the extension.
@@ -12,11 +12,10 @@ export interface AksClusterTreeNode {
     readonly armId: string;
     readonly name: string;
     readonly session: ISubscriptionContext;
-    readonly subscription: Subscription;
-    readonly resourceGroupName: string;
+    readonly subscription: SubscriptionModels.Subscription;
 }
 
-export default class AksClusterTreeItem extends AzExtTreeItem implements AksClusterTreeNode {
+export default class AksClusterTreeItem extends AzureTreeItem implements AksClusterTreeNode {
     constructor(
         parent: AzExtParentTreeItem,
         private readonly resource: Resource) {
@@ -45,12 +44,11 @@ export default class AksClusterTreeItem extends AzExtTreeItem implements AksClus
     }
 
     public get session(): ISubscriptionContext {
-        return this.session;
+        return this.root;
     }
 
-    public get resourceGroupName(): string {
-        // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
-        return parseResource(this.armId).resourceGroupName!;
+    public get subscription(): SubscriptionModels.Subscription {
+        return toSubscription(this.root);
     }
 
     public readonly nodeType = 'cluster';

--- a/src/tree/azureAccountTreeItem.ts
+++ b/src/tree/azureAccountTreeItem.ts
@@ -1,5 +1,4 @@
-import { ISubscriptionContext } from '@microsoft/vscode-azext-utils';
-import { AzureAccountTreeItemBase, SubscriptionTreeItemBase } from '@microsoft/vscode-azext-azureutils';
+import { AzureAccountTreeItemBase, ISubscriptionContext, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import SubscriptionTreeItem from './subscriptionTreeItem';
 import * as k8s from 'vscode-kubernetes-tools-api';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,8 @@
         "strict": true, /* enable all strict type-checking options */
         "noUnusedLocals": true, /* Report errors on unused locals. */
         "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+        "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */
         // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-        "skipLibCheck": true,
     },
     "exclude": [
         "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,5 @@
 {
 	"rules": {
-		"skipLibCheck": true,
 		"only-arrow-functions": [
 			true,
 			"allow-declarations",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,7 @@ const config = {
     'spawn-sync': 'commonjs spawn-sync',
     'utf-8-validate': 'commonjs utf-8-validate',
     'applicationinsights-native-metrics': 'applicationinsights-native-metrics',
-    '@opentelemetry/tracing': '@opentelemetry/tracing',
-    '@microsoft/vscode-azext-utils': '@microsoft/vscode-azext-utils'
+    '@opentelemetry/tracing': '@opentelemetry/tracing'
   },
   plugins: [
       new webpack.IgnorePlugin(/^electron$/),
@@ -37,8 +36,8 @@ const config = {
           onEnd: {
               copy: [
                   {
-                      source: path.join(__dirname, 'node_modules', '@microsoft', 'vscode-azext-azureutils', 'resources', '**'),
-                      destination: path.join(__dirname, 'dist', 'node_modules', '@microsoft', 'vscode-azext-azureutils', 'resources')
+                      source: path.join(__dirname, 'node_modules', 'vscode-azureextensionui', 'resources', '**'),
+                      destination: path.join(__dirname, 'dist', 'node_modules', 'vscode-azureextensionui', 'resources')
                   }
               ]
           }


### PR DESCRIPTION
This needs revert because for some reason, the update of the `extension` package leads to bespoke VSIX broken, and needs investigation.

In debug mode it will work, and the hunch is that there is a tsconfig break which is causing it when the extension ui package is updated to latest.

https://github.com/Azure/vscode-aks-tools/pull/144

Thanks, cc: @peterbom 