### PR TITLE
Remove unnecessary kubelogin download

### DIFF
--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -8,7 +8,6 @@ import * as tmpfile from '../utils/tempfile';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
 import { createWebView, getRenderedContent, getResourceUri } from '../utils/webviews';
 import { invokeKubectlCommand } from '../utils/kubectl';
-import { getKubeloginBinaryPath } from '../utils/helper/kubeloginDownload';
 
 export async function aksKubectlGetPodsCommands(
   _context: IActionContext,
@@ -130,10 +129,6 @@ async function loadKubectlCommandRun(
   kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
 
   const clustername = cloudTarget.name;
-  // Download and get Kubelogin path for AAD Enabled AKS Cluster.
-  // Sample use
-  const kubeloginPath = await getKubeloginBinaryPath();
-  console.log(kubeloginPath);
 
   await longRunning(`Loading ${clustername} kubectl command run.`,
     async () => {


### PR DESCRIPTION
I think we added this for testing purposes when enabling kubelogin for AAD clusters with local users disabled.

It's not needed because the common code for retrieving the kubeconfig takes care of this.