### PR TITLE
Enable non-interactive Inspektor Gadget Commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,15 @@
         "onCommand:aks.aksKubectlK8sLivezAPIEndpointCommands",
         "onCommand:aks.aksKubectlK8sReadyzAPIEndpointCommands",
         "onCommand:aks.aksInspektorGadgetDeploy",
-        "onCommand:aks.aksInspektorGadgetUnDeploy"
+        "onCommand:aks.aksInspektorGadgetUnDeploy",
+        "onCommand:aks.aksInspektorGadgetTopTCP",
+        "onCommand:aks.aksInspektorGadgetTopEBPF",
+        "onCommand:aks.aksInspektorGadgetTopBlockIO",
+        "onCommand:aks.aksInspektorGadgetTopFile",
+        "onCommand:aks.aksInspektorGadgetProfileBlockIO",
+        "onCommand:aks.aksInspektorGadgetProfileCPU",
+        "onCommand:aks.aksInspektorGadgetSnapshotProcess",
+        "onCommand:aks.aksInspektorGadgetSnapshotSocket"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -217,6 +225,38 @@
             {
                 "command": "aks.aksInspektorGadgetUnDeploy",
                 "title": "Undeploy"
+            },
+            {
+                "command": "aks.aksInspektorGadgetTopTCP",
+                "title": "Top Tcp"
+            },
+            {
+                "command": "aks.aksInspektorGadgetTopEBPF",
+                "title": "Top Ebpf"
+            },
+            {
+                "command": "aks.aksInspektorGadgetTopBlockIO",
+                "title": "Top BlockIO"
+            },
+            {
+                "command": "aks.aksInspektorGadgetTopFile",
+                "title": "Top File"
+            },
+            {
+                "command": "aks.aksInspektorGadgetProfileBlockIO",
+                "title": "Profile BlockIO"
+            },
+            {
+                "command": "aks.aksInspektorGadgetProfileCPU",
+                "title": "Profile CPU"
+            },
+            {
+                "command": "aks.aksInspektorGadgetSnapshotProcess",
+                "title": "Sanpshot Process"
+            },
+            {
+                "command": "aks.aksInspektorGadgetSnapshotSocket",
+                "title": "Sanpshot Socket"
             }
         ],
         "menus": {
@@ -396,7 +436,53 @@
             ],
             "aks.inspektorGadgetCommandsSubMenu": [
                 {
-                    "command": "aks.aksKubectlK8sReadyzAPIEndpointCommands",
+                    "submenu": "aks.inspektorGadgetTopCommandSubMenu",
+                    "group": "navigation"
+                },
+                {
+                    "submenu": "aks.inspektorGadgetProfileCommandSubMenu",
+                    "group": "navigation"
+                },
+                {
+                    "submenu": "aks.inspektorGadgetSanpshotCommandSubMenu",
+                    "group": "navigation"
+                }
+            ],
+            "aks.inspektorGadgetTopCommandSubMenu": [
+                {
+                    "command": "aks.aksInspektorGadgetTopTCP",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksInspektorGadgetTopEBPF",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksInspektorGadgetTopBlockIO",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksInspektorGadgetTopFile",
+                    "group": "navigation"
+                }
+            ],
+            "aks.inspektorGadgetProfileCommandSubMenu": [
+                {
+                    "command": "aks.aksInspektorGadgetProfileBlockIO",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksInspektorGadgetProfileCPU",
+                    "group": "navigation"
+                }
+            ],
+            "aks.inspektorGadgetSanpshotCommandSubMenu": [
+                {
+                    "command": "aks.aksInspektorGadgetSnapshotProcess",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksInspektorGadgetSnapshotSocket",
                     "group": "navigation"
                 }
             ]
