### PR TITLE
Add k8s api healtch check submenu.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
         "onCommand:aks.aksKubectlGetEventsCommands",
         "onCommand:aks.aksCategoryConnectivity",
         "onCommand:aks.aksDeleteCluster",
-        "onCommand:aks.aksRotateClusterCert"
+        "onCommand:aks.aksRotateClusterCert",
+        "onCommand:aks.aksKubectlK8sHealthzAPIEndpointCommands",
+        "onCommand:aks.aksKubectlK8sLivezAPIEndpointCommands",
+        "onCommand:aks.aksKubectlK8sReadyzAPIEndpointCommands"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -186,6 +189,18 @@
             {
                 "command": "aks.aksRotateClusterCert",
                 "title": "Rotate Cluster Certificate"
+            },
+            {
+                "command": "aks.aksKubectlK8sHealthzAPIEndpointCommands",
+                "title": "Healthz check"
+            },
+            {
+                "command": "aks.aksKubectlK8sLivezAPIEndpointCommands",
+                "title": "Livez check"
+            },
+            {
+                "command": "aks.aksKubectlK8sReadyzAPIEndpointCommands",
+                "title": "Readyz check"
             }
         ],
         "menus": {
@@ -241,6 +256,11 @@
                 },
                 {
                     "submenu": "aks.managedClusterOperationSubMenu",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
+                    "group": "9@3"
+                },
+                {
+                    "submenu": "aks.K8sAPIEndpointHealthCheck",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i",
                     "group": "9@3"
                 }
@@ -324,6 +344,20 @@
                     "command": "aks.aksRotateClusterCert",
                     "group": "navigation"
                 }
+            ],
+            "aks.K8sAPIEndpointHealthCheck": [
+                {
+                    "command": "aks.aksKubectlK8sHealthzAPIEndpointCommands",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksKubectlK8sLivezAPIEndpointCommands",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksKubectlK8sReadyzAPIEndpointCommands",
+                    "group": "navigation"
+                }
             ]
         },
         "submenus": [
@@ -342,6 +376,10 @@
             {
                 "id": "aks.managedClusterOperationSubMenu",
                 "label": "Managed Cluster Operations"
+            },
+            {
+                "id": "aks.K8sAPIEndpointHealthCheck",
+                "label": "Kubernetes API Health Endpoints"
             }
         ]
     },

--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -58,6 +58,30 @@ export async function aksKubectlGetEventsCommands(
   await aksKubectlCommands(_context, target, command);
 }
 
+export async function aksKubectlK8sHealthzAPIEndpointCommands(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const command = `get --raw='/healthz?verbose'`;
+  await aksKubectlCommands(_context, target, command);
+}
+
+export async function aksKubectlK8sLivezAPIEndpointCommands(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const command = `get --raw='/livez?verbose'`;
+  await aksKubectlCommands(_context, target, command);
+}
+
+export async function aksKubectlK8sReadyzAPIEndpointCommands(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const command = `get --raw='/readyz?verbose'`;
+  await aksKubectlCommands(_context, target, command);
+}
+
 async function aksKubectlCommands(
   _context: IActionContext,
   target: any,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import aksNavToPortal from './commands/aksNavToPortal/aksNavToPortal';
 import aksClusterProperties from './commands/aksClusterProperties/aksClusterProperties';
 import aksCreateClusterNavToAzurePortal from './commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal';
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { aksKubectlGetPodsCommands, aksKubectlGetClusterInfoCommands, aksKubectlGetAPIResourcesCommands, aksKubectlGetNodeCommands, aksKubectlDescribeServicesCommands, aksKubectlGetEventsCommands } from './commands/aksKubectlCommands/aksKubectlCommands';
+import { aksKubectlGetPodsCommands, aksKubectlGetClusterInfoCommands, aksKubectlGetAPIResourcesCommands, aksKubectlGetNodeCommands, aksKubectlDescribeServicesCommands, aksKubectlGetEventsCommands, aksKubectlK8sLivezAPIEndpointCommands, aksKubectlK8sHealthzAPIEndpointCommands, aksKubectlK8sReadyzAPIEndpointCommands } from './commands/aksKubectlCommands/aksKubectlCommands';
 import aksCategoryConnectivity from './commands/aksCategoryConnectivity/aksCategoryConnectivity';
 import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
@@ -69,6 +69,9 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksCategoryConnectivity', aksCategoryConnectivity);
         registerCommandWithTelemetry('aks.aksDeleteCluster', aksDeleteCluster);
         registerCommandWithTelemetry('aks.aksRotateClusterCert', aksRotateClusterCert);
+        registerCommandWithTelemetry('aks.aksKubectlK8sHealthzAPIEndpointCommands', aksKubectlK8sHealthzAPIEndpointCommands);
+        registerCommandWithTelemetry('aks.aksKubectlK8sLivezAPIEndpointCommands', aksKubectlK8sLivezAPIEndpointCommands);
+        registerCommandWithTelemetry('aks.aksKubectlK8sReadyzAPIEndpointCommands', aksKubectlK8sReadyzAPIEndpointCommands);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This PR enable quick access to the `Healthz, livez and readyz` k8s API endpoint health checks to the user.

More details for these are here: https://kubernetes.io/docs/reference/using-api/health-checks/ 

Thanks heaps, fyi and cc: @rzhang628 & @peterbom ☕️❤️💡🙏

<img width="1754" alt="Screenshot 2023-01-08 at 3 17 29 PM" src="https://user-images.githubusercontent.com/6233295/211233516-7c86d966-c3a1-4648-9c13-27a317560fe7.png">
