### PR TITLE
Update Periscope deployment to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,13 +80,13 @@
                 },
                 "aks.periscope.releaseTag": {
                     "type": "string",
-                    "default": "0.0.11",
+                    "default": "0.0.13",
                     "title": "Periscope repository release tag",
                     "description": "Release tag for the Kustomize templates in the Periscope repository."
                 },
                 "aks.periscope.imageVersion": {
                     "type": "string",
-                    "default": "0.0.11",
+                    "default": "0.0.13",
                     "title": "Periscope image version",
                     "description": "Docker image tag corresponding to the Periscope version."
                 },

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -141,6 +141,13 @@ export async function prepareAKSPeriscopeKustomizeOverlay(
         }
     }
 
+    // From 0.0.13 onwards, the image names are the same for Windows and Linux.
+    // Previously the Windows image was named 'periscope-win'.
+    let windowsImageName = "periscope";
+    if (semver.parse(kustomizeConfig.imageVersion) && semver.lt(kustomizeConfig.imageVersion, "0.0.13")) {
+        windowsImageName = "periscope-win";
+    }
+
     // Build a Kustomize overlay referencing a base for a known release, and using the images from MCR
     // for that release.
     const kustomizeContent = `
@@ -154,7 +161,7 @@ images:
   newName: ${kustomizeConfig.containerRegistry}/aks/periscope
   newTag: "${kustomizeConfig.imageVersion}"
 - name: periscope-windows
-  newName: ${kustomizeConfig.containerRegistry}/aks/periscope-win
+  newName: ${kustomizeConfig.containerRegistry}/aks/${windowsImageName}
   newTag: "${kustomizeConfig.imageVersion}"
 
 secretGenerator:

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -141,7 +141,8 @@ export async function prepareAKSPeriscopeKustomizeOverlay(
         }
     }
 
-    // From 0.0.13 onwards, the image names are the same for Windows and Linux.
+    // From 0.0.13 onwards, the image names are the same for Windows and Linux. Discussion linked to PR here:
+    // https://github.com/Azure/aks-periscope/pull/212
     // Previously the Windows image was named 'periscope-win'.
     let windowsImageName = "periscope";
     if (semver.parse(kustomizeConfig.imageVersion) && semver.lt(kustomizeConfig.imageVersion, "0.0.13")) {


### PR DESCRIPTION
This accounts for a change in the way Periscope is deployed in the latest version. Because the image tag refers to a manifest containing images for each OS, the tag is now the same for both Linux and Windows deployments.