@@ -428,7 +514,19 @@
             },
             {
                 "id": "aks.inspektorGadgetCommandsSubMenu",
-                "label": "Trace Gadgets"
+                "label": "Gadget Commands"
+            },
+            {
+                "id": "aks.inspektorGadgetTopCommandSubMenu",
+                "label": "Top Commands"
+            },
+            {
+                "id": "aks.inspektorGadgetProfileCommandSubMenu",
+                "label": "Profile Commands"
+            },
+            {
+                "id": "aks.inspektorGadgetSanpshotCommandSubMenu",
+                "label": "Sanpshot Commands"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -388,6 +388,16 @@
                 {
                     "command": "aks.aksInspektorGadgetUnDeploy",
                     "group": "navigation"
+                },
+                {
+                    "submenu": "aks.inspektorGadgetCommandsSubMenu",
+                    "group": "navigation"
+                }
+            ],
+            "aks.inspektorGadgetCommandsSubMenu": [
+                {
+                    "command": "aks.aksKubectlK8sReadyzAPIEndpointCommands",
+                    "group": "navigation"
                 }
             ]
         },
@@ -415,6 +425,10 @@
             {
                 "id": "aks.inspektorGadgetSubMenu",
                 "label": "Inspektor Gadget"
+            },
+            {
+                "id": "aks.inspektorGadgetCommandsSubMenu",
+                "label": "Trace Gadgets"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
         "onCommand:aks.aksInspektorGadgetTopEBPF",
         "onCommand:aks.aksInspektorGadgetTopBlockIO",
         "onCommand:aks.aksInspektorGadgetTopFile",
-        "onCommand:aks.aksInspektorGadgetProfileBlockIO",
         "onCommand:aks.aksInspektorGadgetProfileCPU",
         "onCommand:aks.aksInspektorGadgetSnapshotProcess",
         "onCommand:aks.aksInspektorGadgetSnapshotSocket"
@@ -241,10 +240,6 @@
             {
                 "command": "aks.aksInspektorGadgetTopFile",
                 "title": "Top File"
-            },
-            {
-                "command": "aks.aksInspektorGadgetProfileBlockIO",
-                "title": "Profile BlockIO"
             },
             {
                 "command": "aks.aksInspektorGadgetProfileCPU",
@@ -467,10 +462,6 @@
                 }
             ],
             "aks.inspektorGadgetProfileCommandSubMenu": [
-                {
-                    "command": "aks.aksInspektorGadgetProfileBlockIO",
-                    "group": "navigation"
-                },
                 {
                     "command": "aks.aksInspektorGadgetProfileCPU",
                     "group": "navigation"

--- a/package.json
+++ b/package.json
@@ -227,11 +227,11 @@
             },
             {
                 "command": "aks.aksInspektorGadgetTopTCP",
-                "title": "Top Tcp"
+                "title": "Top TCP"
             },
             {
                 "command": "aks.aksInspektorGadgetTopEBPF",
-                "title": "Top Ebpf"
+                "title": "Top eBPF"
             },
             {
                 "command": "aks.aksInspektorGadgetTopBlockIO",
@@ -251,7 +251,7 @@
             },
             {
                 "command": "aks.aksInspektorGadgetSnapshotSocket",
-                "title": "Sanpshot Socket"
+                "title": "Snapshot Socket"
             }
         ],
         "menus": {

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -18,7 +18,6 @@ enum Command {
     TopBlockIO,
     TopFile,
     ProfileCPU,
-    ProfileBlockIO,
     SnapshotProcess,
     SnapshotSocket
 }
@@ -63,13 +62,6 @@ export async function aksInspektorGadgetTopFile(
     target: any
 ): Promise<void> {
     await gadgetDeployUndeploy(_context, target, GadgetCommand.TopFile);
-}
-
-export async function aksInspektorGadgetProfileBlockIO(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.ProfileBlockIO);
 }
 
 export async function aksInspektorGadgetProfileCPU(
@@ -156,9 +148,6 @@ async function prepareInspektorGadgetInstall(
         case GadgetCommand.TopFile:
             await topFile(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.ProfileBlockIO:
-            await profileBlockIO(clustername, kubeconfig, kubectl);
-            return;
         case GadgetCommand.ProfileCPU:
             await profileCPU(clustername, kubeconfig, kubectl);
             return;
@@ -224,16 +213,6 @@ async function topFile(
 
     return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
 }
-
-async function profileBlockIO(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "profile block-io";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
 async function profileCPU(
     clustername: string,
     clusterConfig: string,

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -26,67 +26,66 @@ export async function aksInspektorGadgetDeploy(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.Deploy)
+    await gadgetDeployUndeploy(target, Command.Deploy)
 }
 
 export async function aksInspektorGadgetUnDeploy(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.Undeploy);
+    await gadgetDeployUndeploy(target, Command.Undeploy);
 }
 
 export async function aksInspektorGadgetTopTCP(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.TopTCP);
+    await gadgetDeployUndeploy(target, Command.TopTCP);
 }
 
 export async function aksInspektorGadgetTopEBPF(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.TopEBPF);
+    await gadgetDeployUndeploy(target, Command.TopEBPF);
 }
 
 export async function aksInspektorGadgetTopBlockIO(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.TopBlockIO);
+    await gadgetDeployUndeploy(target, Command.TopBlockIO);
 }
 
 export async function aksInspektorGadgetTopFile(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.TopFile);
