### PR TITLE
Use Pull request rather then pull request target for now.

### DIFF
--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -1,7 +1,7 @@
 name: ChatGPT Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, edited, ready_for_review]
     branches:
       - 'master'

--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -2,7 +2,7 @@ name: ChatGPT Review
 
 on:
   pull_request_review:
-    types: [opened, reopened, edited, ready_for_review]
+    types: [submitted, edited]
     branches:
       - 'master'
 

--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -1,7 +1,7 @@
 name: ChatGPT Review
 
 on:
-  pull_request:
+  pull_request_review:
     types: [opened, reopened, edited, ready_for_review]
     branches:
       - 'master'


### PR DESCRIPTION
This work was added for this:

* https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

But now changing it to `pull_request` only due to this:

* https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Thanks heaps, cc: @peterbom , @rzhang628 