### PR TITLE
Managed cluster rotate certificate feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,6 +361,14 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@azure/core-rest-pipeline/node_modules/form-data": {
             "version": "4.0.0",
             "license": "MIT",
@@ -368,6 +376,19 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
             },
             "engines": {
                 "node": ">= 6"
@@ -7057,12 +7078,27 @@
                         "tslib": "^2.2.0"
                     }
                 },
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+                    "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+                },
                 "form-data": {
                     "version": "4.0.0",
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.8",
                         "mime-types": "^2.1.12"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+                    "requires": {
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "onCommand:aks.aksKubectlDescribeServicesCommands",
         "onCommand:aks.aksKubectlGetEventsCommands",
         "onCommand:aks.aksCategoryConnectivity",
-        "onCommand:aks.aksDeleteCluster"
+        "onCommand:aks.aksDeleteCluster",
+        "onCommand:aks.aksRotateClusterCert"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -181,6 +182,10 @@
             {
                 "command": "aks.aksDeleteCluster",
                 "title": "Delete Cluster"
+            },
+            {
+                "command": "aks.aksRotateClusterCert",
+                "title": "Rotate Cluster Certificate"
             }
         ],
         "menus": {
@@ -313,6 +318,10 @@
             "aks.managedClusterOperationSubMenu": [
                 {
                     "command": "aks.aksDeleteCluster",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksRotateClusterCert",
                     "group": "navigation"
                 }
             ]

--- a/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
+++ b/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
@@ -21,8 +21,12 @@ export default async function aksRotateClusterCert(
 
   const answer = await vscode.window.showInformationMessage(`Do you want to rotate cluster ${clusterName} certificate?`, "Yes", "No");
 
+  if (answer !== "Yes") {
+    return;
+  }
+
   if (answer === "Yes") {
-    const result = await longRunning(`Rotating cluster certificate for ${clusterName}.`, async () => { return await rotateClusterCert(cluster.result, clusterName) });
+    const result = await longRunning(`Rotating cluster certificate for ${clusterName}.`, async () => rotateClusterCert(cluster.result, clusterName) );
 
     if (failed(result)) {
       vscode.window.showErrorMessage(result.error);

--- a/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
+++ b/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { getAksClusterTreeItem, rotateClusterCert } from '../utils/clusters';
+import { failed, succeeded } from '../utils/errorable';
+import { longRunning } from '../utils/host';
+
+export default async function aksRotateClusterCert(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+  const cluster = getAksClusterTreeItem(target, cloudExplorer);
+  if (failed(cluster)) {
+    vscode.window.showErrorMessage(cluster.error);
+    return;
+  }
+
+  const clusterName = cluster.result.name;
+
+  const answer = await vscode.window.showInformationMessage(`Do you want to rotate cluster ${clusterName} certificate?`, "Yes", "No");
+
+  if (answer === "Yes") {
+    const result = await longRunning(`Rotating cluster certificate for ${clusterName}.`, async () => { return await rotateClusterCert(cluster.result, clusterName) });
+
+    if (failed(result)) {
+      vscode.window.showErrorMessage(result.error);
+    }
+
+    if (succeeded(result)) {
+      vscode.window.showInformationMessage(result.result);
+    }
+  }
+}

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -427,3 +427,17 @@ export async function deleteCluster(
         return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${getErrorMessage(ex)}` };
     }
 }
+
+export async function rotateClusterCert(
+    target: AksClusterTreeItem,
+    clusterName: string
+): Promise<Errorable<string>> {
+    try {
+        const containerClient = getContainerClient(target);
+        await containerClient.managedClusters.beginRotateClusterCertificatesAndWait(target.resourceGroupName, clusterName)
+
+        return { succeeded: true, result: `Rotate cluster certificate for ${clusterName} succeeded.` };
+    } catch (ex) {
+        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${getErrorMessage(ex)}` };
+    }
+}

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -434,7 +434,7 @@ export async function rotateClusterCert(
 ): Promise<Errorable<string>> {
     try {
         const containerClient = getContainerClient(target);
-        await containerClient.managedClusters.beginRotateClusterCertificatesAndWait(target.resourceGroupName, clusterName)
+        await containerClient.managedClusters.beginRotateClusterCertificatesAndWait(target.resourceGroupName, clusterName);
 
         return { succeeded: true, result: `Rotate cluster certificate for ${clusterName} succeeded.` };
     } catch (ex) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import aksCategoryConnectivity from './commands/aksCategoryConnectivity/aksCateg
 import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
 import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
+import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -67,6 +68,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKubectlGetEventsCommands', aksKubectlGetEventsCommands);
         registerCommandWithTelemetry('aks.aksCategoryConnectivity', aksCategoryConnectivity);
         registerCommandWithTelemetry('aks.aksDeleteCluster', aksDeleteCluster);
+        registerCommandWithTelemetry('aks.aksRotateClusterCert', aksRotateClusterCert);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR is written to piggy back on all the achievable `managed cluster operations` which we can integrate with users for `one-click` - `aks vscode` functionality. 

This PR adds the one click `rotate cluster certificate` api trigger via the TS api: https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/delete?tabs=JavaScript 

🥷💡🙏 Please note: the api return void but it takes time, so I have added appropriate messaging for user to see what is happening. Also, to those who have so far used the `rotate cluster certificate operation` from portal have seen little-longer to delete the cluster which is the responsibility of API, hence you will see the `long running` beahviour via vscode as well.

💼☕️ Key advantage of this feature will be that not only in one-click user can delete the cluster but also they can send multiple parallel delete operation at once. 

Thank you so much and fyi to: ❤️💡🥷 @rzhang628, @squillace , @peterbom and @gambtho ☕️❤️🙏

Here are some screenshots: 

<img width="576" alt="Screenshot 2022-12-28 at 10 37 00 AM" src="https://user-images.githubusercontent.com/6233295/209762645-da9d3432-3db4-4a16-b199-950b8d10b61c.png">


<img width="584" alt="Screenshot 2022-12-28 at 10 37 36 AM" src="https://user-images.githubusercontent.com/6233295/209762657-2411a20f-9f76-419a-8a52-880eff985183.png">


<img width="576" alt="Screenshot 2022-12-28 at 10 37 43 AM" src="https://user-images.githubusercontent.com/6233295/209762670-d54cd4ea-cb36-46c6-821e-ca89e6e05b44.png">

<img width="588" alt="Screenshot 2022-12-28 at 10 53 56 AM" src="https://user-images.githubusercontent.com/6233295/209762683-29e4cd7b-c616-4be3-88a1-78ab116523d6.png">



