### PR TITLE
Changes for publishing 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.3.6]
+
+* Fix for css custom uri to use asWebViewURI.
+
+ Thanks to @rzhang628 and @peterbom.
+
 ## [1.3.5]
 
 * Generate periscope links from run ID.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-containerservice": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
Publishing version `1.3.6` with web view css fix by using `asWebViewURI` api. Thanks heaps and cc: @peterbom and @rzhang628 + @gambtho ❤️🙏

Thanks,
^Tats