### PR TITLE
Update config to use kubectl-gadget v0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.12.0",
+                    "default": "v0.12.1",
                     "title": "Kubectl-gadget repository release tag",
-                    "description": "Release tag for the stable kubectl-gadget tool release."
+                    "description": "Release tag for the stable kubectl-gadget tool."
                 }
             }
         },


### PR DESCRIPTION
This PR only updates the config to use the latest version released for Inspektor Gadget: [v0.12.1](https://github.com/inspektor-gadget/inspektor-gadget/releases/tag/v0.12.1).

cc @Tatsinnit 