### PR TITLE
Update latest Periscope version and support optional Windows features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "handlebars": "^4.7.7",
                 "js-yaml": "^3.14.0",
                 "neverthrow": "^4.3.0",
+                "semver": "^7.3.7",
                 "sinon": "^12.0.1",
                 "tmp": "^0.2.1",
                 "tslib": "^2.1.0",
@@ -43,6 +44,7 @@
                 "@types/js-yaml": "^3.12.1",
                 "@types/mocha": "^2.2.48",
                 "@types/node": "^16.11.7",
+                "@types/semver": "^7.3.11",
                 "@types/underscore": "^1.11.3",
                 "@types/vscode": "^1.52.0",
                 "chai": "^4.3.4",
@@ -951,20 +953,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-azureutils/node_modules/tough-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -1108,20 +1096,6 @@
                 "domhandler": "^4.0.0",
                 "domutils": "^2.5.2",
                 "entities": "^2.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/vscode-nls": {
@@ -1348,6 +1322,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.11.tgz",
+            "integrity": "sha512-R9HhjC4aKx3jL0FLwU7x6qMTysTvLh7jesRslXmxgCOXZwyh5dsnmrPQQToMyess8D4U+8G9x9mBFZoC/1o/Tw==",
+            "dev": true
         },
         "node_modules/@types/sinon": {
             "version": "10.0.6",
@@ -1844,6 +1824,14 @@
                 "node": "<=0.11.8 || >0.11.10"
             }
         },
+        "node_modules/async-listener/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2232,6 +2220,14 @@
                 "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
             }
         },
+        "node_modules/cls-hooked/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2526,6 +2522,14 @@
             "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
             "peerDependencies": {
                 "diagnostic-channel": "*"
+            }
+        },
+        "node_modules/diagnostic-channel/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/diff": {
@@ -3685,6 +3689,14 @@
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/just-extend": {
@@ -4887,11 +4899,17 @@
             }
         },
         "node_modules/semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/serialize-javascript": {
@@ -5388,21 +5406,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ts-loader/node_modules/semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/ts-loader/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5457,6 +5460,15 @@
             },
             "peerDependencies": {
                 "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+            }
+        },
+        "node_modules/tslint/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/tslint/node_modules/tslib": {
@@ -6845,14 +6857,6 @@
                         }
                     }
                 },
-                "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "tough-cookie": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -6955,14 +6959,6 @@
                         "domhandler": "^4.0.0",
                         "domutils": "^2.5.2",
                         "entities": "^2.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
                     }
                 },
                 "vscode-nls": {
@@ -7161,6 +7157,12 @@
                     }
                 }
             }
+        },
+        "@types/semver": {
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.11.tgz",
+            "integrity": "sha512-R9HhjC4aKx3jL0FLwU7x6qMTysTvLh7jesRslXmxgCOXZwyh5dsnmrPQQToMyess8D4U+8G9x9mBFZoC/1o/Tw==",
+            "dev": true
         },
         "@types/sinon": {
             "version": "10.0.6",
@@ -7585,6 +7587,13 @@
             "requires": {
                 "semver": "^5.3.0",
                 "shimmer": "^1.1.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "asynckit": {
@@ -7849,6 +7858,13 @@
                 "async-hook-jl": "^1.7.6",
                 "emitter-listener": "^1.0.1",
                 "semver": "^5.4.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "color-convert": {
@@ -8062,6 +8078,13 @@
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
             "requires": {
                 "semver": "^5.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "diagnostic-channel-publishers": {
@@ -8903,6 +8926,11 @@
                         "jwa": "^1.4.1",
                         "safe-buffer": "^5.0.1"
                     }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                 }
             }
         },
@@ -9807,9 +9835,12 @@
             }
         },
         "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "serialize-javascript": {
             "version": "5.0.1",
@@ -10190,15 +10221,6 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "semver": {
-                    "version": "7.3.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10242,6 +10264,12 @@
                 "tsutils": "^2.29.0"
             },
             "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,13 +60,13 @@
                 },
                 "aks.periscope.releaseTag": {
                     "type": "string",
-                    "default": "v0.9",
+                    "default": "0.0.10",
                     "title": "Periscope repository release tag",
                     "description": "Release tag for the Kustomize templates in the Periscope repository."
                 },
                 "aks.periscope.imageVersion": {
                     "type": "string",
-                    "default": "0.0.9",
+                    "default": "0.0.10",
                     "title": "Periscope image version",
                     "description": "Docker image tag corresponding to the Periscope version."
                 }
