### PR TITLE
Move padding for ASO webview to correct css file

### DIFF
--- a/resources/webviews/azureserviceoperator/azureserviceoperator.css
+++ b/resources/webviews/azureserviceoperator/azureserviceoperator.css
@@ -14,6 +14,7 @@ body {
 .container .panel {
     margin-bottom: 20px;
     margin-top: 20px;
+    padding: 10px;
     background-color: #fff;
     border: 1px solid #ddd;
     border-left-width: 0;

--- a/resources/webviews/periscope/periscope.css
+++ b/resources/webviews/periscope/periscope.css
@@ -14,7 +14,6 @@ body {
 .container .panel {
     margin-bottom: 20px;
     margin-top: 20px;
-    padding: 10px;
     background-color: #fff;
     border: 1px solid #ddd;
     border-left-width: 0;


### PR DESCRIPTION
I mistakenly [added some CSS padding to the wrong file](https://github.com/Azure/vscode-aks-tools/pull/181/files#diff-1b4ebc75fee5dcd8fb408864476596c83e3fb2ce6e49e11b20d261540e1249d5) when making the changes to support ASO for non-AKS clusters.

This moves it to the right place.