### PR TITLE
Enable delete cluster functionality.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.3.7",
             "license": "MIT",
             "dependencies": {
-                "@azure/arm-containerservice": "^16.1.0",
+                "@azure/arm-containerservice": "^17.2.0",
                 "@azure/arm-monitor": "^6.0.0",
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-subscriptions": "^2.0.1",
@@ -78,19 +78,20 @@
             "license": "0BSD"
         },
         "node_modules/@azure/arm-containerservice": {
-            "version": "16.1.0",
-            "license": "MIT",
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-17.2.0.tgz",
+            "integrity": "sha512-Ofl9G57wrDYQ7ueELT/vR1Tv3/Qg9IUq6TpXWT3UckRltj3BV/tZdTDuueJoA6k23wPFHbDRrDO0AJt19D8EKg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
+                "@azure/core-client": "^1.6.1",
                 "@azure/core-lro": "^2.2.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/arm-monitor": {
@@ -416,8 +417,9 @@
             "license": "MIT"
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.3.2",
-            "license": "MIT",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
+            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
@@ -427,12 +429,13 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.6.0",
-            "license": "MIT",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.1.tgz",
+            "integrity": "sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.5.0",
+                "@azure/core-auth": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.9.1",
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
@@ -542,22 +545,23 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.9.0",
-            "license": "MIT",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.0.tgz",
+            "integrity": "sha512-m6c4iAalfaf6sytOOQhLKFprEHSkSjQuRgkW7MTMnAN+GENDDL4XZJp7WKFnq9VpKUE+ggq+rp5xX9GI93lumw==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
+                "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
-                "http-proxy-agent": "^4.0.1",
+                "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
                 "tslib": "^2.2.0",
                 "uuid": "^8.3.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
@@ -570,6 +574,14 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@azure/core-rest-pipeline/node_modules/form-data": {
             "version": "4.0.0",
             "license": "MIT",
@@ -577,6 +589,19 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
             },
             "engines": {
                 "node": ">= 6"
@@ -6996,11 +7021,13 @@
             }
         },
         "@azure/arm-containerservice": {
-            "version": "16.1.0",
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-17.2.0.tgz",
+            "integrity": "sha512-Ofl9G57wrDYQ7ueELT/vR1Tv3/Qg9IUq6TpXWT3UckRltj3BV/tZdTDuueJoA6k23wPFHbDRrDO0AJt19D8EKg==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
+                "@azure/core-client": "^1.6.1",
                 "@azure/core-lro": "^2.2.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
@@ -7280,18 +7307,22 @@
             "version": "1.0.0"
         },
         "@azure/core-auth": {
-            "version": "1.3.2",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
+            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
             }
         },
         "@azure/core-client": {
-            "version": "1.6.0",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.1.tgz",
+            "integrity": "sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-rest-pipeline": "^1.5.0",
+                "@azure/core-auth": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.9.1",
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
@@ -7372,15 +7403,17 @@
             }
         },
         "@azure/core-rest-pipeline": {
-            "version": "1.9.0",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.0.tgz",
+            "integrity": "sha512-m6c4iAalfaf6sytOOQhLKFprEHSkSjQuRgkW7MTMnAN+GENDDL4XZJp7WKFnq9VpKUE+ggq+rp5xX9GI93lumw==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
+                "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
-                "http-proxy-agent": "^4.0.1",
+                "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
                 "tslib": "^2.2.0",
                 "uuid": "^8.3.0"
@@ -7392,12 +7425,27 @@
                         "tslib": "^2.2.0"
                     }
                 },
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+                    "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+                },
                 "form-data": {
                     "version": "4.0.0",
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.8",
                         "mime-types": "^2.1.12"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+                    "requires": {
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 },
                 "uuid": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "onCommand:aks.aksKubectlGetNodeCommands",
         "onCommand:aks.aksKubectlDescribeServicesCommands",
         "onCommand:aks.aksKubectlGetEventsCommands",
-        "onCommand:aks.aksCategoryConnectivity"
+        "onCommand:aks.aksCategoryConnectivity",
+        "onCommand:aks.aksDeleteCluster"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -176,6 +177,10 @@
             {
                 "command": "aks.aksKubectlGetEventsCommands",
                 "title": "Get All Events"
+            },
+            {
+                "command": "aks.aksDeleteCluster",
+                "title": "Delete Cluster"
             }
         ],
         "menus": {
@@ -228,6 +233,11 @@
                     "submenu": "aks.runKubectlCmdSubMenu",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "9@1"
+                },
+                {
+                    "command": "aks.aksDeleteCluster",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
+                    "group": "9@3"
                 }
             ],
             "aks.detectorsSubMenu": [
@@ -348,7 +358,7 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@azure/arm-containerservice": "^16.1.0",
+        "@azure/arm-containerservice": "^17.2.0",
         "@azure/arm-monitor": "^6.0.0",
         "@azure/arm-resources": "^3.0.0",
         "@azure/arm-resources-subscriptions": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
                     "group": "9@1"
                 },
                 {
-                    "command": "aks.aksDeleteCluster",
+                    "submenu": "aks.managedClusterOperationSubMenu",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "9@3"
                 }