+    await gadgetDeployUndeploy(target, Command.TopFile);
 }
 
 export async function aksInspektorGadgetProfileCPU(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.ProfileCPU);
+    await gadgetDeployUndeploy(target, Command.ProfileCPU);
 }
 
 export async function aksInspektorGadgetSnapshotProcess(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.SnapshotProcess);
+    await gadgetDeployUndeploy(target, Command.SnapshotProcess);
 }
 
 export async function aksInspektorGadgetSnapshotSocket(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, Command.SnapshotSocket);
+    await gadgetDeployUndeploy(target, Command.SnapshotSocket);
 }
 
 async function gadgetDeployUndeploy(
-    _context: IActionContext,
     target: any,
     cmd: Command
 ): Promise<void> {

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -40,49 +40,49 @@ export async function aksInspektorGadgetTopTCP(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopTCP);
+    await gadgetDeployUndeploy(_context, target, Command.TopTCP);
 }
 
 export async function aksInspektorGadgetTopEBPF(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopEBPF);
+    await gadgetDeployUndeploy(_context, target, Command.TopEBPF);
 }
 
 export async function aksInspektorGadgetTopBlockIO(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopBlockIO);
+    await gadgetDeployUndeploy(_context, target, Command.TopBlockIO);
 }
 
 export async function aksInspektorGadgetTopFile(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopFile);
+    await gadgetDeployUndeploy(_context, target, Command.TopFile);
 }
 
 export async function aksInspektorGadgetProfileCPU(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.ProfileCPU);
+    await gadgetDeployUndeploy(_context, target, Command.ProfileCPU);
 }
 
 export async function aksInspektorGadgetSnapshotProcess(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.SnapshotProcess);
+    await gadgetDeployUndeploy(_context, target, Command.SnapshotProcess);
 }
 
 export async function aksInspektorGadgetSnapshotSocket(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(_context, target, GadgetCommand.SnapshotSocket);
+    await gadgetDeployUndeploy(_context, target, Command.SnapshotSocket);
 }
 
 async function gadgetDeployUndeploy(
@@ -136,25 +136,25 @@ async function prepareInspektorGadgetInstall(
                 await unDeployGadget(clustername, kubeconfig, kubectl);
             }
             return;
-        case GadgetCommand.TopTCP:
+        case Command.TopTCP:
             await topTCPGadget(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.TopEBPF:
+        case Command.TopEBPF:
             await topEBPFGadget(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.TopBlockIO:
+        case Command.TopBlockIO:
             await topBlockIOGadget(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.TopFile:
+        case Command.TopFile:
             await topFile(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.ProfileCPU:
+        case Command.ProfileCPU:
             await profileCPU(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.SnapshotProcess:
+        case Command.SnapshotProcess:
             await snapshotProcess(clustername, kubeconfig, kubectl);
             return;
-        case GadgetCommand.SnapshotSocket:
+        case Command.SnapshotSocket:
             await snapshotSocket(clustername, kubeconfig, kubectl);
             return;
     }

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -26,66 +26,66 @@ export async function aksInspektorGadgetDeploy(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.Deploy)
+    await checkTargetAndRunGadgetCommand(target, Command.Deploy)
 }
 
 export async function aksInspektorGadgetUnDeploy(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.Undeploy);
+    await checkTargetAndRunGadgetCommand(target, Command.Undeploy);
 }
 
 export async function aksInspektorGadgetTopTCP(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.TopTCP);
+    await checkTargetAndRunGadgetCommand(target, Command.TopTCP);
 }
 
 export async function aksInspektorGadgetTopEBPF(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.TopEBPF);
+    await checkTargetAndRunGadgetCommand(target, Command.TopEBPF);
 }
 
 export async function aksInspektorGadgetTopBlockIO(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.TopBlockIO);
+    await checkTargetAndRunGadgetCommand(target, Command.TopBlockIO);
 }
 
 export async function aksInspektorGadgetTopFile(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.TopFile);
