### PR TITLE
Fix error when running Periscope using a branch release tag

### DIFF
--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -134,7 +134,7 @@ export async function prepareAKSPeriscopeKustomizeOverlay(
     let components = "components:\n";
     if ((clusterFeatures & ClusterFeatures.WindowsHpc) === ClusterFeatures.WindowsHpc) {
         // The Windows HPC component is only supported in Periscope 0.0.10 and higher.
-        if (semver.gte(kustomizeConfig.releaseTag, "0.0.10")) {
+        if (semver.parse(kustomizeConfig.imageVersion) && semver.gte(kustomizeConfig.imageVersion, "0.0.10")) {
             components += `- https://github.com/${kustomizeConfig.repoOrg}/aks-periscope//deployment/components/win-hpc?ref=${kustomizeConfig.releaseTag}\n`;
         }
     }


### PR DESCRIPTION
The release tag setting for Periscope allows any GH reference (branch, commit, tag), so this may not be a valid semver value.

Some logic for determining which components to deploy checks the version of Periscope being deployed using the release tag, which results in runtime errors when this is a branch or commit.

This changes that logic to use the image version, which is more likely to be a semver value (it still might not be, so we need to try and parse it first to avoid runtime errors).