### PR TITLE
Upgrade ARM resources library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-authorization": "^8.4.1",
                 "@azure/arm-containerservice": "^17.2.0",
                 "@azure/arm-monitor": "^6.0.0",
-                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-subscriptions": "^2.0.1",
                 "@azure/arm-storage": "^15.2.0",
                 "@azure/arm-subscriptions": "^5.0.1",
@@ -127,12 +127,20 @@
             "license": "0BSD"
         },
         "node_modules/@azure/arm-resources": {
-            "version": "3.0.0",
-            "license": "MIT",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.2.0.tgz",
+            "integrity": "sha512-wQyuhL8WQsLkW/KMdik8bLJIJCz3Z6mg/+AKm0KedgK73SKhicSqYP+ed3t+43tLlRFltcrmGKMcHLQ+Jhv/6A==",
             "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid": {
@@ -162,10 +170,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "node_modules/@azure/arm-resources/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
         },
         "node_modules/@azure/arm-storage": {
             "version": "15.2.0",
@@ -227,9 +231,9 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.1.tgz",
-            "integrity": "sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
+            "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -240,7 +244,7 @@
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/core-client/node_modules/@azure/core-tracing": {
@@ -309,16 +313,17 @@
             }
         },
         "node_modules/@azure/core-lro": {
-            "version": "2.2.0",
-            "license": "MIT",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.4.tgz",
+            "integrity": "sha512-3GJiMVH7/10bulzOKGrrLeG/uCBH/9VtxqaMcB9lIqAeamI/xYQSHJL/KcsLDuH+yTjYpro/u6D/MuRe4dN70Q==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-util": "^1.2.0",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/core-paging": {
@@ -406,13 +411,15 @@
             }
         },
         "node_modules/@azure/core-util": {
-            "version": "1.0.0",
-            "license": "MIT",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
+            "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
             "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/identity": {
@@ -801,22 +808,6 @@
                 "semver": "^7.3.7",
                 "uuid": "^8.3.2",
                 "vscode-nls": "^5.0.1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-resources": {
-            "version": "5.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@azure/arm-resources-subscriptions": {
@@ -6889,16 +6880,17 @@
             }
         },
         "@azure/arm-resources": {
-            "version": "3.0.0",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.2.0.tgz",
+            "integrity": "sha512-wQyuhL8WQsLkW/KMdik8bLJIJCz3Z6mg/+AKm0KedgK73SKhicSqYP+ed3t+43tLlRFltcrmGKMcHLQ+Jhv/6A==",
             "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1"
-                }
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
+                "tslib": "^2.2.0"
             }
         },
         "@azure/arm-resources-profile-2020-09-01-hybrid": {
@@ -6977,9 +6969,9 @@
             }
         },
         "@azure/core-client": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.6.1.tgz",
-            "integrity": "sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
+            "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -7043,10 +7035,12 @@
             }
         },
         "@azure/core-lro": {
-            "version": "2.2.0",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.4.tgz",
+            "integrity": "sha512-3GJiMVH7/10bulzOKGrrLeG/uCBH/9VtxqaMcB9lIqAeamI/xYQSHJL/KcsLDuH+yTjYpro/u6D/MuRe4dN70Q==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/core-util": "^1.2.0",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             }
@@ -7113,8 +7107,11 @@
             }
         },
         "@azure/core-util": {
-            "version": "1.0.0",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
+            "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
             "requires": {
+                "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
             }
         },