+    await checkTargetAndRunGadgetCommand(target, Command.TopFile);
 }
 
 export async function aksInspektorGadgetProfileCPU(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.ProfileCPU);
+    await checkTargetAndRunGadgetCommand(target, Command.ProfileCPU);
 }
 
 export async function aksInspektorGadgetSnapshotProcess(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.SnapshotProcess);
+    await checkTargetAndRunGadgetCommand(target, Command.SnapshotProcess);
 }
 
 export async function aksInspektorGadgetSnapshotSocket(
     _context: IActionContext,
     target: any
 ): Promise<void> {
-    await gadgetDeployUndeploy(target, Command.SnapshotSocket);
+    await checkTargetAndRunGadgetCommand(target, Command.SnapshotSocket);
 }
 
-async function gadgetDeployUndeploy(
+async function checkTargetAndRunGadgetCommand(
     target: any,
     cmd: Command
 ): Promise<void> {
@@ -114,10 +114,10 @@ async function gadgetDeployUndeploy(
         return undefined;
     }
 
-    await prepareInspektorGadgetInstall(clusterInfo.result, cmd, kubectl);
+    await runGadgetCommand(clusterInfo.result, cmd, kubectl);
 }
 
-async function prepareInspektorGadgetInstall(
+async function runGadgetCommand(
     clusterInfo: KubernetesClusterInfo,
     cmd: Command,
     kubectl: k8s.APIAvailable<k8s.KubectlV1>

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -12,7 +12,15 @@ import { createWebView, getRenderedContent, getResourceUri } from '../utils/webv
 
 enum Command {
     Deploy,
-    Undeploy
+    Undeploy,
+    TopTCP,
+    TopEBPF,
+    TopBlockIO,
+    TopFile,
+    ProfileCPU,
+    ProfileBlockIO,
+    SnapshotProcess,
+    SnapshotSocket
 }
 
 export async function aksInspektorGadgetDeploy(
@@ -27,6 +35,62 @@ export async function aksInspektorGadgetUnDeploy(
     target: any
 ): Promise<void> {
     await gadgetDeployUndeploy(_context, target, Command.Undeploy);
+}
+
+export async function aksInspektorGadgetTopTCP(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopTCP);
+}
+
+export async function aksInspektorGadgetTopEBPF(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopEBPF);
+}
+
+export async function aksInspektorGadgetTopBlockIO(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopBlockIO);
+}
+
+export async function aksInspektorGadgetTopFile(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.TopFile);
+}
+
+export async function aksInspektorGadgetProfileBlockIO(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.ProfileBlockIO);
+}
+
+export async function aksInspektorGadgetProfileCPU(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.ProfileCPU);
+}
+
+export async function aksInspektorGadgetSnapshotProcess(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.SnapshotProcess);
+}
+
+export async function aksInspektorGadgetSnapshotSocket(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    await gadgetDeployUndeploy(_context, target, GadgetCommand.SnapshotSocket);
 }
 
 async function gadgetDeployUndeploy(
@@ -80,6 +144,30 @@ async function prepareInspektorGadgetInstall(
                 await unDeployGadget(clustername, kubeconfig, kubectl);
             }
             return;
+        case GadgetCommand.TopTCP:
+            await topTCPGadget(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.TopEBPF:
+            await topEBPFGadget(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.TopBlockIO:
+            await topBlockIOGadget(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.TopFile:
+            await topFile(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.ProfileBlockIO:
+            await profileBlockIO(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.ProfileCPU:
+            await profileCPU(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.SnapshotProcess:
+            await snapshotProcess(clustername, kubeconfig, kubectl);
+            return;
+        case GadgetCommand.SnapshotSocket:
+            await snapshotSocket(clustername, kubeconfig, kubectl);
+            return;
     }
 }
 
@@ -97,6 +185,78 @@ async function unDeployGadget(
     clusterConfig: string,
     kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
     const command = "undeploy";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function topTCPGadget(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "top tcp 30 --all-namespaces --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function topEBPFGadget(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "top ebpf 30 --all-namespaces --sort cumulruntime --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function topBlockIOGadget(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "top block-io 30 --all-namespaces --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function topFile(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "top file 30 --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function profileBlockIO(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "profile block-io";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function profileCPU(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "profile cpu --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function snapshotProcess(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "snapshot process --all-namespaces 30 --timeout 30";
+
+    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
+}
+
+async function snapshotSocket(
+    clustername: string,
+    clusterConfig: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
+    const command = "snapshot socket --all-namespaces 30 --timeout 30";
 
     return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
 import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
-import { aksInspektorGadgetDeploy, aksInspektorGadgetProfileBlockIO, aksInspektorGadgetProfileCPU, aksInspektorGadgetSnapshotProcess, aksInspektorGadgetSnapshotSocket, aksInspektorGadgetTopBlockIO, aksInspektorGadgetTopEBPF, aksInspektorGadgetTopFile, aksInspektorGadgetTopTCP, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
+import { aksInspektorGadgetDeploy, aksInspektorGadgetProfileCPU, aksInspektorGadgetSnapshotProcess, aksInspektorGadgetSnapshotSocket, aksInspektorGadgetTopBlockIO, aksInspektorGadgetTopEBPF, aksInspektorGadgetTopFile, aksInspektorGadgetTopTCP, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -79,7 +79,6 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksInspektorGadgetTopEBPF', aksInspektorGadgetTopEBPF);
         registerCommandWithTelemetry('aks.aksInspektorGadgetTopBlockIO', aksInspektorGadgetTopBlockIO);
         registerCommandWithTelemetry('aks.aksInspektorGadgetTopFile', aksInspektorGadgetTopFile);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetProfileBlockIO', aksInspektorGadgetProfileBlockIO);
         registerCommandWithTelemetry('aks.aksInspektorGadgetProfileCPU', aksInspektorGadgetProfileCPU);
         registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotProcess', aksInspektorGadgetSnapshotProcess);
         registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotSocket', aksInspektorGadgetSnapshotSocket);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
 import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
-import { aksInspektorGadgetDeploy, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
+import { aksInspektorGadgetDeploy, aksInspektorGadgetProfileBlockIO, aksInspektorGadgetProfileCPU, aksInspektorGadgetSnapshotProcess, aksInspektorGadgetSnapshotSocket, aksInspektorGadgetTopBlockIO, aksInspektorGadgetTopEBPF, aksInspektorGadgetTopFile, aksInspektorGadgetTopTCP, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -75,6 +75,14 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKubectlK8sReadyzAPIEndpointCommands', aksKubectlK8sReadyzAPIEndpointCommands);
         registerCommandWithTelemetry('aks.aksInspektorGadgetDeploy', aksInspektorGadgetDeploy);
         registerCommandWithTelemetry('aks.aksInspektorGadgetUnDeploy', aksInspektorGadgetUnDeploy);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetTopTCP', aksInspektorGadgetTopTCP);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetTopEBPF', aksInspektorGadgetTopEBPF);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetTopBlockIO', aksInspektorGadgetTopBlockIO);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetTopFile', aksInspektorGadgetTopFile);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetProfileBlockIO', aksInspektorGadgetProfileBlockIO);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetProfileCPU', aksInspektorGadgetProfileCPU);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotProcess', aksInspektorGadgetSnapshotProcess);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotSocket', aksInspektorGadgetSnapshotSocket);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
Thank you for taking time and reviewing this! This PR enables the few `Non-Interative` **inspector gadget command**. This PR capitalise the ground up work we did under #190

List of commands this drop enables are:

- Inspector gadget Top command
    - TCP
    - eBPF
    - BlockIO
    - File
- IG Snapshot
    - Process
    - Socket
- IG Profile
    -  CPU

Sample:

<img width="848" alt="Screenshot 2023-02-15 at 10 06 39 AM" src="https://user-images.githubusercontent.com/6233295/218863128-8916c07f-397e-4c97-b155-d716099a3f1f.png">