@@ -309,6 +309,12 @@
                     "command": "aks.aksKubectlGetEventsCommands",
                     "group": "navigation"
                 }
+            ],
+            "aks.managedClusterOperationSubMenu": [
+                {
+                    "command": "aks.aksDeleteCluster",
+                    "group": "navigation"
+                }
             ]
         },
         "submenus": [
@@ -323,6 +329,10 @@
             {
                 "id": "aks.runKubectlCmdSubMenu",
                 "label": "Run Kubectl Commands"
+            },
+            {
+                "id": "aks.managedClusterOperationSubMenu",
+                "label": "Managed Cluster Operations"
             }
         ]
     },

--- a/src/commands/aksDeleteCluster/aksDeleteCluster.ts
+++ b/src/commands/aksDeleteCluster/aksDeleteCluster.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { deleteCluster, getAksClusterTreeItem } from '../utils/clusters';
+import { failed, succeeded } from '../utils/errorable';
+import { longRunning } from '../utils/host';
+
+export default async function aksDeleteCluster(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const cluster = getAksClusterTreeItem(target, cloudExplorer);
+    if (failed(cluster)) {
+      vscode.window.showErrorMessage(cluster.error);
+      return;
+    }
+
+    const clusterName = cluster.result.name;
+
+    vscode.window.showInformationMessage(`Do you want to delete cluster ${clusterName}?`, "Yes", "No")
+    .then(async answer => {
+      if (answer === "Yes") {
+
+        const result = await longRunning(`Deleting cluster ${clusterName}.`, async () => { return await deleteCluster(cluster.result, clusterName) });
+
+        if (failed(result)) {
+          vscode.window.showErrorMessage(result.error);
+        }
+
+        if (succeeded(result)) {
+          vscode.window.showInformationMessage(result.result);
+        }
+      }
+    });
+}

--- a/src/commands/aksDeleteCluster/aksDeleteCluster.ts
+++ b/src/commands/aksDeleteCluster/aksDeleteCluster.ts
@@ -6,32 +6,30 @@ import { failed, succeeded } from '../utils/errorable';
 import { longRunning } from '../utils/host';
 
 export default async function aksDeleteCluster(
-    _context: IActionContext,
-    target: any
+  _context: IActionContext,
+  target: any
 ): Promise<void> {
-    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+  const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-      vscode.window.showErrorMessage(cluster.error);
-      return;
+  const cluster = getAksClusterTreeItem(target, cloudExplorer);
+  if (failed(cluster)) {
+    vscode.window.showErrorMessage(cluster.error);
+    return;
+  }
+
+  const clusterName = cluster.result.name;
+
+  const answer = await vscode.window.showInformationMessage(`Do you want to delete cluster ${clusterName}?`, "Yes", "No");
+
+  if (answer === "Yes") {
+    const result = await longRunning(`Deleting cluster ${clusterName}.`, async () => { return await deleteCluster(cluster.result, clusterName) });
+
+    if (failed(result)) {
+      vscode.window.showErrorMessage(result.error);
     }
 
-    const clusterName = cluster.result.name;
-
-    vscode.window.showInformationMessage(`Do you want to delete cluster ${clusterName}?`, "Yes", "No")
-    .then(async answer => {
-      if (answer === "Yes") {
-
-        const result = await longRunning(`Deleting cluster ${clusterName}.`, async () => { return await deleteCluster(cluster.result, clusterName) });
-
-        if (failed(result)) {
-          vscode.window.showErrorMessage(result.error);
-        }
-
-        if (succeeded(result)) {
-          vscode.window.showInformationMessage(result.result);
-        }
-      }
-    });
+    if (succeeded(result)) {
+      vscode.window.showInformationMessage(result.result);
+    }
+  }
 }

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -1,7 +1,7 @@
 import { API, CloudExplorerV1 } from 'vscode-kubernetes-tools-api';
 import AksClusterTreeItem from "../../tree/aksClusterTreeItem";
 import * as azcs from '@azure/arm-containerservice';