@@ -263,6 +263,7 @@
         "@types/js-yaml": "^3.12.1",
         "@types/mocha": "^2.2.48",
         "@types/node": "^16.11.7",
+        "@types/semver": "^7.3.11",
         "@types/underscore": "^1.11.3",
         "@types/vscode": "^1.52.0",
         "chai": "^4.3.4",
@@ -295,6 +296,7 @@
         "handlebars": "^4.7.7",
         "js-yaml": "^3.14.0",
         "neverthrow": "^4.3.0",
+        "semver": "^7.3.7",
         "sinon": "^12.0.1",
         "tmp": "^0.2.1",
         "tslib": "^2.1.0",

--- a/src/commands/periscope/models/clusterFeatures.ts
+++ b/src/commands/periscope/models/clusterFeatures.ts
@@ -1,0 +1,4 @@
+export enum ClusterFeatures {
+    None = 0,
+    WindowsHpc = 1
+}

--- a/src/commands/periscope/periscope.ts
+++ b/src/commands/periscope/periscope.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as tmpfile from '../utils/tempfile';
-import { CloudType, getAksClusterTreeItem, getKubeconfigYaml } from '../utils/clusters';
+import { CloudType, getAksClusterTreeItem, getContainerClient, getKubeconfigYaml } from '../utils/clusters';
 import { getKustomizeConfig } from '../utils/config';
 import { getExtensionPath, longRunning } from '../utils/host';
 import {
@@ -100,8 +100,10 @@ async function runAKSPeriscope(
         return undefined;
     }
 
+    const containerClient = getContainerClient(cluster);
+
     // Get the features of the cluster that determine which optional kustomize components to deploy.
-    const clusterFeatures = await getClusterFeatures(kubectl, clusterKubeConfig);
+    const clusterFeatures = await getClusterFeatures(containerClient, cluster.resourceGroupName, cluster.name);
     if (failed(clusterFeatures)) {
         vscode.window.showErrorMessage(clusterFeatures.error);
         return undefined;

--- a/src/commands/utils/azurestorage.ts
+++ b/src/commands/utils/azurestorage.ts
@@ -9,7 +9,7 @@ export enum LinkDuration {
 function sasDuration(duration: LinkDuration): number {
     switch (duration) {
         case LinkDuration.StartTime: return 2 * 60 * 1000;
-        case LinkDuration.DownloadNow: return 5 * 60 * 1000;
+        case LinkDuration.DownloadNow: return 15 * 60 * 1000; // 15 minutes to allow for Windows image pulls and log export
         case LinkDuration.Shareable: return 7 * 24 * 60 * 60 * 1000;
     }
 }

--- a/src/commands/utils/text.ts
+++ b/src/commands/utils/text.ts
@@ -1,9 +1,0 @@
-import { Errorable } from "./errorable";
-
-export function asJson(text: string): Errorable<any> {
-    try {
-        return { succeeded: true, result: JSON.parse(text) };
-    } catch (e) {
-        return { succeeded: false, error: `Error parsing text: ${e}` };
-    }
-}

--- a/src/commands/utils/text.ts
+++ b/src/commands/utils/text.ts
@@ -1,0 +1,9 @@
+import { Errorable } from "./errorable";
+
+export function asJson(text: string): Errorable<any> {
+    try {
+        return { succeeded: true, result: JSON.parse(text) };
+    } catch (e) {
+        return { succeeded: false, error: `Error parsing text: ${e}` };
+    }
+}


### PR DESCRIPTION
This updates the extension to use the latest version of Periscope (0.0.10) by default.

This version of Periscope has an optional Kustomize component, which should only be deployed if the cluster supports it. For this, there is some extra checking in the Periscope helper module to determine if this component is supported. Although there is just one feature/component right now, the code is structured such that the pattern can be extended to add further components later.

The `DIAGNOSTIC_RUN_ID` configuration value is required to support the new optional Periscope component, but may in future be required by the Periscope application.