@@ -7403,18 +7400,6 @@
                 "vscode-nls": "^5.0.1"
             },
             "dependencies": {
-                "@azure/arm-resources": {
-                    "version": "5.0.1",
-                    "requires": {
-                        "@azure/abort-controller": "^1.0.0",
-                        "@azure/core-auth": "^1.3.0",
-                        "@azure/core-client": "^1.5.0",
-                        "@azure/core-lro": "^2.2.0",
-                        "@azure/core-paging": "^1.2.0",
-                        "@azure/core-rest-pipeline": "^1.8.0",
-                        "tslib": "^2.2.0"
-                    }
-                },
                 "@azure/arm-resources-subscriptions": {
                     "version": "1.0.1",
                     "requires": {

--- a/package.json
+++ b/package.json
@@ -544,7 +544,7 @@
         "@azure/arm-authorization": "^8.4.1",
         "@azure/arm-containerservice": "^17.2.0",
         "@azure/arm-monitor": "^6.0.0",
-        "@azure/arm-resources": "^3.0.0",
+        "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-subscriptions": "^2.0.1",
         "@azure/arm-storage": "^15.2.0",
         "@azure/arm-subscriptions": "^5.0.1",

--- a/src/azure-api-utils.ts
+++ b/src/azure-api-utils.ts
@@ -1,15 +1,3 @@
-export interface PartialList<T> extends Array<T> {
-    nextLink?: string;
-}
-
-export async function listAll<T>(client: { listNext(nextPageLink: string): Promise<PartialList<T>>; }, first: Promise<PartialList<T>>): Promise<T[]> {
-    const all: T[] = [];
-    for (let list = await first; list.length || list.nextLink; list = list.nextLink ? await client.listNext(list.nextLink) : []) {
-        all.push(...list);
-    }
-    return all;
-}
-
 export function parseResource(armId: string): { resourceGroupName: string | undefined, name: string | undefined } {
     const bits = armId.split('/');
     const resourceGroupName = bitAfter(bits, 'resourceGroups');

--- a/src/commands/utils/detectors.ts
+++ b/src/commands/utils/detectors.ts
@@ -1,9 +1,9 @@
-import { ResourceManagementClient } from "@azure/arm-resources";
 import { Errorable, combine, failed, getErrorMessage } from "./errorable";
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DetectorTypes } from "../../webview-contract/webviewTypes";
+import { getResourceManagementClient } from "./clusters";
 const tmp = require('tmp');
 const meta = require('../../../package.json');
 
@@ -72,9 +72,9 @@ export async function getDetectorInfo(
     detectorName: string
 ): Promise<Errorable<DetectorTypes.ARMResponse<any>>> {
     try {
-        const client = new ResourceManagementClient(target.subscription.credentials, target.subscription.subscriptionId, { noRetryPolicy: true });
-    // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
-    const resourceGroup = target.armId.split("/")[4];
+        const client = getResourceManagementClient(target);
+        // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
+        const resourceGroup = target.armId.split("/")[4];
         const detectorInfo = await client.resources.get(
             resourceGroup, target.resourceType,
             target.name, "detectors", detectorName, "2019-08-01");

--- a/src/tree/aksClusterTreeItem.ts
+++ b/src/tree/aksClusterTreeItem.ts
@@ -1,9 +1,9 @@
 import { AzExtParentTreeItem, AzExtTreeItem , ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { CloudExplorerV1 } from "vscode-kubernetes-tools-api";
 import { Subscription } from '@azure/arm-subscriptions';
-import { Resource } from "@azure/arm-resources/esm/models";
 import { assetUri } from "../assets";
 import { parseResource } from "../azure-api-utils";
+import { Resource } from "@azure/arm-resources";
 
 // The de facto API of tree nodes that represent individual AKS clusters.
 // Tree items should implement this interface to maintain backward compatibility with previous versions of the extension.


### PR DESCRIPTION
This upgrades the `@azure/arm-resources` library to the latest version, which has support for creating a client with a specified ARM endpoint (as we do for the Container Services client).

This cleans up some client code because the newer libraries have better support for paged enumeration of resources. It also identified places where we were creating these clients directly rather than using our library function, so we are no always creating them in the same way.

The `clusters.ts` file is also cleaned up a little, so that the same functions can be called to create both `ResourceManagerClient` and `ContainerServicesClient` objects, without needing separate functions depending on whether you're starting from a subscription or a cluster.