### PR TITLE
Publish 1.3.12.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.3.12]
+
+* Remove unnecessary kubelogin download.
+* Allow development of VS Code-themed webviews using UI toolkit and React framework.
+* Update Periscope deployment to latest version.
+* Remove deprecated activation events.
+* Publish gh.io readme as a vscode documentation.
+* Link the GH pages to the Readme doc of this repo.
+
+Thank you so much to @rzhang628, @peterbom.
+
 ## [1.3.11]
 
 * Enable Non-Interactive InspektorGadget Commands like Top, Profile and Snapshot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.3.11",
+            "version": "1.3.12",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
Publishing version `1.3.12`, in this release we with add few updates as described below. Thanks heaps and cc: @peterbom and @rzhang628 ❤️🙏🎊🥷 + fyi @gambtho + @squillace 

Following feature are going out with this release:

* Remove unnecessary kubelogin download.
* Allow development of VS Code-themed webviews using UI toolkit and React framework.
* Update Periscope deployment to latest version.
* Remove deprecated activation events.
* Publish gh.io readme as a vscode documentation.
* Link the GH pages to the Readme doc of this repo.

Thanks heaps.