### PR TITLE
Feature customise kubectl command

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,6 +267,10 @@
             {
                 "command": "aks.createCluster",
                 "title": "Create Standard Cluster"
+            },
+            {
+                "command": "aks.aksCustomKubectlCommand",
+                "title": "Run Custom Kubectl Command"
             }
         ],
         "menus": {
@@ -413,6 +417,10 @@
                 },
                 {
                     "command": "aks.aksKubectlGetEventsCommands",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.aksCustomKubectlCommand",
                     "group": "navigation"
                 }
             ],

--- a/src/commands/aksKubectlCommands/aksCustomiseKubectlCommand.ts
+++ b/src/commands/aksKubectlCommands/aksCustomiseKubectlCommand.ts
@@ -2,6 +2,7 @@ import { createInputBoxStep, runMultiStepInput } from '../../multistep-helper/mu
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { Errorable } from '../utils/errorable';
 import { aksKubectlCommands } from './aksKubectlCommands';
+import * as vscode from 'vscode';
 
 interface State {
     clusterkubectlcommand: string;
@@ -17,7 +18,7 @@ export default async function aksCustomKubectlCommand(
     const clusterKubectlCommandStep = createInputBoxStep<State>({
         shouldResume: () => Promise.resolve(false),
         getValue: () => '',
-        prompt: 'Please enter the Kubectl command to run against the cluster \n Please make sure only follwogin Arguments are progivded ratehr then typing kubectl for example if command is `kubectl get pods` then only type `get pods`',
+        prompt: 'Please enter the Kubectl command to run against the cluster. \n Please make sure only arguments following kubectl command are provivded rather then typing kubectl. \n For example if command is kubectl get pods then only type get pods',
         validate: validateAKSKubectlClusterCommand,
         storeValue: (state, value) => ({...state, clusterkubectlcommand: value})
     });
@@ -30,7 +31,11 @@ export default async function aksCustomKubectlCommand(
         return;
     }
 
-    aksKubectlCommands(_context, target, state.clusterkubectlcommand);
+    const answer = await vscode.window.showInformationMessage(`Do you want to run command: kubectl ${state.clusterkubectlcommand}, against your AKS cluster.`, "Yes", "No");
+
+    if (answer === "Yes") {
+        aksKubectlCommands(_context, target, state.clusterkubectlcommand);
+    }
 
 }
 

--- a/src/commands/aksKubectlCommands/aksCustomiseKubectlCommand.ts
+++ b/src/commands/aksKubectlCommands/aksCustomiseKubectlCommand.ts
@@ -1,0 +1,43 @@
+import { createInputBoxStep, runMultiStepInput } from '../../multistep-helper/multistep-helper';
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { Errorable } from '../utils/errorable';
+import { aksKubectlCommands } from './aksKubectlCommands';
+
+interface State {
+    clusterkubectlcommand: string;
+}
+
+/**
+ * A single-step input for enabling custom kubectl command.
+ */
+export default async function aksCustomKubectlCommand(
+    _context: IActionContext,
+    target: any
+): Promise<void> {
+    const clusterKubectlCommandStep = createInputBoxStep<State>({
+        shouldResume: () => Promise.resolve(false),
+        getValue: () => '',
+        prompt: 'Please enter the Kubectl command to run against the cluster \n Please make sure only follwogin Arguments are progivded ratehr then typing kubectl for example if command is `kubectl get pods` then only type `get pods`',
+        validate: validateAKSKubectlClusterCommand,
+        storeValue: (state, value) => ({...state, clusterkubectlcommand: value})
+    });
+    
+    const initialState: Partial<State> = {};
+
+    const state = await runMultiStepInput('Run Custom Kubectl Command', initialState, clusterKubectlCommandStep);
+    if (!state) {
+        // Cancelled
+        return;
+    }
+
+    aksKubectlCommands(_context, target, state.clusterkubectlcommand);
+
+}
+
+async function validateAKSKubectlClusterCommand(command: string): Promise<Errorable<void>> {
+    if (command.trim().length == 0) {
+        return { succeeded: false, error: 'Invalid AKS Cluster Kubectl Command.' };
+    }
+
+    return { succeeded: true, result: undefined };
+}

--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -81,7 +81,7 @@ export async function aksKubectlK8sReadyzAPIEndpointCommands(
   await aksKubectlCommands(_context, target, command);
 }
 
-async function aksKubectlCommands(
+export async function aksKubectlCommands(
   _context: IActionContext,
   target: any,
   command: string

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
 import { aksInspektorGadgetDeploy, aksInspektorGadgetProfileCPU, aksInspektorGadgetSnapshotProcess, aksInspektorGadgetSnapshotSocket, aksInspektorGadgetTopBlockIO, aksInspektorGadgetTopEBPF, aksInspektorGadgetTopFile, aksInspektorGadgetTopTCP, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
 import aksCreateCluster from './commands/aksCreateCluster/aksCreateCluster';
+import aksCustomKubectlCommand from './commands/aksKubectlCommands/aksCustomiseKubectlCommand';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -89,6 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotProcess', aksInspektorGadgetSnapshotProcess);
         registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotSocket', aksInspektorGadgetSnapshotSocket);
         registerCommandWithTelemetry('aks.createCluster', aksCreateCluster);
+        registerCommandWithTelemetry('aks.aksCustomKubectlCommand', aksCustomKubectlCommand);
 
         await registerAzureServiceNodes(context);
 


### PR DESCRIPTION
This is moving forward PR which is written with an intent to make part way progress on #222 

As part 1 - of this - the PR enables any user input kubectl command against their `aks` cluster. 

As a build up work, next we can do is to build a `kubectlfile.aks` file where user can add their list of `kubectl` commands and we can add a parser to hook so that we can read the input of that file and execute and record result for the user.

Current custom behaviour will look like this. 🙏☕️❤️ thank you so much as always.

<img width="495" alt="Screenshot 2023-09-04 at 11 38 35 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/546fafa6-2727-4443-8a6d-ba1df8f6b5d0">


<img width="880" alt="Screenshot 2023-09-04 at 11 43 44 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/6930ac7a-47c5-4c3a-80e1-7ea9ce94f269">



<img width="570" alt="Screenshot 2023-09-04 at 1 42 54 PM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/c3b9c155-910f-4304-af4d-5a76eef8747a">


<img width="1327" alt="Screenshot 2023-09-04 at 11 44 16 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/402fda0a-4a77-42e9-a735-45bf96189164">




