### PR TITLE
Kubectl get events feature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
             },
             {
                 "command": "aks.aksKubectlGetNodeCommands",
-                "title": "Get Node"
+                "title": "Get Nodes"
             },
             {
                 "command": "aks.aksKubectlDescribeServicesCommands",
@@ -169,7 +169,7 @@
             },
             {
                 "command": "aks.aksKubectlGetEventsCommands",
-                "title": "Get Events"
+                "title": "Get All Events"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "onCommand:aks.aksKubectlGetClusterInfoCommands",
         "onCommand:aks.aksKubectlGetAPIResourcesCommands",
         "onCommand:aks.aksKubectlGetNodeCommands",
-        "onCommand:aks.aksKubectlDescribeServicesCommands"
+        "onCommand:aks.aksKubectlDescribeServicesCommands",
+        "onCommand:aks.aksKubectlGetEventsCommands"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -165,6 +166,10 @@
             {
                 "command": "aks.aksKubectlDescribeServicesCommands",
                 "title": "Describe Services"
+            },
+            {
+                "command": "aks.aksKubectlGetEventsCommands",
+                "title": "Get Events"
             }
         ],
         "menus": {
@@ -282,6 +287,10 @@
                 },
                 {
                     "command": "aks.aksKubectlDescribeServicesCommands",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksKubectlGetEventsCommands",
                     "group": "navigation"
                 }
             ]

--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -50,6 +50,14 @@ export async function aksKubectlDescribeServicesCommands(
   await aksKubectlCommands(_context, target, command);
 }
 
+export async function aksKubectlGetEventsCommands(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const command = `get events  --all-namespaces`;
+  await aksKubectlCommands(_context, target, command);
+}
+
 async function aksKubectlCommands(
   _context: IActionContext,
   target: any,

--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -54,7 +54,7 @@ export async function aksKubectlGetEventsCommands(
   _context: IActionContext,
   target: any
 ): Promise<void> {
-  const command = `get events  --all-namespaces`;
+  const command = `get events --all-namespaces`;
   await aksKubectlCommands(_context, target, command);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import aksNavToPortal from './commands/aksNavToPortal/aksNavToPortal';
 import aksClusterProperties from './commands/aksClusterProperties/aksClusterProperties';
 import aksCreateClusterNavToAzurePortal from './commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal';
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { aksKubectlGetPodsCommands, aksKubectlGetClusterInfoCommands, aksKubectlGetAPIResourcesCommands, aksKubectlGetNodeCommands, aksKubectlDescribeServicesCommands } from './commands/aksKubectlCommands/aksKubectlCommands';
+import { aksKubectlGetPodsCommands, aksKubectlGetClusterInfoCommands, aksKubectlGetAPIResourcesCommands, aksKubectlGetNodeCommands, aksKubectlDescribeServicesCommands, aksKubectlGetEventsCommands } from './commands/aksKubectlCommands/aksKubectlCommands';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -63,6 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKubectlGetAPIResourcesCommands', aksKubectlGetAPIResourcesCommands);
         registerCommandWithTelemetry('aks.aksKubectlGetNodeCommands', aksKubectlGetNodeCommands);
         registerCommandWithTelemetry('aks.aksKubectlDescribeServicesCommands', aksKubectlDescribeServicesCommands);
+        registerCommandWithTelemetry('aks.aksKubectlGetEventsCommands', aksKubectlGetEventsCommands);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR enables the `kubectl get events --all-namespaces` feature to enable user run quick commands using our helpful kubectl submenu.

Thanks heaps, @peterbom and @rzhang628 ❤️☕️🙏 fyi @gambtho 

<img width="420" alt="Screenshot 2022-11-02 at 1 28 43 PM" src="https://user-images.githubusercontent.com/6233295/199366781-d3c34372-6313-4cf2-b680-aee5d36e799a.png">