-import { Errorable, failed } from './errorable';
+import { Errorable, failed, getErrorMessage } from './errorable';
 import { ResourceManagementClient } from '@azure/arm-resources';
 import { SubscriptionTreeNode } from '../../tree/subscriptionTreeItem';
 import { getAksAadAccessToken } from './authProvider';
@@ -364,6 +364,6 @@ export async function deleteCluster(
 
         return { succeeded: true, result: "Delete cluster succeeded." };
     } catch (ex) {
-        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${ex}` };
+        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${getErrorMessage(ex)}` };
     }
 }

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -353,3 +353,17 @@ export function getContainerClient(target: AksClusterTreeItem): azcs.ContainerSe
     const environment = target.subscription.environment;
     return new azcs.ContainerServiceClient(target.subscription.credentials, target.subscription.subscriptionId, {endpoint: environment.resourceManagerEndpointUrl});
 }
+
+export async function deleteCluster(
+    target: AksClusterTreeItem,
+    clusterName: string
+): Promise<Errorable<string>> {
+    try {
+        const containerClient = getContainerClient(target);
+        await containerClient.managedClusters.beginDeleteAndWait(target.resourceGroupName, clusterName)
+
+        return { succeeded: true, result: "Delete cluster succeeded." };
+    } catch (ex) {
+        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${ex}` };
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { aksKubectlGetPodsCommands, aksKubectlGetClusterInfoCommands, aksKubectl
 import aksCategoryConnectivity from './commands/aksCategoryConnectivity/aksCategoryConnectivity';
 import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
+import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -65,6 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKubectlDescribeServicesCommands', aksKubectlDescribeServicesCommands);
         registerCommandWithTelemetry('aks.aksKubectlGetEventsCommands', aksKubectlGetEventsCommands);
         registerCommandWithTelemetry('aks.aksCategoryConnectivity', aksCategoryConnectivity);
+        registerCommandWithTelemetry('aks.aksDeleteCluster', aksDeleteCluster);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR is written to enable all the achievable `managed cluster operations` which we can integrate with users for `one-click` - `aks vscode` functionality. 

This PR adds the `submenu` along with one click `delete cluster` api trigger via the TS api: https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/delete?tabs=JavaScript 

🥷💡🙏 Please note: the api return void but it takes time, so I have added appropriate messaging for user to see what is happening. Also, to those who have so far used the `delete cluster operation` from portal have seen little-longer to delete the cluster which is the responsibility of API, hence you will see the `long running` beahviour via vscode as well.

💼☕️ Key advantage of this feature will be that not only in one-click user can delete the cluster but also they can send multiple parallel delete operation at once. 

Thank you so much and fyi to: ❤️💡🥷 @rzhang628, @squillace , @peterbom and @gambtho ☕️❤️🙏

Here are some screenshots: 

<img width="438" alt="Screenshot 2022-12-22 at 10 40 12 AM" src="https://user-images.githubusercontent.com/6233295/209062804-2014f587-c575-4327-944b-abf082dd7e82.png">


<img width="597" alt="Screenshot 2022-12-22 at 10 16 01 AM" src="https://user-images.githubusercontent.com/6233295/209062819-058ca045-86aa-41d3-b39b-e0bd33608da7.png">



<img width="571" alt="Screenshot 2022-12-22 at 10 07 03 AM" src="https://user-images.githubusercontent.com/6233295/209062834-285b2493-03ff-4258-b1e0-602bc8b1b4ac.png">


<img width="585" alt="Screenshot 2022-12-22 at 10 15 41 AM" src="https://user-images.githubusercontent.com/6233295/209062850-4714f837-cfe9-454a-bab9-28ed6c3b0422.png">

