### PR TITLE
Run Inspektor Gadget commands from webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "js-yaml": "^3.14.0",
                 "move-file": "^3.0.0",
                 "neverthrow": "^4.3.0",
+                "rxjs": "^7.8.0",
                 "semver": "^7.3.7",
                 "sinon": "^12.0.1",
                 "tmp": "^0.2.1",
@@ -61,7 +62,7 @@
                 "mocha": "^9.0.2",
                 "sinon": "^12.0.1",
                 "ts-loader": "^9.4.1",
-                "typescript": "^3.9.10",
+                "typescript": "^4.9.5",
                 "webpack": "^5.75.0",
                 "webpack-cli": "^4.10.0"
             },
@@ -5728,6 +5729,14 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "license": "MIT"
@@ -6273,8 +6282,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.0",
-            "license": "0BSD"
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -6313,9 +6323,10 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.9.10",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6347,8 +6358,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.1",
-            "license": "MIT"
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "node_modules/universalify": {
             "version": "0.1.2",
@@ -10631,6 +10643,14 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "rxjs": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2"
         },
@@ -10987,7 +11007,9 @@
             }
         },
         "tslib": {
-            "version": "2.4.0"
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "tunnel": {
             "version": "0.0.6"
@@ -11007,7 +11029,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.9.10",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "uglify-js": {
@@ -11025,7 +11049,9 @@
             }
         },
         "underscore": {
-            "version": "1.13.1"
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "universalify": {
             "version": "0.1.2"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.12.1",
+                    "default": "v0.19.0",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 }
@@ -229,40 +229,8 @@
                 "title": "Readyz check"
             },
             {
-                "command": "aks.aksInspektorGadgetDeploy",
-                "title": "Deploy"
-            },
-            {
-                "command": "aks.aksInspektorGadgetUnDeploy",
-                "title": "Undeploy"
-            },
-            {
-                "command": "aks.aksInspektorGadgetTopTCP",
-                "title": "Top TCP"
-            },
-            {
-                "command": "aks.aksInspektorGadgetTopEBPF",
-                "title": "Top eBPF"
-            },
-            {
-                "command": "aks.aksInspektorGadgetTopBlockIO",
-                "title": "Top BlockIO"
-            },
-            {
-                "command": "aks.aksInspektorGadgetTopFile",
-                "title": "Top File"
-            },
-            {
-                "command": "aks.aksInspektorGadgetProfileCPU",
-                "title": "Profile CPU"
-            },
-            {
-                "command": "aks.aksInspektorGadgetSnapshotProcess",
-                "title": "Snapshot Process"
-            },
-            {
-                "command": "aks.aksInspektorGadgetSnapshotSocket",
-                "title": "Snapshot Socket"
+                "command": "aks.aksInspektorGadgetShow",
+                "title": "Show Inspektor Gadget"
             },
             {
                 "command": "aks.createCluster",
@@ -335,7 +303,7 @@
                     "group": "9@3"
                 },
                 {
-                    "submenu": "aks.inspektorGadgetSubMenu",
+                    "command": "aks.aksInspektorGadgetShow",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i || view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster$/i",
                     "group": "9@4"
                 }
@@ -447,68 +415,6 @@
                     "command": "aks.aksKubectlK8sReadyzAPIEndpointCommands",
                     "group": "navigation"
                 }
-            ],
-            "aks.inspektorGadgetSubMenu": [
-                {
-                    "command": "aks.aksInspektorGadgetDeploy",
-                    "group": "navigation"
-                },
-                {
-                    "command": "aks.aksInspektorGadgetUnDeploy",
-                    "group": "navigation"
-                },
-                {
-                    "submenu": "aks.inspektorGadgetCommandsSubMenu",
-                    "group": "navigation"
-                }
-            ],
-            "aks.inspektorGadgetCommandsSubMenu": [
-                {
-                    "submenu": "aks.inspektorGadgetTopCommandSubMenu",
-                    "group": "navigation"
-                },
-                {
-                    "submenu": "aks.inspektorGadgetProfileCommandSubMenu",
-                    "group": "navigation"
-                },
-                {
-                    "submenu": "aks.inspektorGadgetSnapshotCommandSubMenu",
-                    "group": "navigation"
-                }
-            ],
-            "aks.inspektorGadgetTopCommandSubMenu": [
-                {
-                    "command": "aks.aksInspektorGadgetTopTCP",
-                    "group": "navigation"
-                },
-                {
-                    "command": "aks.aksInspektorGadgetTopEBPF",
-                    "group": "navigation"
-                },
-                {
-                    "command": "aks.aksInspektorGadgetTopBlockIO",
-                    "group": "navigation"
-                },
-                {
-                    "command": "aks.aksInspektorGadgetTopFile",
-                    "group": "navigation"
-                }
-            ],
-            "aks.inspektorGadgetProfileCommandSubMenu": [
-                {
-                    "command": "aks.aksInspektorGadgetProfileCPU",
-                    "group": "navigation"
-                }
-            ],
-            "aks.inspektorGadgetSnapshotCommandSubMenu": [
-                {
-                    "command": "aks.aksInspektorGadgetSnapshotProcess",
-                    "group": "navigation"
-                },
-                {
-                    "command": "aks.aksInspektorGadgetSnapshotSocket",
-                    "group": "navigation"
-                }
             ]
         },
         "submenus": [
@@ -531,26 +437,6 @@
             {
                 "id": "aks.K8sAPIEndpointHealthCheck",
                 "label": "Kubernetes API Health Endpoints"
-            },
-            {
-                "id": "aks.inspektorGadgetSubMenu",
-                "label": "Inspektor Gadget"
-            },
-            {
-                "id": "aks.inspektorGadgetCommandsSubMenu",
-                "label": "Gadget Commands"
-            },
-            {
-                "id": "aks.inspektorGadgetTopCommandSubMenu",
-                "label": "Top Commands"
-            },
-            {
-                "id": "aks.inspektorGadgetProfileCommandSubMenu",
-                "label": "Profile Commands"
-            },
-            {
-                "id": "aks.inspektorGadgetSnapshotCommandSubMenu",
-                "label": "Snapshot Commands"
             },
             {
                 "id": "aks.createClusterSubMenu",
@@ -587,7 +473,7 @@
         "mocha": "^9.0.2",
         "sinon": "^12.0.1",
         "ts-loader": "^9.4.1",
-        "typescript": "^3.9.10",
+        "typescript": "^4.9.5",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0"
     },
@@ -620,6 +506,7 @@
         "js-yaml": "^3.14.0",
         "move-file": "^3.0.0",
         "neverthrow": "^4.3.0",
+        "rxjs": "^7.8.0",
         "semver": "^7.3.7",
         "sinon": "^12.0.1",
         "tmp": "^0.2.1",

--- a/src/commands/aksInspektorGadget/aksInspektorGadget.ts
+++ b/src/commands/aksInspektorGadget/aksInspektorGadget.ts
@@ -1,93 +1,20 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getKubernetesClusterInfo, KubernetesClusterInfo } from '../utils/clusters';
-import { getExtensionPath, longRunning } from '../utils/host';
-import { Errorable, failed } from '../utils/errorable';
+import { getKubernetesClusterInfo } from '../utils/clusters';
+import { getExtension } from '../utils/host';
+import { failed } from '../utils/errorable';
 import * as tmpfile from '../utils/tempfile';
 import { getKubectlGadgetBinaryPath } from '../utils/helper/kubectlGadgetDownload';
-import { invokeKubectlCommand } from '../utils/kubectl';
 import path = require('path');
-import { createWebView, getRenderedContent, getResourceUri } from '../utils/webviews';
+import { InspektorGadgetDataProvider, InspektorGadgetPanel } from '../../panels/InspektorGadgetPanel';
+import { KubectlClusterOperations } from './clusterOperations';
+import { TraceWatcher } from './traceWatcher';
+import { ensureDirectoryInPath } from '../utils/env';
 
-enum Command {
-    Deploy,
-    Undeploy,
-    TopTCP,
-    TopEBPF,
-    TopBlockIO,
-    TopFile,
-    ProfileCPU,
-    SnapshotProcess,
-    SnapshotSocket
-}
-
-export async function aksInspektorGadgetDeploy(
+export async function aksInspektorGadgetShow(
     _context: IActionContext,
     target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.Deploy)
-}
-
-export async function aksInspektorGadgetUnDeploy(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.Undeploy);
-}
-
-export async function aksInspektorGadgetTopTCP(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.TopTCP);
-}
-
-export async function aksInspektorGadgetTopEBPF(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.TopEBPF);
-}
-
-export async function aksInspektorGadgetTopBlockIO(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.TopBlockIO);
-}
-
-export async function aksInspektorGadgetTopFile(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.TopFile);
-}
-
-export async function aksInspektorGadgetProfileCPU(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.ProfileCPU);
-}
-
-export async function aksInspektorGadgetSnapshotProcess(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.SnapshotProcess);
-}
-
-export async function aksInspektorGadgetSnapshotSocket(
-    _context: IActionContext,
-    target: any
-): Promise<void> {
-    await checkTargetAndRunGadgetCommand(target, Command.SnapshotSocket);
-}
-
-async function checkTargetAndRunGadgetCommand(
-    target: any,
-    cmd: Command
 ): Promise<void> {
     const kubectl = await k8s.extension.kubectl.v1;
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -95,212 +22,45 @@ async function checkTargetAndRunGadgetCommand(
 
     if (!kubectl.available) {
         vscode.window.showWarningMessage(`Kubectl is unavailable.`);
-        return undefined;
+        return;
     }
 
     if (!cloudExplorer.available) {
         vscode.window.showWarningMessage(`Cloud explorer is unavailable.`);
-        return undefined;
+        return;
     }
 
     if (!clusterExplorer.available) {
         vscode.window.showWarningMessage(`Cluster explorer is unavailable.`);
-        return undefined;
+        return;
     }
 
     const clusterInfo = await getKubernetesClusterInfo(target, cloudExplorer, clusterExplorer);
     if (failed(clusterInfo)) {
         vscode.window.showErrorMessage(clusterInfo.error);
-        return undefined;
+        return;
     }
-
-    await runGadgetCommand(clusterInfo.result, cmd, kubectl);
-}
-
-async function runGadgetCommand(
-    clusterInfo: KubernetesClusterInfo,
-    cmd: Command,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>
-): Promise<void> {
-    const clustername = clusterInfo.name;
-    const kubeconfig = clusterInfo.kubeconfigYaml;
-
-    switch (cmd) {
-        case Command.Deploy:
-            await deployGadget(clustername, kubeconfig, kubectl);
-            return;
-        case Command.Undeploy:
-            const answer = await vscode.window.showInformationMessage(`Do you want to undeploy Inspektor Gadget in ${clustername}?`, "Yes", "No");
-            if (answer === "Yes") {
-                await unDeployGadget(clustername, kubeconfig, kubectl);
-            }
-            return;
-        case Command.TopTCP:
-            await topTCPGadget(clustername, kubeconfig, kubectl);
-            return;
-        case Command.TopEBPF:
-            await topEBPFGadget(clustername, kubeconfig, kubectl);
-            return;
-        case Command.TopBlockIO:
-            await topBlockIOGadget(clustername, kubeconfig, kubectl);
-            return;
-        case Command.TopFile:
-            await topFile(clustername, kubeconfig, kubectl);
-            return;
-        case Command.ProfileCPU:
-            await profileCPU(clustername, kubeconfig, kubectl);
-            return;
-        case Command.SnapshotProcess:
-            await snapshotProcess(clustername, kubeconfig, kubectl);
-            return;
-        case Command.SnapshotSocket:
-            await snapshotSocket(clustername, kubeconfig, kubectl);
-            return;
-    }
-}
-
-async function deployGadget(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "deploy";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function unDeployGadget(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "undeploy";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function topTCPGadget(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "top tcp 30 --all-namespaces --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function topEBPFGadget(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "top ebpf 30 --all-namespaces --sort cumulruntime --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function topBlockIOGadget(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "top block-io 30 --all-namespaces --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function topFile(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "top file 30 --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-async function profileCPU(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "profile cpu --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function snapshotProcess(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "snapshot process --all-namespaces 30 --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function snapshotSocket(
-    clustername: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
-    const command = "snapshot socket --all-namespaces 30 --timeout 30";
-
-    return await runKubectlGadgetCommands(clustername, command, clusterConfig, kubectl);
-}
-
-async function runKubectlGadgetCommands(
-    clustername: string,
-    command: string,
-    clusterConfig: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>) {
 
     const kubectlGadgetPath = await getKubectlGadgetBinaryPath();
-
     if (failed(kubectlGadgetPath)) {
         vscode.window.showWarningMessage(`kubectl gadget path was not found ${kubectlGadgetPath.error}`);
         return;
     }
 
-    const extensionPath = getExtensionPath();
+    ensureDirectoryInPath(path.dirname(kubectlGadgetPath.result));
 
-    if (failed(extensionPath)) {
-        vscode.window.showErrorMessage(extensionPath.error);
+    const extension = getExtension();
+    if (failed(extension)) {
+        vscode.window.showErrorMessage(extension.error);
         return;
     }
 
-    return await longRunning(`Running kubectl gadget command on ${clustername}`,
-        async () => {
-            const commandToRun = `gadget ${command}`;
-            const binaryPathDir = path.dirname(kubectlGadgetPath.result);
+    const kubeConfigFile = await tmpfile.createTempFile(clusterInfo.result.kubeconfigYaml, "yaml");
+    const clusterOperations = new KubectlClusterOperations(kubectl, clusterInfo.result, kubeConfigFile.filePath);
+    const traceWatcher = new TraceWatcher(clusterOperations, clusterInfo.result.name);
+    const dataProvider = new InspektorGadgetDataProvider(clusterOperations, clusterInfo.result.name, traceWatcher);
+    const panel = new InspektorGadgetPanel(extension.result.extensionUri);
 
-            if (process.env.PATH === undefined) {
-                process.env.PATH = binaryPathDir
-            } else if (process.env.PATH.indexOf(binaryPathDir) < 0) {
-                process.env.PATH = binaryPathDir + path.delimiter + process.env.PATH;
-            }
-
-            const kubectlresult = await tmpfile.withOptionalTempFile<Errorable<k8s.KubectlV1.ShellResult>>(
-                clusterConfig, "YAML", async (kubeConfigFile) => {
-                    return await invokeKubectlCommand(kubectl, kubeConfigFile, commandToRun);
-                });
-
-            if (failed(kubectlresult)) {
-                vscode.window.showWarningMessage(`kubectl gadget command failed with following error: ${kubectlresult.error}`);
-                return;
-            }
-
-            if (kubectlresult.succeeded) {
-                const webview = createWebView('AKS Kubectl Commands', `AKS Kubectl Command view for: ${clustername}`).webview;
-                webview.html = getWebviewContent(kubectlresult.result, commandToRun, extensionPath.result, webview);
-            }
-        }
-    );
-}
-
-function getWebviewContent(
-    clusterdata: k8s.KubectlV1.ShellResult,
-    commandRun: string,
-    vscodeExtensionPath: string,
-    webview: vscode.Webview
-): string {
-    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
-    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'aksKubectlCommand', 'akskubectlcommand.html');
-    const data = {
-        cssuri: styleUri,
-        name: commandRun,
-        command: clusterdata.stdout,
-    };
-
-    return getRenderedContent(templateUri, data);
+    // Pass the disposables into the `show` method so that they get disposed when the panel is closed.
+    panel.show(dataProvider, kubeConfigFile, traceWatcher);
 }

--- a/src/commands/aksInspektorGadget/clusterOperations.ts
+++ b/src/commands/aksInspektorGadget/clusterOperations.ts
@@ -1,0 +1,118 @@
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { Errorable, map as errmap, bindAsync, bindAll } from '../utils/errorable';
+import { invokeKubectlCommand, streamKubectlOutput } from '../utils/kubectl';
+import { KubernetesClusterInfo } from '../utils/clusters';
+import { OutputStream } from '../utils/commands';
+import { asFlatItems, parseOutputLine } from './traceItems';
+import { GadgetArguments, GadgetVersion, NamespaceSelection, TraceOutputItem } from '../../webview-contract/webviewDefinitions/inspektorGadget';
+
+export interface ClusterOperations {
+    getGadgetVersion(): Promise<Errorable<GadgetVersion>>;
+    deploy(): Promise<Errorable<GadgetVersion>>;
+    undeploy(): Promise<Errorable<GadgetVersion>>;
+    runTrace(gadgetArgs: GadgetArguments): Promise<Errorable<TraceOutputItem[]>>;
+    watchTrace(gadgetArgs: GadgetArguments): Promise<Errorable<OutputStream>>;
+    getNodes(): Promise<Errorable<string[]>>;
+    getNamespaces(): Promise<Errorable<string[]>>;
+    getPods(namespace: string): Promise<Errorable<string[]>>;
+    getContainers(namespace: string, podName: string): Promise<Errorable<string[]>>;
+}
+
+export class KubectlClusterOperations implements ClusterOperations {
+    constructor(
+        readonly kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+        readonly clusterInfo: KubernetesClusterInfo,
+        readonly kubeConfigFile: string
+    ) { }
+
+    async getGadgetVersion(): Promise<Errorable<GadgetVersion>> {
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, "gadget version");
+
+        function setNullIfNotInstalled(version: string) {
+            return version === "not installed" ? null : version;
+        }
+
+        return errmap(commandResult, sr => {
+            const lines = sr.stdout.split('\n').filter(l => l.trim().length);
+            return {
+                client: lines[0].replace(/^Client\sversion:\s*/, ''),
+                server: setNullIfNotInstalled(lines[1].replace(/^Server\sversion:\s*/, ''))
+            };
+        });
+    }
+
+    async deploy(): Promise<Errorable<GadgetVersion>> {
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, "gadget deploy");
+        return bindAsync(commandResult, _ => this.getGadgetVersion());
+    }
+
+    async undeploy(): Promise<Errorable<GadgetVersion>> {
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, "gadget undeploy");
+        return bindAsync(commandResult, _ => this.getGadgetVersion());
+    }
+
+    async runTrace(gadgetArguments: GadgetArguments): Promise<Errorable<TraceOutputItem[]>> {
+        const command = this._getKubectlArgs(gadgetArguments).join(' ');
+        const shellResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
+        const linesResult = errmap(shellResult, r => r.stdout.split('\n'));
+        const arraysResult = bindAll(linesResult, parseOutputLine);
+        return errmap(arraysResult, arrays => arrays.flatMap(arrays => arrays).flatMap(asFlatItems));
+    }
+
+    watchTrace(gadgetArguments: GadgetArguments): Promise<Errorable<OutputStream>> {
+        const args = this._getKubectlArgs(gadgetArguments);
+        return streamKubectlOutput(this.kubectl, this.kubeConfigFile, args);
+    }
+
+    private _getKubectlArgs(args: GadgetArguments): string[] {
+        const pluginCommand = ["gadget", args.gadgetCategory, args.gadgetResource, "--output", "json"];
+        const nodeNameFilter = args.filters.nodeName ? ["--node", args.filters.nodeName] : [];
+        const namespaceFilter =
+            args.filters.namespace === NamespaceSelection.Default ? [] :
+            args.filters.namespace === NamespaceSelection.All ? ["--all-namespaces"] :
+            ["--namespace", args.filters.namespace];
+        const podFilter = args.filters.podName ? ["--podname", args.filters.podName] : [];
+        const containerFilter = args.filters.containerName ? ["--containername", args.filters.containerName] : [];
+        const labelFilter = args.filters.labels ? ["--selector", Object.entries(args.filters.labels).map(kv => `${kv[0]}=${kv[1]}`).join(',')] : [];
+        const sort = args.sortString ? ["--sort", args.sortString] : [];
+        const limit = args.maxRows ? ["--max-rows", args.maxRows.toString()] : [];
+        const interval = args.interval ? ["--interval", args.interval.toString()] : [];
+        const timeout = args.timeout ? ["--timeout", args.timeout.toString()] : [];
+        return [
+            ...pluginCommand,
+            ...nodeNameFilter,
+            ...namespaceFilter,
+            ...podFilter,
+            ...containerFilter,
+            ...labelFilter,
+            ...sort,
+            ...limit,
+            ...interval,
+            ...timeout
+        ];
+    }
+
+    async getNodes(): Promise<Errorable<string[]>> {
+        const command = `get node --no-headers -o custom-columns=":metadata.name"`;
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
+        return errmap(commandResult, sr => sr.stdout.trim().split("\n"));
+    }
+
+    async getNamespaces(): Promise<Errorable<string[]>> {
+        const command = `get ns --no-headers -o custom-columns=":metadata.name"`;
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
+        return errmap(commandResult, sr => sr.stdout.trim().split("\n"));
+    }
+
+    async getPods(namespace: string): Promise<Errorable<string[]>> {
+        const command = `get pod -n ${namespace} --no-headers -o custom-columns=":metadata.name"`;
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
+        return errmap(commandResult, sr => sr.stdout.trim().split("\n"));
+    }
+
+    async getContainers(namespace: string, podName: string): Promise<Errorable<string[]>> {
+        const command = `get pod -n ${namespace} ${podName} -o jsonpath={.spec.containers[*].name}`;
+        const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
+        return errmap(commandResult, sr => sr.stdout.trim().split(" "));
+    }
+}

--- a/src/commands/aksInspektorGadget/traceItems.ts
+++ b/src/commands/aksInspektorGadget/traceItems.ts
@@ -1,0 +1,77 @@
+import { TraceOutputItem } from "../../webview-contract/webviewDefinitions/inspektorGadget";
+import { Errorable, map as errmap } from "../utils/errorable";
+import { parseJson } from "../utils/json";
+
+// The keys of values which should be serialized as JSON, rather than flattened or spread into separate
+// objects (see `asFlatItems`).
+const jsonKeys = ["userStack", "kernelStack", "addresses", "args"];
+
+/**
+ * Takes IG output and converts it to an array of (unflattened) objects.
+ * The JSON may be a single object or an array, but this will always return an array.
+ * @param line A line from stdout which is assumed to be JSON.
+ * @returns An array of objects.
+ */
+export function parseOutputLine(line: string): Errorable<object[]> {
+    line = line.trim();
+    if (!line) {
+        return { succeeded: true, result: [] };
+    }
+
+    const objectOrArray = parseJson<object | object[]>(line);
+    return errmap(objectOrArray, objOrArray => isArray(objOrArray) ? objOrArray as object[] : [objOrArray as object]);
+}
+
+/**
+ * Flattens complex objects into ones that can be read with simple property lookups. This involves two transformations:
+ * - Nested objects are flattened, e.g.:
+ *   {a: 1, b: {c: 2, d: 3}}   ===>   {a: 1, "b.c": 2, "b.d": 3}
+ * - Arrays are spread out into multiple objects, e.g.:
+ *   {a: [1,2]}   ===>   [{a: 1}, {b: 2}]
+ *   {processes: [{pid: 1, comm: "a"}, {pid: 2, comm: "b"}]}   ===>   [{"processes.pid": 1, "processes.comm": "a"}, {"processes.pid": 2, "processes.comm": "b"}]
+ * @param item An item read from the `gadgettracermanager` process.
+ * @returns An array of objects that contain no nested objects or arrays for consumption by the webview presentation layer.
+ */
+export function asFlatItems(item: object): TraceOutputItem[] {
+    const allObjectEntries = Object.entries(item).reduce(addFlatEntries, [[]]);
+    return allObjectEntries.map(objectEntries => Object.fromEntries(objectEntries));
+}
+
+export function isObject(value: any) {
+    return value !== null ? value.constructor.name === 'Object' : false;
+}
+
+export function isArray(value: any) {
+    return value !== null ? value.constructor.name === 'Array' : false;
+}
+
+type ObjectEntry = [string, any];
+type ObjectEntries = ObjectEntry[];
+type MultiObjectEntries = ObjectEntries[];
+
+// Function for folding/reducing an object's properties into a collection of flattened property entries.
+function addFlatEntries(allObjectEntries: MultiObjectEntries, entry: ObjectEntry): MultiObjectEntries {
+    const [key, value] = entry;
+
+    if (jsonKeys.includes(key)) {
+        // Add an entry where the value is a JSON string.
+        return allObjectEntries.map(objectEntries => [...objectEntries, [key, JSON.stringify(value)]]);
+    }
+
+    if (isArray(value)) {
+        // Create new target objects for every item in the array.
+        // To each of those we add all the existing properties, as well as the array item properties.
+        return (value as any[]).flatMap(val => addFlatEntries(allObjectEntries, [key, val]));
+    }
+
+    if (isObject(value)) {
+        // Add entries for each of this object's properties, to each of the target objects,
+        // making sure to prepend the parent key, e.g.:
+        // [key, {subkey: 1}] ==> ["key.subkey": 1]
+        const prependKey: (e: ObjectEntry) => ObjectEntry = e => [`${key}.${e[0]}`, e[1]];
+        return Object.entries(value).map(prependKey).reduce(addFlatEntries, allObjectEntries);
+    }
+
+    // This is a simple property. Append an entry for this to every target object.
+    return allObjectEntries.map(objectEntries => [...objectEntries, [key, value]]);
+}

--- a/src/commands/aksInspektorGadget/traceWatcher.ts
+++ b/src/commands/aksInspektorGadget/traceWatcher.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+import { Errorable, failed, map as errmap } from '../utils/errorable';
+import { Observable, Subscription, filter, map as rxmap } from 'rxjs';
+import { ClusterOperations } from './clusterOperations';
+import { asFlatItems, parseOutputLine } from './traceItems';
+import { OutputStream } from '../utils/commands';
+import { GadgetArguments, TraceOutputItem } from '../../webview-contract/webviewDefinitions/inspektorGadget';
+
+export class TraceWatcher extends vscode.Disposable {
+    private _currentTraceOutput: TraceOutput | null = null;
+    private _outputItemsSubscription: Subscription | null = null;
+
+    constructor(
+        readonly clusterOperations: ClusterOperations,
+        readonly clusterName: string
+    ) {
+        super(() => {
+            this.stopWatching();
+        })
+    }
+
+    async watch(
+        gadgetArgs: GadgetArguments,
+        outputItemsHandler: (items: TraceOutputItem[]) => void,
+        errorHandler: (e: Error) => {}
+    ): Promise<Errorable<void>> {
+        this.stopWatching();
+
+        const outputStream = await this.clusterOperations.watchTrace(gadgetArgs);
+        const output = errmap(outputStream, stream => new TraceOutput(stream));
+        if (failed(output)) {
+            return output;
+        }
+
+        this._currentTraceOutput = output.result;
+        this._outputItemsSubscription = output.result.outputItems.subscribe({ next: outputItemsHandler, error: errorHandler });
+
+        return { succeeded: true, result: undefined };
+    }
+
+    stopWatching() {
+        this._currentTraceOutput?.dispose();
+        this._currentTraceOutput = null;
+        this._outputItemsSubscription?.unsubscribe();
+        this._outputItemsSubscription = null;
+    }
+}
+
+class TraceOutput extends vscode.Disposable {
+    constructor(
+        readonly source: OutputStream
+    ) {
+        super(() => {
+            this.source.dispose();
+        });
+
+        this.outputItems = this.source.lines.pipe(filter(line => !!line)).pipe(rxmap(line => this._outputLineToObjects(line)));
+    }
+
+    readonly outputItems: Observable<TraceOutputItem[]>;
+
+    private _outputLineToObjects(line: string): object[] {
+        const items = parseOutputLine(line);
+        if (failed(items)) {
+            throw new Error(`Unable to read streaming trace output: ${items.error}`);
+        }
+
+        return items.result.flatMap(asFlatItems);
+    }
+}

--- a/src/commands/utils/commands.ts
+++ b/src/commands/utils/commands.ts
@@ -1,0 +1,10 @@
+import { Observable } from 'rxjs';
+import { Disposable } from 'vscode';
+
+export class OutputStream extends Disposable {
+    constructor(
+        dispose: () => void,
+        readonly lines: Observable<string>) {
+        super(dispose);
+    }
+}

--- a/src/commands/utils/env.ts
+++ b/src/commands/utils/env.ts
@@ -1,0 +1,9 @@
+import path = require("path");
+
+export function ensureDirectoryInPath(directoryPath: string) {
+    if (process.env.PATH === undefined) {
+        process.env.PATH = directoryPath
+    } else if (process.env.PATH.indexOf(directoryPath) < 0) {
+        process.env.PATH = directoryPath + path.delimiter + process.env.PATH;
+    }
+}

--- a/src/commands/utils/errorable.ts
+++ b/src/commands/utils/errorable.ts
@@ -18,11 +18,53 @@ export function failed<T>(e: Errorable<T>): e is Failed {
     return !e.succeeded;
 }
 
+export function success<T>(item: T): Errorable<T> {
+    return { succeeded: true, result: item };
+}
+
 export function map<T, U>(e: Errorable<T>, fn: (t: T) => U): Errorable<U> {
     if (failed(e)) {
         return { succeeded: false, error: e.error };
     }
     return { succeeded: true, result: fn(e.result) };
+}
+
+export function bind<T, U>(e: Errorable<T>, fn: (t: T) => Errorable<U>): Errorable<U> {
+    if (failed(e)) {
+        return e;
+    }
+    return fn(e.result);
+}
+
+export function bindAsync<T, U>(e: Errorable<T>, fn: (t: T) => Promise<Errorable<U>>): Promise<Errorable<U>> {
+    if (failed(e)) {
+        return Promise.resolve(e);
+    }
+    return fn(e.result);
+}
+
+export function bindAll<T, U>(es: Errorable<T[]>, fn: (t: T) => Errorable<U>): Errorable<U[]> {
+    if (failed(es)) {
+        return es;
+    }
+    return applyAll(es.result, fn);
+}
+
+export function bindAllAsync<T, U>(es: Errorable<T[]>, fn: (t: T) => Promise<Errorable<U>>): Promise<Errorable<U[]>> {
+    if (failed(es)) {
+        return Promise.resolve(es);
+    }
+    return applyAllAsync(es.result, fn);
+}
+
+export function applyAll<T, U>(items: T[], fn: (t: T) => Errorable<U>): Errorable<U[]> {
+    return combine(items.map(fn));
+}
+
+export async function applyAllAsync<T, U>(items: T[], fn: (t: T) => Promise<Errorable<U>>): Promise<Errorable<U[]>> {
+    const promises = items.map(fn);
+    const results = await Promise.all(promises);
+    return combine(results);
 }
 
 export function combine<T>(es: Errorable<T>[]): Errorable<T[]> {
@@ -45,4 +87,9 @@ export function getErrorMessage(error: unknown) {
        return error.message;
     }
     return String(error);
- }
+}
+
+export function findOrError<T>(items: T[], predicate: (value: T, index: number) => boolean, errorMessage: string): Errorable<T> {
+    const foundItem = items.find(predicate);
+    return foundItem ? { succeeded: true, result: foundItem } : { succeeded: false, error: errorMessage };
+}

--- a/src/commands/utils/json.ts
+++ b/src/commands/utils/json.ts
@@ -1,0 +1,10 @@
+import { Errorable, getErrorMessage } from "./errorable";
+
+export function parseJson<T>(input: string): Errorable<T> {
+    try {
+        const result = JSON.parse(input) as T;
+        return { succeeded: true, result };
+    } catch (e) {
+        return { succeeded: false, error: `Error parsing JSON: ${getErrorMessage(e)}\nInput: ${input}` };
+    }
+}

--- a/src/commands/utils/kubectl.ts
+++ b/src/commands/utils/kubectl.ts
@@ -1,5 +1,7 @@
 import { APIAvailable, KubectlV1 } from 'vscode-kubernetes-tools-api';
-import { Errorable } from './errorable';
+import { Errorable, failed, getErrorMessage, map } from './errorable';
+import { OutputStream } from './commands';
+import { Observable, concat, of } from 'rxjs';
 
 export async function invokeKubectlCommand(kubectl: APIAvailable<KubectlV1>, kubeConfigFile: string, command: string): Promise<Errorable<KubectlV1.ShellResult>> {
     // Note: kubeconfig is the last argument because kubectl plugins will not work with kubeconfig in start.
@@ -15,3 +17,94 @@ export async function invokeKubectlCommand(kubectl: APIAvailable<KubectlV1>, kub
     return { succeeded: true, result: shellResult };
 }
 
+export async function getKubectlJsonResult<T>(kubectl: APIAvailable<KubectlV1>, kubeConfigFile: string, command: string): Promise<Errorable<T>> {
+    const shellResult = await invokeKubectlCommand(kubectl, kubeConfigFile, command);
+    if (failed(shellResult)) {
+        return shellResult;
+    }
+
+    const output = shellResult.result.stdout.trim();
+    try {
+        return { succeeded: true, result: JSON.parse(output) as T };
+    }
+    catch (e) {
+        return { succeeded: false, error: `Failed to parse command output as JSON:\n\tError: ${e}\n\tCommand: ${command}\n\tOutput: ${output}` };
+    }
+}
+
+export enum NamespaceType {
+    NotNamespaced,
+    AllNamespaces
+}
+
+export async function getResources<T>(
+    kubectl: APIAvailable<KubectlV1>,
+    kubeConfigFile: string,
+    resourceName: string,
+    namespace: string | NamespaceType,
+    labels: { [label: string]: string } = {}
+): Promise<Errorable<T[]>> {
+    let namespaceFlags: string;
+    switch (namespace) {
+        case NamespaceType.AllNamespaces:
+            namespaceFlags = "-A";
+            break;
+        case NamespaceType.NotNamespaced:
+            namespaceFlags = "";
+            break;
+        default:
+            namespaceFlags = `-n ${namespace}`
+            break;
+    }
+
+    const labelFlags = Object.keys(labels).map(l => `-l ${l}=${labels[l]}`)
+
+    const command = [
+        `get ${resourceName}`,
+        namespaceFlags,
+        labelFlags,
+        "-o json"
+    ].filter(arg => arg).join(" ");
+
+    const listResult = await getKubectlJsonResult<K8sList<T>>(kubectl, kubeConfigFile, command);
+    return map(listResult, r => r.items);
+}
+
+interface K8sList<T> {
+    items: T[]
+}
+
+export async function streamKubectlOutput(kubectl: APIAvailable<KubectlV1>, kubeConfigFile: string, kubectlArgs: string[]): Promise<Errorable<OutputStream>> {
+    const kubectlInternal = <KubectlInternal>(<any>kubectl.api).kubectl;
+
+    // If part of the command is a plugin, the kubeconfig argument must be placed after that,
+    // so we add it at the end here.
+    const args = [...kubectlArgs, "--kubeconfig", kubeConfigFile];
+    const runningProcess = await kubectlInternal.observeCommand(args);
+
+    return new Promise<Errorable<OutputStream>>(resolve => {
+        // Wait until there's some output or an error before completing
+        let running = false;
+        runningProcess.lines.subscribe({
+            next: line => {
+                if (!running) {
+                    running = true;
+                    const observable = concat(of(line), runningProcess.lines);
+                    const disposable = new OutputStream(() => runningProcess.terminate(), observable);
+                    resolve({ succeeded: true, result: disposable });
+                }
+            },
+            error: e => resolve({ succeeded: false, error: `Failed to run 'kubectl ${args.join(' ')}': ${getErrorMessage(e)}` }),
+            complete: () => resolve({ succeeded: true, result: new OutputStream(() => {}, new Observable()) })
+        });
+    });
+}
+
+interface KubectlInternal {
+    observeCommand(args: string[]): Promise<RunningProcess>;
+}
+
+interface RunningProcess {
+    readonly lines: Observable<string>;
+    terminate(): void;
+}

--- a/src/commands/utils/sleep.ts
+++ b/src/commands/utils/sleep.ts
@@ -1,5 +1,5 @@
 export function sleep(ms: number): Promise<void> {
-   return new Promise<void>((resolve) => {
-      setTimeout(resolve, ms);
-   });
+    return new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    });
 }

--- a/src/commands/utils/tempfile.ts
+++ b/src/commands/utils/tempfile.ts
@@ -1,16 +1,36 @@
+import * as vscode from 'vscode';
 import { fs } from './fs';
 const tmp = require('tmp');
 
 export async function withOptionalTempFile<T>(
     content: string,
-    fileType: string,
+    extension: string,
     fn: (filename: string) => Promise<T>): Promise<T> {
-    const tempFile = tmp.fileSync({ prefix: "aks-periscope-", postfix: `.${fileType}` });
-    await fs.writeFile(tempFile.name, content);
+    const tempFile = await createTempFile(content, extension);
 
     try {
-        return await fn(tempFile.name);
+        return await fn(tempFile.filePath);
     } finally {
-        tempFile.removeCallback();
+        tempFile.dispose();
     }
+}
+
+export async function createTempFile(content: string, extension: string): Promise<TempFile> {
+    const tempFile = tmp.fileSync({ prefix: "aks-periscope-", postfix: `.${extension}` });
+    await fs.writeFile(tempFile.name, content);
+    return new TempFile(tempFile);
+}
+
+export class TempFile extends vscode.Disposable {
+    public readonly filePath: string;
+
+    constructor(reference: TempFileReference) {
+        super(() => reference.removeCallback());
+        this.filePath = reference.name;
+    }
+}
+
+interface TempFileReference {
+    name: string
+    removeCallback(): void
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { longRunning } from './commands/utils/host';
 import { getClusterProperties, getKubeconfigYaml } from './commands/utils/clusters';
 import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
-import { aksInspektorGadgetDeploy, aksInspektorGadgetProfileCPU, aksInspektorGadgetSnapshotProcess, aksInspektorGadgetSnapshotSocket, aksInspektorGadgetTopBlockIO, aksInspektorGadgetTopEBPF, aksInspektorGadgetTopFile, aksInspektorGadgetTopTCP, aksInspektorGadgetUnDeploy } from './commands/aksInspektorGadget/aksInspektorGadget';
+import { aksInspektorGadgetShow } from './commands/aksInspektorGadget/aksInspektorGadget';
 import aksCreateCluster from './commands/aksCreateCluster/aksCreateCluster';
 import aksCustomKubectlCommand from './commands/aksKubectlCommands/aksCustomiseKubectlCommand';
 
@@ -80,15 +80,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksKubectlK8sHealthzAPIEndpointCommands', aksKubectlK8sHealthzAPIEndpointCommands);
         registerCommandWithTelemetry('aks.aksKubectlK8sLivezAPIEndpointCommands', aksKubectlK8sLivezAPIEndpointCommands);
         registerCommandWithTelemetry('aks.aksKubectlK8sReadyzAPIEndpointCommands', aksKubectlK8sReadyzAPIEndpointCommands);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetDeploy', aksInspektorGadgetDeploy);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetUnDeploy', aksInspektorGadgetUnDeploy);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetTopTCP', aksInspektorGadgetTopTCP);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetTopEBPF', aksInspektorGadgetTopEBPF);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetTopBlockIO', aksInspektorGadgetTopBlockIO);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetTopFile', aksInspektorGadgetTopFile);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetProfileCPU', aksInspektorGadgetProfileCPU);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotProcess', aksInspektorGadgetSnapshotProcess);
-        registerCommandWithTelemetry('aks.aksInspektorGadgetSnapshotSocket', aksInspektorGadgetSnapshotSocket);
+        registerCommandWithTelemetry('aks.aksInspektorGadgetShow', aksInspektorGadgetShow);
         registerCommandWithTelemetry('aks.createCluster', aksCreateCluster);
         registerCommandWithTelemetry('aks.aksCustomKubectlCommand', aksCustomKubectlCommand);
 

--- a/src/panels/BasePanel.ts
+++ b/src/panels/BasePanel.ts
@@ -107,7 +107,7 @@ class MessageContext<TContent extends ContentId> implements VsCodeMessageContext
 
                 const action = (handler as MessageHandler<MessageDefinition>)[message.command];
                 if (action) {
-                    action(message.parameters);
+                    action(message.parameters, message.command);
                 } else {
                     window.showErrorMessage(`No handler found for command ${message.command}`);
                 }

--- a/src/panels/InspektorGadgetPanel.ts
+++ b/src/panels/InspektorGadgetPanel.ts
@@ -1,0 +1,134 @@
+import * as vscode from "vscode";
+import { BasePanel, PanelDataProvider } from "./BasePanel";
+import { MessageHandler, MessageSink } from "../webview-contract/messaging";
+import { failed, getErrorMessage } from '../commands/utils/errorable';
+import { ClusterOperations } from '../commands/aksInspektorGadget/clusterOperations';
+import { TraceWatcher } from '../commands/aksInspektorGadget/traceWatcher';
+import { GadgetArguments, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef, TraceOutputItem } from "../webview-contract/webviewDefinitions/inspektorGadget";
+
+export class InspektorGadgetPanel extends BasePanel<"gadget"> {
+    constructor(extensionUri: vscode.Uri) {
+        super(extensionUri, "gadget");
+    }
+}
+
+export class InspektorGadgetDataProvider implements PanelDataProvider<"gadget"> {
+    constructor(
+        readonly clusterOperations: ClusterOperations,
+        readonly clusterName: string,
+        readonly traceWatcher: TraceWatcher
+    ) { }
+
+    getTitle(): string {
+        return `Inspektor Gadget on ${this.clusterName}`;
+    }
+
+    getInitialState(): InitialState {
+        return {};
+    }
+
+    getMessageHandler(webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {
+        return {
+            getVersionRequest: _ => this._handleGetVersionRequest(webview),
+            deployRequest: _ => this._handleDeployRequest(webview),
+            undeployRequest: _ => this._handleUndeployRequest(webview),
+            runStreamingTraceRequest: args => this._handleRunStreamingTraceRequest(args.traceId, args.arguments, webview),
+            runBlockingTraceRequest: args => this._handleRunBlockingTraceRequest(args.traceId, args.arguments, webview),
+            stopStreamingTraceRequest: _ => this._handleStopStreamingTraceRequest(),
+            getNodesRequest: _ => this._handleGetNodesRequest(webview),
+            getNamespacesRequest: _ => this._handleGetNamespacesRequest(webview),
+            getPodsRequest: args => this._handleGetPodsRequest(args.namespace, webview),
+            getContainersRequest: args => this._handleGetContainersRequest(args.namespace, args.podName, webview),
+        };
+    }
+
+    private async _handleGetVersionRequest(webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const version = await this.clusterOperations.getGadgetVersion();
+        if (failed(version)) {
+            vscode.window.showErrorMessage(version.error);
+            return;
+        }
+
+        webview.postMessage({ command: "updateVersion", parameters: version.result });
+    }
+
+    private async _handleDeployRequest(webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const version = await this.clusterOperations.deploy();
+        if (failed(version)) {
+            vscode.window.showErrorMessage(version.error);
+            return;
+        }
+
+        webview.postMessage({ command: "updateVersion", parameters: version.result });
+    }
+
+    private async _handleUndeployRequest(webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const version = await this.clusterOperations.undeploy();
+        if (failed(version)) {
+            vscode.window.showErrorMessage(version.error);
+            return;
+        }
+
+        webview.postMessage({ command: "updateVersion", parameters: version.result });
+    }
+
+    private async _handleRunStreamingTraceRequest(traceId: number, args: GadgetArguments, webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const outputItemsHandler = (items: TraceOutputItem[]) => webview.postMessage({ command: "runTraceResponse", parameters: {traceId, items} });
+
+        await this.traceWatcher.watch(args, outputItemsHandler, e => vscode.window.showErrorMessage(getErrorMessage(e)));
+    }
+
+    private async _handleRunBlockingTraceRequest(traceId: number, args: GadgetArguments, webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const items = await this.clusterOperations.runTrace(args);
+        if (failed(items)) {
+            vscode.window.showErrorMessage(items.error);
+            return;
+        }
+
+        webview.postMessage({ command: "runTraceResponse", parameters: {traceId, items: items.result} });
+    }
+
+    private async _handleStopStreamingTraceRequest(): Promise<void> {
+        await this.traceWatcher.stopWatching();
+    }
+
+    private async _handleGetNodesRequest(webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const nodes = await this.clusterOperations.getNodes();
+        if (failed(nodes)) {
+            vscode.window.showErrorMessage(nodes.error);
+            return;
+        }
+
+        webview.postMessage({ command: "getNodesResponse", parameters: {nodes: nodes.result} });
+    }
+
+    private async _handleGetNamespacesRequest(webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const namespaces = await this.clusterOperations.getNamespaces();
+        if (failed(namespaces)) {
+            vscode.window.showErrorMessage(namespaces.error);
+            return;
+        }
+
+        webview.postMessage({ command: "getNamespacesResponse", parameters: {namespaces: namespaces.result} });
+    }
+
+    private async _handleGetPodsRequest(namespace: string, webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const pods = await this.clusterOperations.getPods(namespace);
+        if (failed(pods)) {
+            vscode.window.showErrorMessage(pods.error);
+            return;
+        }
+
+        webview.postMessage({ command: "getPodsResponse", parameters: {namespace, podNames: pods.result} });
+    }
+
+    private async _handleGetContainersRequest(namespace: string, podName: string, webview: MessageSink<ToWebViewMsgDef>): Promise<void> {
+        const containers = await this.clusterOperations.getContainers(namespace, podName);
+        if (failed(containers)) {
+            vscode.window.showErrorMessage(containers.error);
+            return;
+        }
+
+        webview.postMessage({ command: "getContainersResponse", parameters: {namespace, podName, containerNames: containers.result} });
+    }
+}

--- a/src/webview-contract/messaging.ts
+++ b/src/webview-contract/messaging.ts
@@ -29,24 +29,26 @@ export interface MessageSource<TListenMsgDef extends MessageDefinition> {
  */
 export type MessageContext<TPostMsgDef extends MessageDefinition, TListenMsgDef extends MessageDefinition> = MessageSink<TPostMsgDef> & MessageSource<TListenMsgDef>;
 
-// Shortcut type for creating mapped types using only the `string` keys of object types (to exclude symbols).
-type StringProperties<T> = Extract<keyof T, string>;
+/**
+ * A discriminated union of the command names produced from the message definition `TMsgDef`.
+ */
+export type Command<T> = Extract<keyof T, string>;
 
 /**
  * A discriminated union of the message types produced from the message definition `TMsgDef`.
  */
 export type Message<TMsgDef extends MessageDefinition> = {
-    [P in StringProperties<TMsgDef>]: {
+    [P in Command<TMsgDef>]: {
         command: P,
         parameters: TMsgDef[P]
     }
-}[StringProperties<TMsgDef>];
+}[Command<TMsgDef>];
 
 /**
  * The handler type for all the messages defined in `TMsgDef`.
  */
 export type MessageHandler<TMsgDef extends MessageDefinition> = {
-    [P in keyof TMsgDef]: (args: TMsgDef[P]) => void
+    [P in keyof TMsgDef]: (args: TMsgDef[P], command: P) => void
 };
 
 export function isValidMessage<TMsgDef extends MessageDefinition>(message: any): message is Message<TMsgDef> {

--- a/src/webview-contract/webviewDefinitions/detector.ts
+++ b/src/webview-contract/webviewDefinitions/detector.ts
@@ -74,4 +74,4 @@ export type ToWebViewMsgDef = {};
 
 export type ToVsCodeMsgDef = {};
 
-export type DetectorDefinition = WebviewDefinition<InitialState, ToWebViewMsgDef, ToVsCodeMsgDef>;
+export type DetectorDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewDefinitions/inspektorGadget.ts
+++ b/src/webview-contract/webviewDefinitions/inspektorGadget.ts
@@ -1,0 +1,84 @@
+import { WebviewDefinition } from "../webviewTypes";
+
+export interface InitialState {}
+
+export interface GadgetVersion {
+    client: string
+    server: string | null
+}
+
+export enum NamespaceSelection {
+    Default,
+    All
+}
+
+export type NamespaceFilter = NamespaceSelection | string;
+
+export interface Filters {
+    namespace: NamespaceFilter
+    nodeName?: string
+    podName?: string
+    containerName?: string
+    labels?: { [key: string]: string }
+};
+
+export interface GadgetArguments {
+    gadgetCategory: string
+    gadgetResource: string
+    filters: Filters
+    sortString?: string
+    interval?: number
+    maxRows?: number
+    timeout?: number
+}
+
+export type TraceOutputItem = { [key: string]: any }
+
+export type ToVsCodeMsgDef = {
+    getVersionRequest: void,
+    deployRequest: void,
+    undeployRequest: void,
+    runStreamingTraceRequest: {
+        traceId: number,
+        arguments: GadgetArguments
+    },
+    runBlockingTraceRequest: {
+        traceId: number,
+        arguments: GadgetArguments
+    },
+    stopStreamingTraceRequest: void,
+    getNodesRequest: void,
+    getNamespacesRequest: void,
+    getPodsRequest: {
+        namespace: string
+    },
+    getContainersRequest: {
+        namespace: string,
+        podName: string
+    }
+};
+
+export type ToWebViewMsgDef = {
+    updateVersion: GadgetVersion,
+    runTraceResponse: {
+        traceId: number,
+        items: TraceOutputItem[]
+    },
+    getNodesResponse: {
+        nodes: string[]
+    },
+    getNamespacesResponse: {
+        namespaces: string[]
+    },
+    getPodsResponse: {
+        namespace: string,
+        podNames: string[]
+    },
+    getContainersResponse: {
+        namespace: string,
+        podName: string,
+        containerNames: string[]
+    }
+};
+
+export type InspektorGadgetDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -1,5 +1,6 @@
 import { Message, MessageContext, MessageDefinition, MessageHandler, MessageSink } from "./messaging";
 import { DetectorDefinition } from "./webviewDefinitions/detector";
+import { InspektorGadgetDefinition } from "./webviewDefinitions/inspektorGadget";
 import { PeriscopeDefinition } from "./webviewDefinitions/periscope";
 import { TestStyleViewerDefinition } from "./webviewDefinitions/testStyleViewer";
 
@@ -19,7 +20,8 @@ export type WebviewDefinition<TInitialState extends object, TToVsCode extends Me
 type AllWebviewDefinitions = {
     style: TestStyleViewerDefinition,
     periscope: PeriscopeDefinition,
-    detector: DetectorDefinition
+    detector: DetectorDefinition,
+    gadget: InspektorGadgetDefinition
 };
 
 type ContentIdLookup = {

--- a/webview-ui/src/InspektorGadget/GadgetSelector.tsx
+++ b/webview-ui/src/InspektorGadget/GadgetSelector.tsx
@@ -1,0 +1,31 @@
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { FormEvent } from "react";
+import { GadgetCategory } from "./helpers/gadgets/types";
+import { configuredGadgetResources } from "./helpers/gadgets";
+
+export interface GadgetSelectorProps {
+    category: GadgetCategory
+    id: string
+    className: React.HTMLAttributes<any>['className']
+    required?: boolean
+    onResourceChanged: (resource: string | null) => void
+}
+
+export function GadgetSelector(props: GadgetSelectorProps) {
+    function handleResourceChange(e: Event | FormEvent<HTMLElement>) {
+        const elem = e.target as HTMLInputElement;
+        const resource = elem.value ? elem.value : null;
+        props.onResourceChanged(resource);
+    }
+
+    const configuredResources = configuredGadgetResources[props.category];
+
+    return (
+        <VSCodeDropdown id={props.id} className={props.className} required={props.required} onChange={handleResourceChange}>
+            <VSCodeOption value="">Select</VSCodeOption>
+            {Object.keys(configuredResources).map(resource => (
+                <VSCodeOption key={resource} value={resource}>{configuredResources[resource]!.name}</VSCodeOption>
+            ))}
+        </VSCodeDropdown>
+    );
+}

--- a/webview-ui/src/InspektorGadget/InspektorGadget.module.css
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.module.css
@@ -1,0 +1,129 @@
+.tab {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.propertyList {
+    width: 100%;
+}
+
+.propertyList dt {
+    float: left;
+    clear: left;
+    padding: 2px 4px;
+    font-weight: bold;
+    width: 10rem;
+}
+
+.propertyList dd {
+    padding: 2px 4px;
+}
+
+table.tracelist {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+table.tracelist th {
+    height: 50px;
+    text-align: left;
+}
+
+table.tracelist td {
+    padding: 5px;
+}
+
+table.tracelist td > * {
+    vertical-align: middle;
+}
+
+table.tracelist tbody tr.selected {
+    background-color: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+table.tracelist tbody tr:hover {
+    background-color: var(--vscode-list-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
+    cursor: pointer;
+}
+
+table.traceoutput {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+table.traceoutput th {
+    height: 50px;
+    text-align: left;
+    padding: 0 0.5rem 0 0.5rem;
+}
+
+table.traceoutput td {
+    padding: 5px;
+}
+
+.label {
+    margin-bottom: 0.2rem;
+}
+
+.control {
+    margin-bottom: 0.8rem;
+    min-width: 15rem;
+}
+
+ul.hierarchyList {
+    list-style-type: none;
+    padding: 0;
+    padding-left: 0;
+    margin: 0;
+}
+
+ul.hierarchyList li {
+    display: grid;
+    grid-template-columns: 1rem auto;
+    grid-gap: 0;
+    grid-column-gap: 0.5rem;
+    align-items: center;
+}
+
+ul.hierarchyList li .expander {
+    grid-column: 1 / 2;
+    cursor: pointer;
+    vertical-align: middle;
+}
+
+ul.hierarchyList li * {
+    grid-column: 2 / 3;
+}
+
+.inputContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: top;
+    align-items: flex-start;
+    min-width: 20rem;
+}
+
+.buttonContainer {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: row;
+    column-gap: 0.5rem;
+}
+
+.panelContent {
+    display: grid;
+    grid-template-rows: fit-content(0) auto;
+    gap: 1rem;
+}
+
+.panelContent .side {
+    grid-column: 1 / 2;
+}
+
+.panelContent .main {
+    grid-column: 2 / 3;
+}

--- a/webview-ui/src/InspektorGadget/InspektorGadget.tsx
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.tsx
@@ -1,0 +1,85 @@
+import { VSCodeLink, VSCodePanelTab, VSCodePanelView, VSCodePanels } from "@vscode/webview-ui-toolkit/react";
+import { Overview } from "./Overview";
+import { Traces, TracesProps } from "./Traces";
+import styles from "./InspektorGadget.module.css";
+import { useEffect, useReducer } from "react";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { createState, updateState, userMessageHandler, vscodeMessageHandler } from "./helpers/state";
+import { GadgetCategory } from "./helpers/gadgets/types";
+import { isNotLoaded } from "../utilities/lazy";
+import { InitialState, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { UserMsgDef } from "./helpers/userCommands";
+import { getEventHandlers, getMessageHandler } from "../utilities/state";
+
+export function InspektorGadget(_props: InitialState) {
+    const vscode = getWebviewMessageContext<"gadget">();
+
+    const [state, dispatch] = useReducer(updateState, createState());
+
+    useEffect(() => {
+        const msgHandler = getMessageHandler<ToWebViewMsgDef>(dispatch, vscodeMessageHandler);
+        vscode.subscribeToMessages(msgHandler);
+    });
+
+    useEffect(() => {
+        if (!state.initializationStarted) {
+            dispatch({ command: "setInitializing" });
+            vscode.postMessage({ command: "getVersionRequest", parameters: undefined });
+        }
+
+        if (isNotLoaded(state.nodes)) {
+            dispatch({ command: "setNodesLoading" });
+            vscode.postMessage({ command: "getNodesRequest", parameters: undefined });
+        }
+
+        if (isNotLoaded(state.resources)) {
+            dispatch({ command: "setNamespacesLoading" });
+            vscode.postMessage({ command: "getNamespacesRequest", parameters: undefined });
+        }
+    });
+
+    const userMessageEventHandlers = getEventHandlers<UserMsgDef>(dispatch, userMessageHandler);
+
+    function handleRequestTraceId(): number {
+        userMessageEventHandlers.onIncrementTraceId();
+        return state.nextTraceId;
+    }
+
+    function getTracesProps(category: GadgetCategory): TracesProps {
+        const traces = state.allTraces.filter(t => t.category === category);
+        return {
+            category,
+            traces,
+            nodes: state.nodes,
+            resources: state.resources,
+            onRequestTraceId: handleRequestTraceId,
+            userMessageHandlers: userMessageEventHandlers
+        };
+    }
+
+    const isDeployed = state.version && state.version.server !== null;
+
+    return (
+    <>
+        <h2>Inspektor Gadget</h2>
+        <p>
+            Inspektor Gadget provides a wide selection of BPF tools to dig deep into your Kubernetes cluster.
+            <VSCodeLink href="https://www.inspektor-gadget.io/">&nbsp;Learn more</VSCodeLink>
+        </p>
+
+        <VSCodePanels aria-label="Inspektory Gadget functions">
+            <VSCodePanelTab>OVERVIEW</VSCodePanelTab>
+            {isDeployed && <VSCodePanelTab>TRACES</VSCodePanelTab>}
+            {isDeployed && <VSCodePanelTab>TOP</VSCodePanelTab>}
+            {isDeployed && <VSCodePanelTab>SNAPSHOTS</VSCodePanelTab>}
+            {isDeployed && <VSCodePanelTab>PROFILE</VSCodePanelTab>}
+
+            <VSCodePanelView className={styles.tab}><Overview status={state.overviewStatus} version={state.version} userMessageHandlers={userMessageEventHandlers} /></VSCodePanelView>
+            {isDeployed && <VSCodePanelView className={styles.tab}><Traces {...getTracesProps("trace")} /></VSCodePanelView>}
+            {isDeployed && <VSCodePanelView className={styles.tab}><Traces {...getTracesProps("top")} /></VSCodePanelView>}
+            {isDeployed && <VSCodePanelView className={styles.tab}><Traces {...getTracesProps("snapshot")} /></VSCodePanelView>}
+            {isDeployed && <VSCodePanelView className={styles.tab}><Traces {...getTracesProps("profile")} /></VSCodePanelView>}
+        </VSCodePanels>
+    </>
+    );
+}

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -1,0 +1,194 @@
+import { VSCodeButton, VSCodeCheckbox, VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import styles from "./InspektorGadget.module.css";
+import { Dialog } from "../components/Dialog";
+import { FormEvent, useEffect, useState, ChangeEvent as InputChangeEvent } from 'react';
+import { ResourceSelector } from './ResourceSelector';
+import { ClusterResources, Nodes } from './helpers/clusterResources';
+import { isLoaded, isNotLoaded } from "../utilities/lazy";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { TraceItemSortSelector } from "./TraceItemSortSelector";
+import { GadgetConfiguration, configuredGadgetResources, getGadgetMetadata } from "./helpers/gadgets";
+import { GadgetSelector } from "./GadgetSelector";
+import { NodeSelector } from "./NodeSelector";
+import { GadgetCategory, GadgetExtraProperties, SortSpecifier, toExtraPropertyObject } from "./helpers/gadgets/types";
+import { NamespaceSelection } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { UserMsgDef } from "./helpers/userCommands";
+import { EventHandlers } from "../utilities/state";
+
+const defaultTimeoutInSeconds = 30;
+const defaultMaxItemCount = 20;
+
+export interface NewTraceDialogProps {
+    isShown: boolean
+    gadgetCategory: GadgetCategory
+    nodes: Nodes
+    resources: ClusterResources
+    userMessageHandlers: EventHandlers<UserMsgDef>
+    onCancel: () => void
+    onAccept: (trace: GadgetConfiguration) => void
+}
+
+export function NewTraceDialog (props: NewTraceDialogProps) {
+    const vscode = getWebviewMessageContext<"gadget">();
+
+    useEffect(() => {
+        if (props.isShown && isNotLoaded(props.nodes)) {
+            props.userMessageHandlers.onSetNodesLoading();
+            vscode.postMessage({ command: "getNodesRequest", parameters: undefined });
+        }
+        if (props.isShown && isNotLoaded(props.resources)) {
+            props.userMessageHandlers.onSetNamespacesLoading();
+            vscode.postMessage({ command: "getNamespacesRequest", parameters: undefined });
+        }
+    });
+
+    const [traceConfig, setTraceConfig] = useState<GadgetConfiguration>({
+        category: props.gadgetCategory,
+        resource: "",
+        filters: {
+            namespace: NamespaceSelection.All
+        },
+        displayProperties: [],
+        sortSpecifiers: [],
+        excludeThreads: undefined,
+        timeout: undefined,
+        maxItemCount: undefined
+    });
+
+    const configuredResources = configuredGadgetResources[props.gadgetCategory];
+    const metadata = traceConfig.resource ? getGadgetMetadata(props.gadgetCategory, traceConfig.resource) : null;
+    const extraProperties = toExtraPropertyObject(metadata?.extraProperties ?? GadgetExtraProperties.None);
+
+    function onResourceChanged(resource: string | null) {
+        const metadata = resource && configuredResources[resource] || null;
+        const extraProperties = toExtraPropertyObject(metadata?.extraProperties ?? GadgetExtraProperties.None);
+
+        const displayProperties = metadata?.defaultProperties || [];
+        const sortSpecifiers = metadata?.defaultSort || [];
+        const maxItemCount = extraProperties.requiresMaxItemCount ? traceConfig.maxItemCount || defaultMaxItemCount : undefined;
+        const excludeThreads = extraProperties.threadExclusionAllowed ? true : undefined;
+        const timeout = extraProperties.requiresTimeout ? traceConfig.timeout || defaultTimeoutInSeconds : undefined;
+        const { namespace, podName, containerName, ...rest } = traceConfig.filters!;
+        const filters = extraProperties.noK8sResourceFiltering ? {...rest, namespace: NamespaceSelection.Default} : traceConfig.filters;
+
+        setTraceConfig({ ...traceConfig, resource: resource || "", filters, displayProperties, sortSpecifiers, excludeThreads, maxItemCount, timeout });
+    }
+
+    function handleNodeChanged(node: string | null) {
+        const filters = { ...traceConfig.filters, nodeName: node || undefined };
+        setTraceConfig({ ...traceConfig, filters });
+    }
+
+    function handleResourceSelectionChanged(selection: {namespace?: string, podName?: string, containerName?: string}) {
+        const { namespace, podName, containerName, ...rest } = traceConfig.filters!;
+        const newNamespace =
+            extraProperties.noK8sResourceFiltering ? NamespaceSelection.Default :
+            !namespace ? NamespaceSelection.All :
+            namespace;
+        const filters = { ...rest, ...selection, namespace: newNamespace };
+        setTraceConfig({...traceConfig, filters });
+    }
+
+    function canCreate(): boolean {
+        const hasTimeoutIfRequired = !extraProperties.requiresTimeout || !!traceConfig.timeout;
+        const hasMaxItemCountIfRequired = !extraProperties.requiresMaxItemCount || !!traceConfig.maxItemCount;
+        return !!traceConfig.resource && hasTimeoutIfRequired && hasMaxItemCountIfRequired;
+    }
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!canCreate()) {
+            return;
+        }
+
+        props.onAccept(traceConfig);
+
+        // TODO: Make this an on-demand refresh, not on every submit.
+        props.userMessageHandlers.onSetNodesNotLoaded();
+        props.userMessageHandlers.onSetNamespacesNotLoaded();
+    }
+
+    function handleSortSpecifiersChange(sortSpecifiers: SortSpecifier<string>[]): void {
+        setTraceConfig({ ...traceConfig, sortSpecifiers });
+    }
+
+    function handleDisplayThreadsChange(e: Event | FormEvent<HTMLElement>): void {
+        const elem = e.target as HTMLInputElement;
+        const excludeThreads = !elem.checked;
+        setTraceConfig({ ...traceConfig, excludeThreads });
+    }
+
+    function handleTimeoutChange(event: InputChangeEvent<HTMLInputElement>): void {
+        setTraceConfig({ ...traceConfig, timeout: parseInt(event.currentTarget.value) });
+    }
+
+    function handleMaxRowsChange(event: InputChangeEvent<HTMLInputElement>): void {
+        setTraceConfig({ ...traceConfig, maxItemCount: parseInt(event.currentTarget.value) });
+    }
+
+    return (
+    <Dialog isShown={props.isShown} onCancel={() => props.onCancel()}>
+        <h2>New Trace</h2>
+
+        <form onSubmit={handleSubmit}>
+            <VSCodeDivider/>
+
+            <div className={styles.inputContainer}>
+                <label htmlFor="gadget-dropdown" className={styles.label}>Gadget</label>
+                <GadgetSelector id="gadget-dropdown" className={styles.control} required category={props.gadgetCategory} onResourceChanged={onResourceChanged} />
+
+                <label htmlFor="node-dropdown" className={styles.label}>Node</label>
+                {isLoaded(props.nodes) ? <NodeSelector nodes={props.nodes.value} onNodeChanged={handleNodeChanged} id="node-dropdown" className={styles.control} /> : <VSCodeProgressRing /> }
+
+                {!extraProperties.noK8sResourceFiltering && (
+                <>
+                    <label htmlFor="resource-selector" className={styles.label}>Resource</label>
+                    {isLoaded(props.resources) ?
+                        (<ResourceSelector id="resource-selector" resources={props.resources.value} onSelectionChanged={handleResourceSelectionChanged} userMessageHandlers={props.userMessageHandlers} />) :
+                        <VSCodeProgressRing />}
+                </>
+                )}
+
+                {extraProperties.sortingAllowed && (
+                <>
+                    <label htmlFor="sort-selector" className={styles.label}>Sort by</label>
+                    <TraceItemSortSelector
+                        id="sort-selector"
+                        className={styles.control}
+                        required={true}
+                        allProperties={metadata?.allProperties || []}
+                        sortSpecifiers={traceConfig.sortSpecifiers || []}
+                        onSortSpecifiersChange={handleSortSpecifiersChange}
+                    />
+                </>
+                )}
+
+                {extraProperties.requiresMaxItemCount && (
+                <>
+                    <label htmlFor="max-rows-input" className={styles.label}>Max rows</label>
+                    <input id="max-rows-input" className={styles.control} type="number" required value={traceConfig.maxItemCount} min={1} max={1000} onChange={handleMaxRowsChange}></input>
+                </>
+                )}
+
+                {extraProperties.threadExclusionAllowed && (
+                    <VSCodeCheckbox checked={traceConfig.excludeThreads === false} onChange={handleDisplayThreadsChange}>Display threads</VSCodeCheckbox>
+                )}
+
+                {extraProperties.requiresTimeout && (
+                <>
+                    <label htmlFor="timeout-input" className={styles.label}>Timeout (s)</label>
+                    <input id="timeout-input" className={styles.control} type="number" required value={traceConfig.timeout} min={1} max={60 * 5} onChange={handleTimeoutChange}></input>
+                </>
+                )}
+            </div>
+
+            <VSCodeDivider/>
+
+            <div className={styles.buttonContainer}>
+                <VSCodeButton type="submit" disabled={!canCreate()}>Ok</VSCodeButton>
+                <VSCodeButton onClick={props.onCancel}>Cancel</VSCodeButton>
+            </div>
+        </form>
+    </Dialog>
+    );
+}

--- a/webview-ui/src/InspektorGadget/NodeSelector.tsx
+++ b/webview-ui/src/InspektorGadget/NodeSelector.tsx
@@ -1,0 +1,27 @@
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { FormEvent } from "react";
+
+export interface NodeSelectorProps {
+    nodes: string[]
+    id: string
+    className: React.HTMLAttributes<any>['className']
+    required?: boolean
+    onNodeChanged: (node: string | null) => void
+}
+
+export function NodeSelector(props: NodeSelectorProps) {
+    function handleNodeChange(e: Event | FormEvent<HTMLElement>) {
+        const elem = e.target as HTMLInputElement;
+        const node = elem.value || null;
+        props.onNodeChanged(node);
+    }
+
+    return (
+        <VSCodeDropdown id={props.id} className={props.className} required={props.required} onChange={handleNodeChange}>
+            <VSCodeOption value="">Select</VSCodeOption>
+            {props.nodes.map(node => (
+                <VSCodeOption key={node} value={node}>{node}</VSCodeOption>
+            ))}
+        </VSCodeDropdown>
+    );
+}

--- a/webview-ui/src/InspektorGadget/Overview.tsx
+++ b/webview-ui/src/InspektorGadget/Overview.tsx
@@ -1,0 +1,55 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEraser, faRocket } from "@fortawesome/free-solid-svg-icons";
+import styles from "./InspektorGadget.module.css";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { GadgetVersion } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { EventHandlers } from "../utilities/state";
+import { UserMsgDef } from "./helpers/userCommands";
+
+export interface OverviewProps {
+    status: string
+    version: GadgetVersion | null
+    userMessageHandlers: EventHandlers<UserMsgDef>
+}
+
+export function Overview(props: OverviewProps) {
+    const vscode = getWebviewMessageContext<"gadget">();
+
+    function handleDeploy() {
+        props.userMessageHandlers.onDeploy();
+        vscode.postMessage({ command: "deployRequest", parameters: undefined });
+    }
+
+    function handleUndeploy() {
+        props.userMessageHandlers.onUndeploy();
+        vscode.postMessage({ command: "undeployRequest", parameters: undefined });
+    }
+
+    return (
+    <>
+        {props.status && (
+            <p>{props.status}</p>
+        )}
+        {props.version && props.version.server && (
+            <>
+                <dl className={styles.propertyList}>
+                    <dt>Client Version</dt><dd>{props.version.client}</dd>
+                    <dt>Server Version</dt><dd>{props.version.server}</dd>
+                </dl>
+                <br/>
+                <VSCodeButton onClick={handleUndeploy}>
+                    <FontAwesomeIcon icon={faEraser} />
+                    &nbsp;Undeploy
+                </VSCodeButton>
+            </>
+        )}
+        {props.version && !props.version.server && (
+            <VSCodeButton onClick={handleDeploy}>
+                <FontAwesomeIcon icon={faRocket} />
+                &nbsp;Deploy
+            </VSCodeButton>
+        )}
+    </>
+    );
+}

--- a/webview-ui/src/InspektorGadget/ResourceSelector.tsx
+++ b/webview-ui/src/InspektorGadget/ResourceSelector.tsx
@@ -1,0 +1,202 @@
+import { FormEvent, useEffect, useState } from "react";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import styles from "./InspektorGadget.module.css";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { NamespaceResources, PodResources } from "./helpers/clusterResources";
+import { Lazy, isLoaded, isNotLoaded, map as lazyMap, orDefault } from "../utilities/lazy";
+import { VSCodeProgressRing, VSCodeRadio } from "@vscode/webview-ui-toolkit/react";
+import { Lookup, asLookup, exclude, intersection } from "../utilities/array";
+import { EventHandlers } from "../utilities/state";
+import { UserMsgDef } from "./helpers/userCommands";
+
+type ChangeEvent = Event | FormEvent<HTMLElement>;
+
+type PodItemStatus = {
+    isExpanded: boolean
+};
+
+type AllPodItemStatuses = Lookup<PodItemStatus>;
+
+type NamespaceItemStatus = {
+    isExpanded: boolean,
+    podStatuses: AllPodItemStatuses
+};
+
+type AllNamespaceItemStatuses = Lookup<NamespaceItemStatus>;
+
+const resourceProperties = {namespace: 'namespace', podName: 'podName', container: 'container'} as const;
+type SelectedNamespace = {[resourceProperties.namespace]: string};
+type SelectedPod = SelectedNamespace & {[resourceProperties.podName]: string};
+type SelectedContainer = SelectedPod & {[resourceProperties.container]: string};
+
+type SelectedResource = {} | SelectedNamespace | SelectedPod | SelectedContainer;
+
+function isNoResource(selectedResource: SelectedResource): selectedResource is {} {
+    return !(resourceProperties.namespace in selectedResource);
+}
+
+function isNamespaceResource(selectedResource: SelectedResource): selectedResource is SelectedNamespace {
+    return resourceProperties.namespace in selectedResource &&
+        !(resourceProperties.podName in selectedResource) &&
+        !(resourceProperties.container in selectedResource);
+}
+
+function isPodResource(selectedResource: SelectedResource): selectedResource is SelectedPod {
+    return resourceProperties.podName in selectedResource &&
+        !(resourceProperties.container in selectedResource);
+}
+
+function isContainerResource(selectedResource: SelectedResource): selectedResource is SelectedContainer {
+    return resourceProperties.container in selectedResource;
+}
+
+function lazyAsLookup<T>(lazyList: Lazy<T[]>, keyFn: (value: T) => string): Lookup<T> {
+    return orDefault(lazyMap(lazyList, items => asLookup(items, keyFn)), {});
+}
+
+function getUpdatedNamespaceItemStatus(status: NamespaceItemStatus, resource: NamespaceResources): NamespaceItemStatus {
+    const resources = lazyAsLookup(resource.children, p => p.name);
+    const pods = Object.keys(resources);
+    const podsWithStatus = Object.keys(status.podStatuses);
+    const existingStatuses = intersection(pods, podsWithStatus).map(p => [p, status.podStatuses[p]]);
+    const newStatuses = exclude(pods, podsWithStatus).map(p => [p, {isExpanded: false}]);
+    const podStatuses = Object.fromEntries(existingStatuses.concat(newStatuses));
+    return {...status, podStatuses};
+}
+
+function getUpdatedStatus(status: AllNamespaceItemStatuses, clusterResources: NamespaceResources[]): AllNamespaceItemStatuses {
+    const resources = asLookup(clusterResources, ns => ns.name);
+    const namespaces = Object.keys(resources);
+    const namespacesWithStatus = Object.keys(status);
+    const existingStatuses = intersection(namespaces, namespacesWithStatus).map(ns => [ns, getUpdatedNamespaceItemStatus(status[ns], resources[ns])]);
+    const newStatuses = exclude(namespaces, namespacesWithStatus).map(ns => [ns, getUpdatedNamespaceItemStatus({isExpanded: false, podStatuses: {}}, resources[ns])]);
+    return Object.fromEntries(existingStatuses.concat(newStatuses));
+}
+
+export interface ResourceSelectorProps {
+    id?: string
+    className?: React.HTMLAttributes<any>['className']
+    resources: NamespaceResources[]
+    onSelectionChanged: (selection: {namespace?: string, podName?: string, container?: string}) => void
+    userMessageHandlers: EventHandlers<UserMsgDef>
+}
+
+export function ResourceSelector(props: ResourceSelectorProps) {
+    const vscode = getWebviewMessageContext<"gadget">();
+
+    const [status, setStatus] = useState<AllNamespaceItemStatuses>({});
+    const [selectedResource, setSelectedResource] = useState<SelectedResource>({});
+
+    let updatedStatus = getUpdatedStatus(status, props.resources);
+    useEffect(() => {
+        setStatus(updatedStatus);
+    }, [props.resources]);
+
+    return (
+        <ul id={props.id} className={props.className ? `${props.className} ${styles.hierarchyList}` : styles.hierarchyList}>
+            <li>
+                <VSCodeRadio onChange={handleNoResourceChange} checked={isNoResource(selectedResource)}>All</VSCodeRadio>
+            </li>
+            {renderNamespaceItems(props.resources, updatedStatus)}
+        </ul>
+    );
+
+    function renderNamespaceItems(items: NamespaceResources[], status: AllNamespaceItemStatuses) {
+        return items.map(item => (
+            <li key={item.name}>
+                <FontAwesomeIcon className={styles.expander} onClick={() => toggleNamespaceExpanded(item.name)} icon={status[item.name].isExpanded ? faChevronDown : faChevronRight} />
+                <VSCodeRadio className={styles.selector} onChange={e => handleNamespaceChange(e, item.name)} checked={isNamespaceResource(selectedResource) && selectedResource.namespace === item.name}>{item.name}</VSCodeRadio>
+                {status[item.name].isExpanded && (
+                <ul className={styles.hierarchyList}>
+                    {isLoaded(item.children) ? renderPodItems(item.name, item.children.value, status[item.name].podStatuses) : <VSCodeProgressRing /> }
+                </ul>
+                )}
+            </li>
+        ));
+    }
+
+    function renderPodItems(namespace: string, items: PodResources[], status: AllPodItemStatuses) {
+        return items.map(item => (
+            <li key={item.name}>
+                <FontAwesomeIcon className={styles.expander} onClick={() => togglePodExpanded(namespace, item.name)} icon={status[item.name].isExpanded ? faChevronDown : faChevronRight} />
+                <VSCodeRadio onChange={e => handlePodChange(e, namespace, item.name)} checked={isPodResource(selectedResource) && selectedResource.namespace === namespace && selectedResource.podName === item.name}>{item.name}</VSCodeRadio>
+                {status[item.name].isExpanded && (
+                <ul className={styles.hierarchyList}>
+                    {isLoaded(item.children) ? renderContainerItems(namespace, item.name, item.children.value) : <VSCodeProgressRing /> }
+                </ul>
+                )}
+            </li>
+        ));
+    }
+
+    function renderContainerItems(namespace: string, podName: string, containerNames: string[]) {
+        return containerNames.map(c => (
+            <li key={c}>
+                <VSCodeRadio onChange={e => handleContainerChange(e, namespace, podName, c)} checked={isContainerResource(selectedResource) && selectedResource.namespace === namespace && selectedResource.podName === podName && selectedResource.container === c}>{c}</VSCodeRadio>
+            </li>
+        ));
+    }
+
+    function handleNoResourceChange(e: ChangeEvent) {
+        if ((e.target as HTMLInputElement).checked) {
+            setSelectedResource({});
+            props.onSelectionChanged({});
+        }
+    }
+
+    function handleNamespaceChange(e: ChangeEvent, namespace: string) {
+        if ((e.target as HTMLInputElement).checked) {
+            setSelectedResource({namespace});
+            props.onSelectionChanged({namespace});
+        }
+    }
+
+    function handlePodChange(e: ChangeEvent, namespace: string, podName: string) {
+        if ((e.target as HTMLInputElement).checked) {
+            setSelectedResource({namespace, podName});
+            props.onSelectionChanged({namespace, podName});
+        }
+    }
+
+    function handleContainerChange(e: ChangeEvent, namespace: string, podName: string, container: string) {
+        if ((e.target as HTMLInputElement).checked) {
+            setSelectedResource({namespace, podName, container});
+            props.onSelectionChanged({namespace, podName, container});
+        }
+    }
+
+    function toggleNamespaceExpanded(namespace: string) {
+        const namespaceItem = status[namespace];
+        const newNamespaceItem = {...namespaceItem, isExpanded: !namespaceItem.isExpanded};
+        const newStatus = {...status, [namespace]: newNamespaceItem};
+        setStatus(newStatus);
+
+        if (newNamespaceItem.isExpanded) {
+            const nsResources = asLookup(props.resources, ns => ns.name);
+            if (isNotLoaded(nsResources[namespace].children)) {
+                props.userMessageHandlers.onSetPodsLoading({namespace});
+                vscode.postMessage({ command: "getPodsRequest", parameters: {namespace} });
+            }
+        }
+    }
+
+    function togglePodExpanded(namespace: string, podName: string) {
+        const namespaceItem = status[namespace];
+        const podItem = namespaceItem.podStatuses[podName];
+        const newPodItem = {...podItem, isExpanded: !podItem.isExpanded};
+        const newPodStatuses = {...namespaceItem.podStatuses, [podName]: newPodItem};
+        const newNamespaceItem = {...namespaceItem, podStatuses: newPodStatuses};
+        const newStatus = {...status, [namespace]: newNamespaceItem};
+        setStatus(newStatus);
+
+        if (newPodItem.isExpanded) {
+            const nsResources = asLookup(props.resources, ns => ns.name);
+            const podResources = lazyAsLookup(nsResources[namespace].children, pod => pod.name);
+            if (isNotLoaded(podResources[podName].children)) {
+                props.userMessageHandlers.onSetContainersLoading({namespace, podName});
+                vscode.postMessage({ command: "getContainersRequest", parameters: {namespace, podName} });
+            }
+        }
+    }
+}

--- a/webview-ui/src/InspektorGadget/TraceItemSortSelector.tsx
+++ b/webview-ui/src/InspektorGadget/TraceItemSortSelector.tsx
@@ -1,0 +1,29 @@
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { FormEvent } from "react";
+import { ItemProperty, SortSpecifier, fromSortString, toSortString } from "./helpers/gadgets/types";
+
+type ChangeEvent = Event | FormEvent<HTMLElement>;
+
+export interface TraceItemSortSelectorProps {
+    id: string
+    className: React.HTMLAttributes<any>['className']
+    required?: boolean
+    sortSpecifiers: SortSpecifier<any>[]
+    allProperties: ItemProperty<any>[]
+    onSortSpecifiersChange: (sortSpecifiers: SortSpecifier<any>[]) => void
+}
+
+export function TraceItemSortSelector(props: TraceItemSortSelectorProps) {
+    function handleSortStringChange(e: ChangeEvent) {
+        const input = e.currentTarget as HTMLInputElement;
+        const sortSpecifiers = fromSortString(input.value, props.allProperties);
+        props.onSortSpecifiersChange(sortSpecifiers);
+    }
+
+    const sortString = toSortString(props.sortSpecifiers);
+    const allowedIdentifiers = props.allProperties.map(p => p.identifier).sort();
+    const title = `Allowed properties:\n${allowedIdentifiers.join('\n')}`;
+    return (
+        <VSCodeTextField title={title} id={props.id} className={props.className} required={props.required} value={sortString} onInput={handleSortStringChange}></VSCodeTextField>
+    );
+}

--- a/webview-ui/src/InspektorGadget/TraceOutput.tsx
+++ b/webview-ui/src/InspektorGadget/TraceOutput.tsx
@@ -1,0 +1,67 @@
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import styles from "./InspektorGadget.module.css";
+import { TraceGadget } from "./helpers/gadgets";
+import { ProcessSnapshotKey } from "./helpers/gadgets/snapshot";
+import { ItemProperty, ValueType } from "./helpers/gadgets/types";
+
+export interface TraceOutputProps {
+    trace: TraceGadget
+}
+
+export function TraceOutput(props: TraceOutputProps) {
+    const tidKey: ProcessSnapshotKey = "tid";
+    const outputProperties = props.trace.displayProperties.filter(p => !props.trace?.excludeThreads || p.key !== tidKey);
+    const outputArrays = props.trace.output?.map(item => outputProperties.map(p => ({ property: p, value: item[p.key] })));
+    if (props.trace.output === null) {
+        return (
+            <>
+                <VSCodeProgressRing></VSCodeProgressRing>
+                Running Gadget...
+            </>
+        );
+    }
+
+    return (
+    <table className={styles.traceoutput}>
+        <thead>
+            <tr>
+                {outputProperties.map(p => (
+                    <th key={p.name}>{p.name}</th>
+                ))}
+            </tr>
+        </thead>
+        <tbody>
+            {outputArrays && outputArrays.map((values, i) => (
+                <tr key={i}>
+                    {values.map((val, i) => (
+                        <td key={i}>{displayValue(val.value, val.property)}</td>
+                    ))}
+                </tr>
+            ))}
+        </tbody>
+    </table>
+    );
+}
+
+function displayValue(value: any, property: ItemProperty<any>) {
+    switch (property.valueType) {
+        case ValueType.CharByte:
+            return <>{String.fromCharCode(value as number)}</>;
+        case ValueType.Bytes:
+            return <>{value} B</>;
+        case ValueType.StackTrace:
+            return <pre>{value}</pre>;
+        case ValueType.AddressArray:
+            return <>{value ? (JSON.parse(value) as string[]).join(',') : ""}</>
+        case ValueType.Timestamp:
+            return <>{value ? formatTime(value) : ""}</>
+        default:
+            return <>{value}</>;
+    }
+}
+
+function formatTime(timestampInNs: number): string {
+    const date = new Date(timestampInNs / 1000000);
+    const msFraction = timestampInNs % 1000000;
+    return date.toISOString().slice(0, -1) + msFraction.toString() + 'Z';
+}

--- a/webview-ui/src/InspektorGadget/Traces.tsx
+++ b/webview-ui/src/InspektorGadget/Traces.tsx
@@ -1,0 +1,197 @@
+import { VSCodeButton, VSCodeCheckbox, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus, faTrashCan, faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import styles from "./InspektorGadget.module.css";
+import { FormEvent, useState } from "react";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { NewTraceDialog } from "./NewTraceDialog";
+import { ClusterResources, Nodes } from "./helpers/clusterResources";
+import { GadgetConfiguration, TraceGadget, getGadgetMetadata, toGadgetArguments } from "./helpers/gadgets";
+import { GadgetCategory } from "./helpers/gadgets/types";
+import { TraceOutput } from "./TraceOutput";
+import { NamespaceFilter, NamespaceSelection } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { UserMsgDef } from "./helpers/userCommands";
+import { EventHandlers } from "../utilities/state";
+
+export interface TracesProps {
+    category: GadgetCategory
+    traces: TraceGadget[]
+    nodes: Nodes
+    resources: ClusterResources
+    onRequestTraceId: () => number
+    userMessageHandlers: EventHandlers<UserMsgDef>
+}
+
+const streamingCategories: GadgetCategory[] = ["top", "trace"];
+
+export function Traces(props: TracesProps) {
+    const vscode = getWebviewMessageContext<"gadget">();
+
+    const [isNewTraceDialogShown, setIsTraceDialogShown] = useState(false);
+    const [checkedTraceIds, setCheckedTraceIds] = useState<number[]>([]);
+    const [selectedTraceId, setSelectedTraceId] = useState<number | null>(null);
+    const [isWatching, setIsWatching] = useState<boolean>(false);
+    const isStreamingTrace = streamingCategories.includes(props.category);
+
+    function handleAdd() {
+        setIsTraceDialogShown(true);
+    }
+
+    function ignoreClick(e: Event | FormEvent<HTMLElement>) {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    function toggleCheckedTraceId(traceId: number) {
+        if (checkedTraceIds.includes(traceId)) {
+            setCheckedTraceIds(checkedTraceIds.filter(id => id !== traceId));
+        } else {
+            setCheckedTraceIds(checkedTraceIds.concat(traceId));
+        }
+    }
+
+    function toggleIsWatching(trace: TraceGadget) {
+        if (!isStreamingTrace) {
+            return;
+        }
+
+        if (isWatching) {
+            vscode.postMessage({ command: "stopStreamingTraceRequest", parameters: undefined });
+        } else {
+            vscode.postMessage({ command: "runStreamingTraceRequest", parameters: {arguments: toGadgetArguments(trace), traceId: trace.traceId} });
+        }
+
+        setIsWatching(!isWatching);
+    }
+
+    function handleDelete() {
+        if (selectedTraceId !== null && checkedTraceIds.includes(selectedTraceId)) {
+            if (isWatching && isStreamingTrace) {
+                vscode.postMessage({ command: "stopStreamingTraceRequest", parameters: undefined });
+            }
+
+            setSelectedTraceId(null);
+        }
+
+        props.userMessageHandlers.onDeleteTraces({traceIds: checkedTraceIds});
+        setCheckedTraceIds([]);
+    }
+
+    function handleNewTraceDialogCancel() {
+        setIsTraceDialogShown(false);
+    }
+
+    function handleNewTraceDialogAccept(traceConfig: GadgetConfiguration) {
+        setIsTraceDialogShown(false);
+        const gadgetArguments = toGadgetArguments(traceConfig);
+        const traceId = props.onRequestTraceId();
+        const trace: TraceGadget = { ...traceConfig, traceId, output: null };
+        if (isStreamingTrace) {
+            vscode.postMessage({ command: "runStreamingTraceRequest", parameters: {arguments: gadgetArguments, traceId} });
+        } else {
+            vscode.postMessage({ command: "runBlockingTraceRequest", parameters: {arguments: gadgetArguments, traceId} });
+        }
+
+        props.userMessageHandlers.onCreateTrace({trace});
+        setSelectedTraceId(traceId);
+
+        if (isStreamingTrace) {
+            setIsWatching(true);
+        }
+    }
+
+    function getTraceRowClassNames(traceId?: number): string {
+        return selectedTraceId === traceId ? styles.selected : '';
+    }
+
+    function handleRowClick(trace: TraceGadget) {
+        if (isWatching && isStreamingTrace) {
+            vscode.postMessage({ command: "stopStreamingTraceRequest", parameters: undefined });
+        }
+
+        const isNewTraceSelected = selectedTraceId !== trace.traceId;
+
+        if (isWatching && isStreamingTrace && isNewTraceSelected) {
+            const gadgetArguments = toGadgetArguments(trace);
+            vscode.postMessage({ command: "runStreamingTraceRequest", parameters: {arguments: gadgetArguments, traceId: trace.traceId} });
+        }
+
+        setSelectedTraceId(isNewTraceSelected ? trace.traceId : null);
+    }
+
+    const selectedTrace = props.traces.find(t => t.traceId === selectedTraceId) || null;
+    const metadata = selectedTrace && getGadgetMetadata(selectedTrace.category, selectedTrace.resource);
+
+    return (
+    <>
+        {props.traces.length > 0 && (
+            <table className={styles.tracelist}>
+                <thead>
+                <tr>
+                    <th>Gadget</th>
+                    <th>Namespace</th>
+                    <th>Node</th>
+                    <th>Pod</th>
+                    <th>Container</th>
+                </tr>
+                </thead>
+                <tbody>
+                    {props.traces.map(trace => (
+                        <tr key={trace.traceId} onClick={_ => handleRowClick(trace)} className={getTraceRowClassNames(trace.traceId)}>
+                            <td>
+                                <VSCodeCheckbox checked={checkedTraceIds.includes(trace.traceId)} onClick={ignoreClick} onChange={() => toggleCheckedTraceId(trace.traceId)} style={{margin: "0", paddingRight: "0.5rem"}} />
+                                {getGadgetMetadata(trace.category, trace.resource)?.name}
+                            </td>
+                            <td>{getNamespaceText(trace.filters.namespace)}</td>
+                            <td>{trace.filters.nodeName}</td>
+                            <td>{trace.filters.podName}</td>
+                            <td>{trace.filters.containerName}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        )}
+
+        <div className={styles.buttonContainer}>
+            <VSCodeButton onClick={handleAdd}>
+                <FontAwesomeIcon icon={faPlus} />
+                &nbsp;Add
+            </VSCodeButton>
+            {checkedTraceIds.length > 0 && (
+                <VSCodeButton onClick={handleDelete}>
+                    <FontAwesomeIcon icon={faTrashCan} />
+                    &nbsp;Delete
+                </VSCodeButton>
+            )}
+        </div>
+
+        <VSCodeDivider />
+
+        {selectedTrace && (
+            <>
+                <h3>
+                    {isStreamingTrace && <FontAwesomeIcon icon={isWatching ? faEye : faEyeSlash} onClick={() => toggleIsWatching(selectedTrace)} style={{cursor: "pointer", paddingRight: "0.5rem"}} />}
+                    {metadata?.name}
+                </h3>
+                <TraceOutput trace={selectedTrace} />
+            </>
+        )}
+
+        <NewTraceDialog
+            isShown={isNewTraceDialogShown}
+            gadgetCategory={props.category}
+            nodes={props.nodes}
+            resources={props.resources}
+            userMessageHandlers={props.userMessageHandlers}
+            onCancel={handleNewTraceDialogCancel}
+            onAccept={handleNewTraceDialogAccept}
+        />
+    </>);
+}
+
+function getNamespaceText(namespace: NamespaceFilter): string {
+    return (
+        namespace === NamespaceSelection.Default ? "" :
+        namespace === NamespaceSelection.All ? "All" :
+        namespace);
+}

--- a/webview-ui/src/InspektorGadget/helpers/clusterResources.ts
+++ b/webview-ui/src/InspektorGadget/helpers/clusterResources.ts
@@ -1,0 +1,66 @@
+import { replaceItem } from "../../utilities/array";
+import { Lazy, map as lazyMap, newLoaded, newLoading, newNotLoaded } from "../../utilities/lazy";
+
+export interface LazyParent<TChild> {
+    name: string
+    children: Lazy<TChild[]>
+}
+
+export type Nodes = Lazy<string[]>;
+
+export type ContainerName = string;
+export type PodResources = LazyParent<ContainerName>;
+export type NamespaceResources = LazyParent<PodResources>;
+export type ClusterResources = Lazy<NamespaceResources[]>;
+
+function updateContainersForPod(podResources: PodResources, containers: string[]): PodResources {
+    return { ...podResources, children: newLoaded(containers) };
+}
+
+function updateContainersForNamespace(namespaceResource: NamespaceResources, podName: string, containers: string[]): NamespaceResources {
+    const children = lazyMap(namespaceResource.children, pods => replaceItem(pods, pod => pod.name === podName, pod => updateContainersForPod(pod, containers)));
+    return { ...namespaceResource, children };
+}
+
+function setContainersLoadingForPod(podResources: PodResources): PodResources {
+    return { ...podResources, children: newNotLoaded() };
+}
+
+function setContainersLoadingForNamespace(namespaceResource: NamespaceResources, podName: string): NamespaceResources {
+    const children = lazyMap(namespaceResource.children, pods => replaceItem(pods, pod => pod.name === podName, setContainersLoadingForPod));
+    return { ...namespaceResource, children };
+}
+
+export function updateContainersForCluster(resources: ClusterResources, namespace: string, podName: string, containers: string[]): ClusterResources {
+    return lazyMap(resources, nsItems => replaceItem(nsItems, ns => ns.name === namespace, ns => updateContainersForNamespace(ns, podName, containers)));
+}
+
+function updatePodsForNamespace(namespaceResource: NamespaceResources, podNames: string[]): NamespaceResources {
+    const children = newLoaded(podNames.map(p => ({name: p, children: newNotLoaded() })));
+    return { ...namespaceResource, children };
+}
+
+function setPodsLoadingForNamespace(namespaceResource: NamespaceResources): NamespaceResources {
+    return { ...namespaceResource, children: newLoading() };
+}
+
+export function updatePodsForCluster(resources: ClusterResources, namespace: string, podNames: string[]): ClusterResources {
+    return lazyMap(resources, nsItems => replaceItem(nsItems, ns => ns.name === namespace, ns => updatePodsForNamespace(ns, podNames)));
+}
+
+export function updateNamespacesForCluster(namespaces: string[]): ClusterResources {
+    const namespaceList = namespaces.map(ns => ({name: ns, children: newNotLoaded()}));
+    return newLoaded(namespaceList);
+}
+
+export function updateNodesForCluster(nodes: string[]): Nodes {
+    return newLoaded(nodes);
+}
+
+export function setPodsLoading(resources: ClusterResources, namespace: string): ClusterResources {
+    return lazyMap(resources, nsItems => replaceItem(nsItems, ns => ns.name === namespace, setPodsLoadingForNamespace ));
+}
+
+export function setContainersLoading(resources: ClusterResources, namespace: string, podName: string) {
+    return lazyMap(resources, nsItems => replaceItem(nsItems, ns => ns.name === namespace, ns => setContainersLoadingForNamespace(ns, podName)));
+}

--- a/webview-ui/src/InspektorGadget/helpers/gadgets.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets.ts
@@ -1,0 +1,148 @@
+import { Filters, GadgetArguments, TraceOutputItem } from "../../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { ProcessThreadKey } from "./gadgets/common";
+import { cpuProfileMetadata } from "./gadgets/profile";
+import { processSnapshotMetadata, socketSnapshotMetadata } from "./gadgets/snapshot";
+import { blockIOTopMetadata, ebpfTopMetadata, fileTopMetadata, tcpTopMetadata } from "./gadgets/top";
+import { dnsTraceMetadata, execTraceMetadata, tcpTraceMetadata } from "./gadgets/trace";
+import { DataItem, GadgetCategory, GadgetMetadata, GadgetProfileResource, GadgetSnapshotResource, GadgetTopResource, GadgetTraceResource, ItemProperty, SortDirection, SortSpecifier, isDerivedProperty, toSortString } from "./gadgets/types";
+
+export type GadgetConfiguration = {
+    category: GadgetCategory,
+    resource: string,
+    displayProperties: ItemProperty<any>[],
+    sortSpecifiers: SortSpecifier<any>[],
+    filters: Filters,
+    maxItemCount?: number,
+    timeout?: number,
+    excludeThreads?: boolean
+};
+
+export function toGadgetArguments(config: GadgetConfiguration): GadgetArguments {
+    return {
+        gadgetCategory: config.category,
+        gadgetResource: config.resource,
+        filters: config.filters,
+        // TODO: interval
+        maxRows: config.maxItemCount,
+        timeout: config.timeout,
+        sortString: toSortString(config.sortSpecifiers)
+    };
+}
+
+export type TraceGadget = GadgetConfiguration & {
+    traceId: number
+    output: TraceOutputItem[] | null
+};
+
+export type ConfiguredGadgetResources<T extends string> = Partial<{[key in T]: GadgetMetadata<string>}>;
+
+const profileGadgetResources: ConfiguredGadgetResources<GadgetProfileResource> = {
+    "cpu": cpuProfileMetadata
+};
+
+const snapshotGadgetResources: ConfiguredGadgetResources<GadgetSnapshotResource> = {
+    "process": processSnapshotMetadata,
+    "socket": socketSnapshotMetadata
+};
+
+const topGadgetResources: ConfiguredGadgetResources<GadgetTopResource> = {
+    "tcp": tcpTopMetadata,
+    "block-io": blockIOTopMetadata,
+    "ebpf": ebpfTopMetadata,
+    "file": fileTopMetadata
+};
+
+const traceGadgetResources: ConfiguredGadgetResources<GadgetTraceResource> = {
+    "dns": dnsTraceMetadata,
+    "tcp": tcpTraceMetadata,
+    "exec": execTraceMetadata
+};
+
+export const configuredGadgetResources: Record<GadgetCategory, ConfiguredGadgetResources<string>> = {
+    "profile": profileGadgetResources,
+    "snapshot": snapshotGadgetResources,
+    "top": topGadgetResources,
+    "trace": traceGadgetResources
+};
+
+export function getGadgetMetadata(gadgetCategory: GadgetCategory, gadgetResource: string): GadgetMetadata<string> | null {
+    return configuredGadgetResources[gadgetCategory][gadgetResource] || null;
+}
+
+export function enrich(configuration: GadgetConfiguration, items: TraceOutputItem[]): TraceOutputItem[] {
+    return items.map(item => enrichItem(configuration, item));
+}
+
+export function enrichSortAndFilter(configuration: GadgetConfiguration, items: TraceOutputItem[]): TraceOutputItem[] {
+    items = enrich(configuration, items);
+    items = filterItems(configuration, items);
+    if (configuration.sortSpecifiers.length) {
+        items = sortItems(items, configuration.sortSpecifiers);
+    }
+
+    if (configuration.maxItemCount) {
+        items = takeFirstItems(items, configuration.maxItemCount);
+    }
+
+    return items;
+}
+
+function enrichItem(configuration: GadgetConfiguration, item: TraceOutputItem): TraceOutputItem {
+    const itemEntries = Object.entries(item);
+    const metadata = getGadgetMetadata(configuration.category, configuration.resource);
+    const derivedEntries = metadata ? metadata.allProperties.filter(isDerivedProperty).map(p => [p.key, p.valueGetter(item)]) : [];
+    return Object.fromEntries([...itemEntries, ...derivedEntries]);
+}
+
+type SortFunction = (a: TraceOutputItem, b: TraceOutputItem) => number;
+
+function negateSortFunction(fn: SortFunction): SortFunction {
+    return (a, b) => -fn(a, b);
+}
+
+function asSortFunction(specifier: SortSpecifier<any>): SortFunction {
+    let key = specifier.property.key;
+    let descending = specifier.direction === SortDirection.Descending;
+    const fn: SortFunction = (a, b) => {
+        if (a[key] > b[key]) {
+            return 1;
+        } else if (a[key] < b[key]) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    return descending ? negateSortFunction(fn) : fn;
+}
+
+function combineSortFunctions(prev: SortFunction, current: SortFunction): SortFunction {
+    return (a, b) => {
+        const result = prev(a, b);
+        return result === 0 ? current(a, b) : result;
+    }
+}
+
+function getSortFunction(sortSpecifiers: SortSpecifier<any>[]): SortFunction {
+    return sortSpecifiers.map(asSortFunction).reduce(combineSortFunctions);
+}
+
+function sortItems(items: TraceOutputItem[], sortSpecifiers: SortSpecifier<any>[]): TraceOutputItem[] {
+    if (sortSpecifiers.length === 0) {
+        return items;
+    }
+
+    return [...items].sort(getSortFunction(sortSpecifiers));
+}
+
+function takeFirstItems(items: TraceOutputItem[], maxRows: number): TraceOutputItem[] {
+    return items.slice(0, maxRows);
+}
+
+function filterItems(configuration: GadgetConfiguration, items: TraceOutputItem[]): TraceOutputItem[] {
+    if (configuration.excludeThreads) {
+        items = items.map(item => item as DataItem<ProcessThreadKey>).filter(item => item.pid === item.tid);
+    }
+
+    return items;
+}

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/common.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/common.ts
@@ -1,0 +1,73 @@
+import { ItemMetadata, ItemProperty, ValueType, getDerivedProperty } from "./types";
+
+// Common K8s properties
+export const k8sKeys = ["k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName"] as const;
+export type K8sKey = typeof k8sKeys[number];
+export const k8sKeyMetadata: ItemMetadata<K8sKey> = {
+    "k8s.node": { identifier: "node", name: "Node" },
+    "k8s.namespace": { identifier: "namespace", name: "Namespace" },
+    "k8s.podName": { identifier: "pod", name: "Pod" },
+    "k8s.containerName": { identifier: "container", name: "Container" }
+};
+
+// Commands
+export const commandKeys = ["comm"] as const;
+export type CommandKey = typeof commandKeys[number];
+export const commandKeyMetadata: ItemMetadata<CommandKey> = {
+    comm: { identifier: "comm", name: "Command" }
+};
+
+// Events
+export const eventKeys = ["type", "message"] as const;
+export type EventKey = typeof eventKeys[number];
+export const eventKeyMetadata: ItemMetadata<EventKey> = {
+    type: { identifier: "type", name: "Type" },
+    message: { identifier: "message", name: "Message" }
+};
+
+// Mount namespace
+export const mountNsKeys = ["mountnsid"] as const;
+export type MountNsKey = typeof mountNsKeys[number];
+export const mountNsKeyMetadata: ItemMetadata<MountNsKey> = {
+    mountnsid: { identifier: "mntns", name: "MountNsID" }
+};
+
+// Network endpoints
+export const networkEndpointKeys = ["src.addr", "src.port", "dst.addr", "dst.port"] as const;
+export type NetworkEndpointKey = typeof networkEndpointKeys[number];
+export const networkEndpointKeyMetadata: ItemMetadata<NetworkEndpointKey> = {
+    "src.addr": { identifier: "src.addr", name: "SrcAddr" },
+    "src.port": { identifier: "src.port", name: "SrcPort" },
+    "dst.addr": { identifier: "dst.addr", name: "DstAddr" },
+    "dst.port": { identifier: "dst.port", name: "DstPort" }
+};
+
+export const derivedNetworkEndpointKeys = ["src", "dst"] as const;
+export type DerivedNetworkEndpointKey = typeof derivedNetworkEndpointKeys[number];
+export const derivedNetworkEndpointProperties: ItemProperty<NetworkEndpointKey | DerivedNetworkEndpointKey>[] = [
+    getDerivedProperty("Src", "src", item => `${item["src.addr"]}:${item["src.port"]}`),
+    getDerivedProperty("Dst", "dst", item => `${item["dst.addr"]}:${item["dst.port"]}`)
+];
+
+// Processes/threads
+export const processThreadKeys = ["pid", "tid"] as const;
+export type ProcessThreadKey = typeof processThreadKeys[number];
+export const processThreadKeyMetadata: ItemMetadata<ProcessThreadKey> = {
+    pid: { identifier: "pid", name: "PID" },
+    tid: { identifier: "tid", name: "TID" }
+};
+
+// Timestamp
+export const timestampKeys = ["timestamp"] as const;
+export type TimestampKey = typeof timestampKeys[number];
+export const timestampKeyMetadata: ItemMetadata<TimestampKey> = {
+    timestamp: { identifier: "timestamp", name: "Timestamp", valueType: ValueType.Timestamp }
+};
+
+// User/group IDs
+export const userKeys = ["uid", "gid"] as const;
+export type UserKey = typeof userKeys[number];
+export const userKeyMetadata: ItemMetadata<UserKey> = {
+    uid: { identifier: "uid", name: "UID" },
+    gid: { identifier: "gid", name: "GID" }
+};

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/profile.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/profile.ts
@@ -1,0 +1,35 @@
+import { commandKeyMetadata, commandKeys, k8sKeyMetadata, k8sKeys } from "./common";
+import { GadgetExtraProperties, GadgetMetadata, ItemMetadata, ItemProperty, ValueType, getDerivedProperty, getLiteralProperties, toProperties } from "./types";
+
+// CPU
+const cpuProfileKeys = [...k8sKeys, ...commandKeys, "pid", "userStack", "kernelStack", "count"] as const;
+type CpuProfileKey = typeof cpuProfileKeys[number];
+const cpuProfileKeyMetadata: ItemMetadata<CpuProfileKey> = {
+    ...k8sKeyMetadata,
+    ...commandKeyMetadata,
+    pid: { identifier: "pid", name: "PID" },
+    userStack: { identifier: "userStack", name: "User Stack" },
+    kernelStack: { identifier: "kernelStack", name: "Kernel Stack" },
+    count: { identifier: "gid", name: "GID" }
+};
+const derivedCpuProfileKeys = ["stack"] as const;
+type DerivedCpuProfileKey = typeof derivedCpuProfileKeys[number];
+const allCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey>[] = [
+    ...getLiteralProperties(cpuProfileKeyMetadata),
+    getDerivedProperty("Stack", "stack", item => {
+        const kernelStack = item.kernelStack ? JSON.parse(item.kernelStack) : [];
+        const userStack = item.userStack ? JSON.parse(item.userStack) : [];
+        return [...kernelStack, ...userStack].join('\n');
+    }, ValueType.StackTrace)
+];
+const defaultCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey>[] = toProperties(
+    allCpuProfileProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","comm","pid","count", "stack"]
+);
+export const cpuProfileMetadata: GadgetMetadata<CpuProfileKey | DerivedCpuProfileKey> = {
+    name: "CPU",
+    allProperties: allCpuProfileProperties,
+    defaultProperties: defaultCpuProfileProperties,
+    defaultSort: null,
+    extraProperties: GadgetExtraProperties.RequiresTimeout
+};

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/snapshot.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/snapshot.ts
@@ -1,0 +1,79 @@
+import { eventKeyMetadata, processThreadKeyMetadata, processThreadKeys, networkEndpointKeys, networkEndpointKeyMetadata, derivedNetworkEndpointKeys, k8sKeys, eventKeys, k8sKeyMetadata, derivedNetworkEndpointProperties, mountNsKeyMetadata, mountNsKeys, commandKeys, commandKeyMetadata, userKeys, userKeyMetadata } from "./common";
+import { GadgetExtraProperties, GadgetMetadata, ItemMetadata, ItemProperty, SortDirection, getLiteralProperties, getSortSpecifiers, toProperties } from "./types";
+
+// Process
+const processSnapshotKeys = [...k8sKeys, ...eventKeys, ...commandKeys, ...processThreadKeys, ...userKeys, "ppid", ...mountNsKeys] as const;
+export type ProcessSnapshotKey = typeof processSnapshotKeys[number];
+const processSnapshotKeyMetadata: ItemMetadata<ProcessSnapshotKey> = {
+    ...k8sKeyMetadata,
+    ...eventKeyMetadata,
+    ...commandKeyMetadata,
+    ...processThreadKeyMetadata,
+    ...userKeyMetadata,
+    ppid: { identifier: "ppid", name: "PPID" },
+    ...mountNsKeyMetadata
+};
+const allProcessSnapshotProperties: ItemProperty<ProcessSnapshotKey>[] = [
+    ...getLiteralProperties(processSnapshotKeyMetadata)
+];
+const defaultProcessSnapshotProperties: ItemProperty<ProcessSnapshotKey>[] = toProperties(
+    allProcessSnapshotProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","comm","pid","tid","uid","gid"]
+);
+const defaultProcessSnapshotSort = getSortSpecifiers(allProcessSnapshotProperties, [
+    {key: "k8s.node", direction: SortDirection.Ascending},
+    {key: "k8s.namespace", direction: SortDirection.Ascending},
+    {key: "k8s.podName", direction: SortDirection.Ascending},
+    {key: "k8s.containerName", direction: SortDirection.Ascending},
+    {key: "comm", direction: SortDirection.Ascending},
+    {key: "pid", direction: SortDirection.Ascending},
+    {key: "tid", direction: SortDirection.Ascending},
+    {key: "ppid", direction: SortDirection.Ascending}
+]);
+export const processSnapshotMetadata: GadgetMetadata<ProcessSnapshotKey> = {
+    name: "Processes",
+    allProperties: allProcessSnapshotProperties,
+    defaultProperties: defaultProcessSnapshotProperties,
+    defaultSort: defaultProcessSnapshotSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed | GadgetExtraProperties.ThreadExclusionAllowed
+};
+
+// Socket
+const socketSnapshotKeys = [...k8sKeys, ...eventKeys, "netnsid", "protocol", ...networkEndpointKeys, "status", "inodeNumber"] as const;
+type SocketSnapshotKey = typeof socketSnapshotKeys[number];
+const socketSnapshotKeyMetadata: ItemMetadata<SocketSnapshotKey> = {
+    ...k8sKeyMetadata,
+    ...eventKeyMetadata,
+    netnsid: { identifier: "netns", name: "NetNS" },
+    protocol: { identifier: "protocol", name: "Protocol" },
+    ...networkEndpointKeyMetadata,
+    status: { identifier: "status", name: "Status" },
+    inodeNumber: { identifier: "inode", name: "Inode" }
+};
+const derivedSocketSnapshotKeys = [...derivedNetworkEndpointKeys] as const;
+type DerivedSocketSnapshotKey = typeof derivedSocketSnapshotKeys[number];
+const allSocketSnapshotProperties: ItemProperty<SocketSnapshotKey | DerivedSocketSnapshotKey>[] = [
+    ...getLiteralProperties(socketSnapshotKeyMetadata),
+    ...derivedNetworkEndpointProperties
+];
+const defaultSocketSnapshotProperties: ItemProperty<SocketSnapshotKey | DerivedSocketSnapshotKey>[] = toProperties(
+    allSocketSnapshotProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","protocol","src","dst","status"]
+);
+const defaultSocketSnapshotSort = getSortSpecifiers(allSocketSnapshotProperties, [
+    {key: "k8s.node", direction: SortDirection.Ascending},
+    {key: "k8s.namespace", direction: SortDirection.Ascending},
+    {key: "k8s.podName", direction: SortDirection.Ascending},
+    {key: "protocol", direction: SortDirection.Ascending},
+    {key: "status", direction: SortDirection.Ascending},
+    {key: "src", direction: SortDirection.Ascending},
+    {key: "dst", direction: SortDirection.Ascending},
+    {key: "inodeNumber", direction: SortDirection.Ascending}
+]);
+export const socketSnapshotMetadata: GadgetMetadata<SocketSnapshotKey | DerivedSocketSnapshotKey> = {
+    name: "Sockets",
+    allProperties: allSocketSnapshotProperties,
+    defaultProperties: defaultSocketSnapshotProperties,
+    defaultSort: defaultSocketSnapshotSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed
+};

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/top.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/top.ts
@@ -1,0 +1,155 @@
+import { networkEndpointKeys, networkEndpointKeyMetadata, derivedNetworkEndpointKeys, k8sKeys, k8sKeyMetadata, derivedNetworkEndpointProperties, mountNsKeys, mountNsKeyMetadata, commandKeys, commandKeyMetadata } from "./common";
+import { GadgetExtraProperties, GadgetMetadata, ItemMetadata, ItemProperty, SortDirection, ValueType, getDerivedProperty, getLiteralProperties, getSortSpecifiers, toProperties } from "./types";
+
+// Blocking IO
+const blockIOTopKeys = [...k8sKeys, ...mountNsKeys, "pid", ...commandKeys, "write", "major", "minor", "bytes", "us", "ops"] as const;
+type BlockIOTopKey = typeof blockIOTopKeys[number];
+const blockIOTopKeyMetadata: ItemMetadata<BlockIOTopKey> = {
+    ...k8sKeyMetadata,
+    ...mountNsKeyMetadata,
+    pid: { identifier: "pid", name: "PID" },
+    ...commandKeyMetadata,
+    write: { identifier: "r/w", name: "R/W" },
+    major: { identifier: "major", name: "Major" },
+    minor: { identifier: "minor", name: "Minor" },
+    bytes: { identifier: "bytes", name: "Bytes" },
+    us: { identifier: "time", name: "Time" },
+    ops: { identifier: "ops", name: "Ops" }
+};
+const allBlockIOTopProperties: ItemProperty<BlockIOTopKey>[] = [
+    ...getLiteralProperties(blockIOTopKeyMetadata)
+];
+const defaultBlockIOTopProperties: ItemProperty<BlockIOTopKey>[] = toProperties(
+    allBlockIOTopProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","pid","comm","write","major","minor","bytes","us","ops"]
+);
+const defaultBlockIOTopSort = getSortSpecifiers(allBlockIOTopProperties, [
+    {key: "ops", direction: SortDirection.Descending},
+    {key: "bytes", direction: SortDirection.Descending},
+    {key: "us", direction: SortDirection.Descending}
+]);
+export const blockIOTopMetadata: GadgetMetadata<BlockIOTopKey> = {
+    name: "Top Block IO",
+    allProperties: allBlockIOTopProperties,
+    defaultProperties: defaultBlockIOTopProperties,
+    defaultSort: defaultBlockIOTopSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed | GadgetExtraProperties.RequiresMaxItemCount
+};
+
+// eBPF
+const ebpfTopKeys = [
+    ...k8sKeys,
+    "progid", "type", "name", "processes.pid", "processes.comm",
+    "currentRuntime", "currentRunCount", "cumulRuntime", "cumulRunCount", "totalRuntime", "totalRunCount",
+    "mapMemory", "mapCount",
+    "totalCpuUsage", "perCpuUsage"] as const;
+type EbpfTopKey = typeof ebpfTopKeys[number];
+const ebpfTopKeyMetadata: ItemMetadata<EbpfTopKey> = {
+    ...k8sKeyMetadata,
+    "progid": { identifier: "progid", name: "Program ID" },
+    "type": { identifier: "type", name: "Type" },
+    "name": { identifier: "name", name: "Name" },
+    "processes.pid": { identifier: "pid", name: "PID" },
+    "processes.comm": { identifier: "comm", name: "Command" },
+    "currentRuntime": { identifier: "runtime", name: "Runtime" },
+    "currentRunCount": { identifier: "runcount", name: "Run Count" },
+    "cumulRuntime": { identifier: "cumulruntime", name: "Cumulative Runtime" },
+    "cumulRunCount": { identifier: "cumulruncount", name: "Cumulative Run Count" },
+    "totalRuntime": { identifier: "totalruntime", name: "Total Runtime" },
+    "totalRunCount": { identifier: "totalRunCount", name: "Total Run Count" },
+    "mapMemory": { identifier: "mapmemory", name: "Map Memory" },
+    "mapCount": { identifier: "mapcount", name: "Map Count" },
+    "totalCpuUsage": { identifier: "totalcpu", name: "Total CPU Usage" },
+    "perCpuUsage": { identifier: "percpu", name: "Per CPU Usage" }
+};
+const allEbpfTopProperties: ItemProperty<EbpfTopKey>[] = [
+    ...getLiteralProperties(ebpfTopKeyMetadata)
+];
+const defaultEbpfTopProperties: ItemProperty<EbpfTopKey>[] = toProperties(
+    allEbpfTopProperties,
+    ["k8s.node","progid","type","name","processes.pid","processes.comm","currentRuntime","currentRunCount","mapMemory","mapCount"]
+);
+const defaultEbpfTopSort = getSortSpecifiers(allEbpfTopProperties, [
+    {key: "currentRuntime", direction: SortDirection.Descending},
+    {key: "currentRunCount", direction: SortDirection.Descending}
+]);
+export const ebpfTopMetadata: GadgetMetadata<EbpfTopKey> = {
+    name: "Top eBPF",
+    allProperties: allEbpfTopProperties,
+    defaultProperties: defaultEbpfTopProperties,
+    defaultSort: defaultEbpfTopSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed | GadgetExtraProperties.RequiresMaxItemCount | GadgetExtraProperties.NoK8sResourceFiltering
+};
+
+// File
+const fileTopKeys = [...k8sKeys, ...mountNsKeys, "pid", ...commandKeys, "reads", "rbytes", "fileType", "filename", "wbytes", "writes"] as const;
+type FileTopKey = typeof fileTopKeys[number];
+const fileTopKeyMetadata: ItemMetadata<FileTopKey> = {
+    ...k8sKeyMetadata,
+    ...mountNsKeyMetadata,
+    pid: { identifier: "pid", name: "PID" },
+    ...commandKeyMetadata,
+    reads: { identifier: "reads", name: "Reads" },
+    rbytes: { identifier: "rbytes", name: "RBytes" },
+    fileType: { identifier: "t", name: "T", valueType: ValueType.CharByte },
+    filename: { identifier: "file", name: "File" },
+    wbytes: { identifier: "wbytes", name: "WBytes" },
+    writes: { identifier: "writes", name: "Writes" }
+};
+const allFileTopProperties: ItemProperty<FileTopKey>[] = [
+    ...getLiteralProperties(fileTopKeyMetadata)
+];
+const defaultFileTopProperties: ItemProperty<FileTopKey>[] = toProperties(
+    allFileTopProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","pid","comm","reads","writes","rbytes","wbytes","fileType","filename"]
+);
+const defaultFileTopSort = getSortSpecifiers(allFileTopProperties, [
+    {key: "reads", direction: SortDirection.Descending},
+    {key: "writes", direction: SortDirection.Descending},
+    {key: "rbytes", direction: SortDirection.Descending},
+    {key: "wbytes", direction: SortDirection.Descending}
+]);
+export const fileTopMetadata: GadgetMetadata<FileTopKey> = {
+    name: "Top File",
+    allProperties: allFileTopProperties,
+    defaultProperties: defaultFileTopProperties,
+    defaultSort: defaultFileTopSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed | GadgetExtraProperties.RequiresMaxItemCount
+};
+
+// TCP
+const tcpTopKeys = [...k8sKeys, ...mountNsKeys, "pid", ...commandKeys, "family", ...networkEndpointKeys, "sent", "received"] as const;
+type TcpTopKey = typeof tcpTopKeys[number];
+const tcpTopKeyMetadata: ItemMetadata<TcpTopKey> = {
+    ...k8sKeyMetadata,
+    ...mountNsKeyMetadata,
+    pid: { identifier: "pid", name: "PID" },
+    ...commandKeyMetadata,
+    family: { identifier: "ip", name: "IP" },
+    ...networkEndpointKeyMetadata,
+    sent: { identifier: "sent", name: "Sent", valueType: ValueType.Bytes },
+    received: { identifier: "recv", name: "Recv", valueType: ValueType.Bytes }
+};
+const derivedTcpTopKeys = ["ip", ...derivedNetworkEndpointKeys] as const;
+type DerivedTcpTopKey = typeof derivedTcpTopKeys[number];
+const allTcpTopProperties: ItemProperty<TcpTopKey | DerivedTcpTopKey>[] = [
+    ...getLiteralProperties(tcpTopKeyMetadata),
+    // https://github.com/inspektor-gadget/inspektor-gadget/blob/08056695b8cfc02698afcbd41add88acfac4d8cf/pkg/gadgets/top/tcp/types/types.go#L64-L69
+    getDerivedProperty("IP", "ip", item => item.family === 2 ? 4 : 6 ),
+    ...derivedNetworkEndpointProperties
+];
+const defaultTcpTopProperties: ItemProperty<TcpTopKey | DerivedTcpTopKey>[] = toProperties(
+    allTcpTopProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","pid","comm","ip","src","dst","sent","received"]
+);
+const defaultTcpTopSort = getSortSpecifiers(allTcpTopProperties, [
+    {key: "sent", direction: SortDirection.Descending},
+    {key: "received", direction: SortDirection.Descending}
+]);
+export const tcpTopMetadata: GadgetMetadata<TcpTopKey | DerivedTcpTopKey> = {
+    name: "Top TCP",
+    allProperties: allTcpTopProperties,
+    defaultProperties: defaultTcpTopProperties,
+    defaultSort: defaultTcpTopSort,
+    extraProperties: GadgetExtraProperties.SortingAllowed | GadgetExtraProperties.RequiresMaxItemCount
+};

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/trace.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/trace.ts
@@ -1,0 +1,109 @@
+import { derivedNetworkEndpointKeys, networkEndpointKeys, networkEndpointKeyMetadata, k8sKeys, k8sKeyMetadata, derivedNetworkEndpointProperties, timestampKeys, mountNsKeys, mountNsKeyMetadata, processThreadKeys, timestampKeyMetadata, processThreadKeyMetadata, commandKeys, commandKeyMetadata, userKeyMetadata, userKeys } from "./common";
+import { GadgetExtraProperties, GadgetMetadata, getDerivedProperty, getLiteralProperties, ItemMetadata, ItemProperty, toProperties, ValueType } from "./types";
+
+// DNS
+const dnsTraceKeys = [...k8sKeys, ...timestampKeys, ...mountNsKeys, "netnsid", ...processThreadKeys, ...commandKeys, ...userKeys, "id", "qr", "nameserver", "pktType", "qtype", "name", "rcode", "numAnswers", "addresses"] as const;
+type DnsTraceKey = typeof dnsTraceKeys[number];
+const dnsTraceKeyMetadata: ItemMetadata<DnsTraceKey> = {
+    ...k8sKeyMetadata,
+    ...timestampKeyMetadata,
+    ...mountNsKeyMetadata,
+    netnsid: { identifier: "netns", name: "NetNS" },
+    ...processThreadKeyMetadata,
+    ...commandKeyMetadata,
+    ...userKeyMetadata,
+    id: { identifier: "id", name: "ID" },
+    qr: { identifier: "qr", name: "QR" },
+    nameserver: { identifier: "nameserver", name: "Nameserver" },
+    pktType: { identifier: "type", name: "Type" },
+    qtype: { identifier: "qtype", name: "QType" },
+    name: { identifier: "name", name: "Name" },
+    rcode: { identifier: "rcode", name: "RCode" },
+    numAnswers: { identifier: "numAnswers", name: "#Answers" },
+    addresses: { identifier: "addresses", name: "Addresses", valueType: ValueType.AddressArray }
+};
+const allDnsTraceProperties: ItemProperty<DnsTraceKey>[] = [
+    ...getLiteralProperties(dnsTraceKeyMetadata)
+];
+const defaultDnsTraceProperties: ItemProperty<DnsTraceKey>[] = toProperties(
+    allDnsTraceProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","pid","tid","comm","qr","pktType","qtype","name","rcode","numAnswers"]
+);
+export const dnsTraceMetadata: GadgetMetadata<DnsTraceKey> = {
+    name: "Trace DNS",
+    allProperties: allDnsTraceProperties,
+    defaultProperties: defaultDnsTraceProperties,
+    defaultSort: null,
+    extraProperties: GadgetExtraProperties.None
+}
+
+// Exec
+const execTraceKeys = [...k8sKeys, ...timestampKeys, ...mountNsKeys, "pid", "ppid", ...commandKeys, "ret", "args", ...userKeys, "loginuid", "sessionid", "cwd"] as const;
+type ExecTraceKey = typeof execTraceKeys[number];
+const execTraceKeyMetadata: ItemMetadata<ExecTraceKey> = {
+    ...k8sKeyMetadata,
+    ...timestampKeyMetadata,
+    ...mountNsKeyMetadata,
+    pid: { identifier: "pid", name: "PID" },
+    ppid: { identifier: "ppid", name: "PPID" },
+    ...commandKeyMetadata,
+    ret: { identifier: "ret", name: "Return" },
+    args: { identifier: "args", name: "Args" },
+    ...userKeyMetadata,
+    loginuid: { identifier: "loginuid", name: "LoginUID" },
+    sessionid: { identifier: "sessionid", name: "SessionID" },
+    cwd: { identifier: "cwd", name: "CWD" }
+}
+const allExecTraceProperties: ItemProperty<ExecTraceKey>[] = [
+    ...getLiteralProperties(execTraceKeyMetadata)
+];
+const defaultExecTraceProperties: ItemProperty<ExecTraceKey>[] = toProperties(
+    allExecTraceProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","pid","ppid","comm","ret","args"]
+);
+export const execTraceMetadata: GadgetMetadata<ExecTraceKey> = {
+    name: "Trace Exec",
+    allProperties: allExecTraceProperties,
+    defaultProperties: defaultExecTraceProperties,
+    defaultSort: null,
+    extraProperties: GadgetExtraProperties.None
+};
+
+// TCP
+const tcpTraceKeys = [...k8sKeys, "operation", "pid", ...commandKeys, "ipversion", ...networkEndpointKeys, ...mountNsKeys] as const;
+type TcpTraceKey = typeof tcpTraceKeys[number];
+const tcpTraceKeyMetadata: ItemMetadata<TcpTraceKey> = {
+    ...k8sKeyMetadata,
+    operation: { identifier: "t", name: "T" },
+    pid: { identifier: "pid", name: "PID" },
+    ...commandKeyMetadata,
+    ipversion: { identifier: "ip", name: "IP" },
+    ...networkEndpointKeyMetadata,
+    ...mountNsKeyMetadata
+};
+const derivedTcpTraceKeys = ["t", ...derivedNetworkEndpointKeys] as const;
+type DerivedTcpTraceKey = typeof derivedTcpTraceKeys[number];
+const allTcpTraceProperties: ItemProperty<TcpTraceKey | DerivedTcpTraceKey>[] = [
+    ...getLiteralProperties(tcpTraceKeyMetadata),
+    ...derivedNetworkEndpointProperties,
+    getDerivedProperty("T", "t", item => tcpOperationDisplay[item.operation] || "U")
+];
+const defaultTcpTraceProperties: ItemProperty<TcpTraceKey | DerivedTcpTraceKey>[] = toProperties(
+    allTcpTraceProperties,
+    ["k8s.node","k8s.namespace","k8s.podName","k8s.containerName","t","pid","comm","ipversion","src","dst"]
+);
+export const tcpTraceMetadata: GadgetMetadata<TcpTraceKey | DerivedTcpTraceKey> = {
+    name: "Trace TCP",
+    allProperties: allTcpTraceProperties,
+    defaultProperties: defaultTcpTraceProperties,
+    defaultSort: null,
+    extraProperties: GadgetExtraProperties.None
+}
+
+// https://github.com/inspektor-gadget/inspektor-gadget/blob/08056695b8cfc02698afcbd41add88acfac4d8cf/pkg/gadgets/trace/tcp/types/types.go#LL40C1-L45C4
+const tcpOperationDisplay: {[op: string]: string} = {
+    accept: "A",
+    connect: "C",
+    close: "X",
+    unknown: "U"
+};

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/types.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/types.ts
@@ -1,0 +1,145 @@
+export const gadgetCategories = ["snapshot", "top", "trace", "profile"] as const;
+export type GadgetCategory = typeof gadgetCategories[number];
+
+export const gadgetProfileResources = ["block-io", "cpu", "tcprtt"] as const;
+export const gadgetSnapshotResources = ["process", "socket"] as const;
+export const gadgetTopResources = ["block-io", "ebpf", "file", "tcp"] as const;
+export const gadgetTraceResources = ["bind", "capabilities", "dns", "exec", "fsslower", "mount", "network", "oomkill", "open", "signal", "sni", "tcp", "tcpconnect", "tcpdrop", "tcpretrans"] as const;
+
+export type GadgetProfileResource = typeof gadgetProfileResources[number];
+export type GadgetSnapshotResource = typeof gadgetSnapshotResources[number];
+export type GadgetTopResource = typeof gadgetTopResources[number];
+export type GadgetTraceResource = typeof gadgetTraceResources[number];
+
+export enum GadgetExtraProperties {
+    None = 0,
+    NoK8sResourceFiltering = 1 << 0,
+    ThreadExclusionAllowed = 1 << 1,
+    SortingAllowed = 1 << 2,
+    RequiresTimeout = 1 << 3,
+    RequiresMaxItemCount = 1 << 4
+}
+
+type ExtraPropertyKeys = Exclude<keyof typeof GadgetExtraProperties, "None">;
+export type GadgetExtraPropertyObject = {[key in ExtraPropertyKeys as Uncapitalize<key>]: boolean};
+
+export type GadgetMetadata<TKey extends string> = {
+    name: string,
+    allProperties: ItemProperty<TKey>[],
+    defaultProperties: ItemProperty<TKey>[],
+    defaultSort: SortSpecifier<TKey>[] | null
+    extraProperties: GadgetExtraProperties
+};
+
+function isExtraPropertySet(allProperties: GadgetExtraProperties, property: GadgetExtraProperties): boolean {
+    return (allProperties & property) === property;
+}
+
+export function toExtraPropertyObject(properties: GadgetExtraProperties): GadgetExtraPropertyObject {
+    return {
+        noK8sResourceFiltering: isExtraPropertySet(properties, GadgetExtraProperties.NoK8sResourceFiltering),
+        requiresMaxItemCount: isExtraPropertySet(properties, GadgetExtraProperties.RequiresMaxItemCount),
+        requiresTimeout: isExtraPropertySet(properties, GadgetExtraProperties.RequiresTimeout),
+        sortingAllowed: isExtraPropertySet(properties, GadgetExtraProperties.SortingAllowed),
+        threadExclusionAllowed: isExtraPropertySet(properties, GadgetExtraProperties.ThreadExclusionAllowed)
+    };
+}
+
+export type ItemKeyMetadata = {
+    identifier: string,
+    name: string
+    valueType?: ValueType
+};
+
+export type ItemMetadata<TKey extends string> = { [key in TKey]: ItemKeyMetadata };
+
+export type DataItem<TKey extends string> = { [key in TKey]: any };
+
+export enum ValueType {
+    Bytes,
+    CharByte,
+    StackTrace,
+    AddressArray,
+    Timestamp
+}
+
+export interface ItemProperty<TKey extends string> {
+    name: string
+    identifier: string
+    key: TKey
+    valueType?: ValueType
+}
+
+export enum SortDirection {
+    Ascending,
+    Descending
+}
+
+export type SortSpecifier<TKey extends string> = {
+    property: ItemProperty<TKey>,
+    direction: SortDirection
+};
+
+export function toSortString(sortSpecifiers: SortSpecifier<any>[]): string {
+    return sortSpecifiers.map(s => `${s.direction === SortDirection.Descending ? '-' : ''}${s.property.identifier}`).join(',');
+}
+
+export function fromSortString(sortString: string, allProperties: ItemProperty<any>[]): SortSpecifier<any>[] {
+    function asSortSpecifier(sortStringItem: string): SortSpecifier<any> | null {
+        let key = sortStringItem.trim();
+        let direction = SortDirection.Ascending;
+        if (key.startsWith('-')) {
+            direction = SortDirection.Descending;
+            key = key.slice(1).trim();
+        }
+    
+        const property = findProperty(allProperties, key);
+        if (!property) {
+            return null;
+        }
+    
+        return { property, direction };
+    }
+
+    return sortString.split(',').map(asSortSpecifier).filter(s => s !== null) as SortSpecifier<any>[];
+}
+
+export interface DerivedItemProperty<TKey extends string, TDerivedKey extends string> extends ItemProperty<TKey | TDerivedKey> {
+    valueGetter: (item: DataItem<TKey>) => any
+}
+
+export function isDerivedProperty<TKey extends string, TDerivedKey extends string>(gadgetProperty: ItemProperty<TKey | TDerivedKey>): gadgetProperty is DerivedItemProperty<TKey, TDerivedKey> {
+    return (gadgetProperty as DerivedItemProperty<TKey, TDerivedKey>).valueGetter !== undefined;
+}
+
+export function getLiteralProperties<TKey extends string>(metadata: ItemMetadata<TKey>): ItemProperty<TKey>[] {
+    return Object.keys(metadata).map(key => key as TKey).map(key => ({
+        name: metadata[key].name,
+        identifier: metadata[key].identifier,
+        key,
+        valueType: metadata[key].valueType
+    }));
+}
+
+export function getDerivedProperty<TKey extends string, TDerivedKey extends string>(name: string, key: TDerivedKey, valueGetter: (item: DataItem<TKey>) => any, valueType?: ValueType): DerivedItemProperty<TKey, TDerivedKey> {
+    return {name, identifier: key, key, valueGetter, valueType};
+}
+
+export function findProperty<TKey extends string>(properties: ItemProperty<TKey>[], key: TKey): ItemProperty<TKey> | null {
+    const result = properties.find(p => p.key === key);
+    if (!result) {
+        return null;
+    }
+    return result;
+}
+
+export function toProperties<TKey extends string>(allProperties: ItemProperty<TKey>[], keys: TKey[]): ItemProperty<TKey>[] {
+    return keys.map(key => findProperty(allProperties, key)).filter(p => p !== null) as ItemProperty<TKey>[];
+}
+
+export function getSortSpecifiers<TKey extends string>(properties: ItemProperty<TKey>[], specifiers: {key: TKey, direction: SortDirection}[]): SortSpecifier<TKey>[] {
+    return specifiers.map(s => ({
+        property: findProperty(properties, s.key),
+        direction: s.direction
+    })).filter(s => s.property !== null) as SortSpecifier<TKey>[];
+}

--- a/webview-ui/src/InspektorGadget/helpers/state.ts
+++ b/webview-ui/src/InspektorGadget/helpers/state.ts
@@ -1,0 +1,114 @@
+import { ClusterResources, Nodes, setContainersLoading, setPodsLoading, updateContainersForCluster, updateNamespacesForCluster, updateNodesForCluster, updatePodsForCluster } from "./clusterResources";
+import { UserMsgDef } from "./userCommands";
+import { newLoading, newNotLoaded } from "../../utilities/lazy";
+import { TraceGadget, enrich, enrichSortAndFilter } from "./gadgets";
+import { GadgetVersion, ToWebViewMsgDef, TraceOutputItem } from "../../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { StateMessageHandler, chainStateUpdaters, toStateUpdater } from "../../utilities/state";
+
+// TODO: Make configurable?
+const maxTraceOutputLength = 1000;
+
+export interface InspektorGadgetState {
+    initializationStarted: boolean
+    nextTraceId: number
+    version: GadgetVersion | null
+    nodes: Nodes
+    resources: ClusterResources
+    overviewStatus: string
+    allTraces: TraceGadget[]
+}
+
+export function createState(): InspektorGadgetState {
+    return {
+        initializationStarted: false,
+        nextTraceId: 0,
+        version: null,
+        nodes: newNotLoaded(),
+        resources: newNotLoaded(),
+        overviewStatus: "Initializing",
+        allTraces: []
+    };
+}
+
+export const vscodeMessageHandler: StateMessageHandler<ToWebViewMsgDef, InspektorGadgetState> = {
+    updateVersion: (state, args) => {
+        return { ...state, overviewStatus: "", version: args };
+    },
+    runTraceResponse: (state, args) => {
+        const allTraces = getUpdatedTraces(state.allTraces, args.traceId, args.items);
+        return { ...state, allTraces };
+    },
+    getNodesResponse: (state, args) => {
+        return { ...state, nodes: updateNodesForCluster(args.nodes) };
+    },
+    getNamespacesResponse: (state, args) => {
+        return { ...state, resources: updateNamespacesForCluster(args.namespaces) };
+    },
+    getPodsResponse: (state, args) => {
+        return { ...state, resources: updatePodsForCluster(state.resources, args.namespace, args.podNames) };
+    },
+    getContainersResponse: (state, args) => {
+        return { ...state, resources: updateContainersForCluster(state.resources, args.namespace, args.podName, args.containerNames) };
+    }
+};
+
+export const userMessageHandler: StateMessageHandler<UserMsgDef, InspektorGadgetState> = {
+    setInitializing: (state) => {
+        return { ...state, initializationStarted: true };
+    },
+    deploy: (state) => {
+        return { ...state, overviewStatus: "Deploying Inspektor Gadget", version: null };
+    },
+    undeploy: (state) => {
+        return { ...state, overviewStatus: "Undeploying Inspektor Gadget", version: null };
+    },
+    incrementTraceId: (state) => {
+        return { ...state, nextTraceId: state.nextTraceId + 1 };
+    },
+    createTrace: (state, args) => {
+        const allTraces = [...state.allTraces, args.trace];
+        return { ...state, allTraces };
+    },
+    deleteTraces: (state, args) => {
+        const allTraces = state.allTraces.filter(t => !args.traceIds.includes(t.traceId));
+        return { ...state, allTraces };
+    },
+    setNodesLoading: (state) => {
+        return { ...state, nodes: newLoading() };
+    },
+    setNamespacesLoading: (state) => {
+        return { ...state, resources: newLoading() };
+    },
+    setPodsLoading: (state, args) => {
+        return { ...state, resources: setPodsLoading(state.resources, args.namespace) };
+    },
+    setContainersLoading: (state, args) => {
+        return { ...state, resources: setContainersLoading(state.resources, args.namespace, args.podName) };
+    },
+    setNodesNotLoaded: (state) => {
+        return { ...state, nodes: newNotLoaded() };
+    },
+    setNamespacesNotLoaded: (state) => {
+        return { ...state, resources: newNotLoaded() };
+    }
+};
+
+export const updateState = chainStateUpdaters(
+    toStateUpdater(vscodeMessageHandler),
+    toStateUpdater(userMessageHandler));
+
+function getUpdatedTraces(traces: TraceGadget[], traceId: number, items: TraceOutputItem[]): TraceGadget[] {
+    const traceIndex = traces.findIndex(t => t.traceId === traceId);
+    if (traceIndex === -1) {
+        return traces;
+    }
+
+    const trace = traces[traceIndex];
+    const appendItems = trace.category === "trace";
+    const newItems =
+        appendItems ? [...(trace.output || []), ...enrich(trace, items)].slice(-maxTraceOutputLength) // Append to the existing items.
+        : enrichSortAndFilter(trace, items); // Replace the existing items in the trace.
+
+    const newTrace = { ...trace, output: newItems };
+    return [...traces.slice(0, traceIndex), newTrace, ...traces.slice(traceIndex + 1)];
+}

--- a/webview-ui/src/InspektorGadget/helpers/userCommands.ts
+++ b/webview-ui/src/InspektorGadget/helpers/userCommands.ts
@@ -1,0 +1,28 @@
+import { Message } from "../../../../src/webview-contract/messaging";
+import { TraceGadget } from "./gadgets";
+
+export type UserMsgDef = {
+    setInitializing: void,
+    deploy: void,
+    undeploy: void,
+    incrementTraceId: void,
+    createTrace: {
+        trace: TraceGadget
+    },
+    deleteTraces: {
+        traceIds: number[]
+    },
+    setNodesLoading: void,
+    setNamespacesLoading: void,
+    setPodsLoading: {
+        namespace: string
+    },
+    setContainersLoading: {
+        namespace: string,
+        podName: string
+    },
+    setNodesNotLoaded: void,
+    setNamespacesNotLoaded: void
+}
+
+export type UserMessage = Message<UserMsgDef>;

--- a/webview-ui/src/Periscope/Periscope.tsx
+++ b/webview-ui/src/Periscope/Periscope.tsx
@@ -1,13 +1,13 @@
 import { VSCodeDivider, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { useEffect, useState } from "react";
-import { InitialState, NodeUploadStatus, PodLogs, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/periscope";
+import { InitialState, NodeUploadStatus, PodLogs } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { getWebviewMessageContext } from "../utilities/vscode";
 import { ErrorView } from "./ErrorView";
 import { NoDiagnosticSettingView } from "./NoDiagnosticSettingView";
 import { SuccessView } from "./SuccessView";
 
 export function Periscope(props: InitialState) {
-    const vscode = getWebviewMessageContext<ToVsCodeMsgDef, ToWebViewMsgDef>();
+    const vscode = getWebviewMessageContext<"periscope">();
 
     const [nodeUploadStatuses, setNodeUploadStatuses] = useState<NodeUploadStatus[]>(props.nodes.map(n => ({ nodeName: n, isUploaded: false })));
     const [selectedNode, setSelectedNode] = useState<string>("");

--- a/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
+++ b/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import { CssRule, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
+import { CssRule, InitialState } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
 import { getWebviewMessageContext } from "../utilities/vscode";
 
 export function TestStyleViewer(props: InitialState) {
-    const vscode = getWebviewMessageContext<ToVsCodeMsgDef, ToWebViewMsgDef>();
+    const vscode = getWebviewMessageContext<"style">();
 
     const [cssVars, setCssVars] = useState<string[]>([]);
     const [cssRules, setCssRules] = useState<CssRule[]>([]);

--- a/webview-ui/src/components/Dialog.tsx
+++ b/webview-ui/src/components/Dialog.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+interface DialogProps {
+    isShown: boolean
+    onCancel: () => void
+}
+
+export function Dialog(props: React.PropsWithChildren<DialogProps>) {
+    const dialogRef = useRef<HTMLDialogElement>(null);
+
+    useEffect(() => {
+        document.body.addEventListener("click", handleDocumentClick);
+        return () => document.removeEventListener("click", handleDocumentClick);
+    });
+
+    useEffect(() => {
+        dialogRef.current?.addEventListener("close", handleClose);
+        return () => dialogRef.current?.removeEventListener("close", handleClose);
+    });
+
+    useEffect(() => {
+        if (props.isShown && !dialogRef.current!.hasAttribute("open")) {
+            dialogRef.current!.showModal();
+        } else if (!props.isShown && dialogRef.current!.hasAttribute("open")) {
+            dialogRef.current!.close();
+        }
+    }, [props.isShown, dialogRef]);
+
+    function handleClose() {
+        if (props.isShown) {
+            props.onCancel();
+        }
+    }
+
+    function handleDocumentClick(e: MouseEvent) {
+        if(e.target === dialogRef.current) {
+            e.preventDefault();
+            e.stopPropagation();
+            dialogRef.current!.close();
+        }
+    }
+
+    return (
+        <dialog ref={dialogRef}>
+            {props.children}
+        </dialog>
+    )
+}

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -84,3 +84,9 @@ kbd {
 ::highlight(current-find-highlight) {
   background-color: var(--vscode-editor-findMatchBackground);
 }
+
+dialog {
+  background-color: var(--vscode-editor-background);
+  color: var(--vscode-editor-foreground);
+  border-color: var(--vscode-editorGroup-border);
+}

--- a/webview-ui/src/main.tsx
+++ b/webview-ui/src/main.tsx
@@ -6,6 +6,7 @@ import { ContentId } from "../../src/webview-contract/webviewTypes";
 import { TestStyleViewer } from "./TestStyleViewer/TestStyleViewer";
 import { Periscope } from "./Periscope/Periscope";
 import { Detector } from "./Detector/Detector";
+import { InspektorGadget } from "./InspektorGadget/InspektorGadget";
 
 // There are two modes of launching this application:
 // 1. Via the VS Code extension inside a Webview.
@@ -33,7 +34,8 @@ function getVsCodeContent(): JSX.Element {
     const rendererLookup: Record<ContentId, () => JSX.Element> = {
         style: () => <TestStyleViewer {...vsCodeInitialState} />,
         periscope: () => <Periscope {...vsCodeInitialState} />,
-        detector: () => <Detector {...vsCodeInitialState} />
+        detector: () => <Detector {...vsCodeInitialState} />,
+	gadget: () => <InspektorGadget {...vsCodeInitialState} />
     };
 
     return rendererLookup[vscodeContentId]();

--- a/webview-ui/src/manualTest/inspektorGadgetTests.tsx
+++ b/webview-ui/src/manualTest/inspektorGadgetTests.tsx
@@ -1,0 +1,324 @@
+import { GadgetArguments, GadgetVersion, InitialState, TraceOutputItem } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
+import { ToVsCodeMessageHandler } from "../../../src/webview-contract/webviewTypes";
+import { InspektorGadget } from "../InspektorGadget/InspektorGadget";
+import { getGadgetMetadata } from "../InspektorGadget/helpers/gadgets";
+import { GadgetCategory, isDerivedProperty } from "../InspektorGadget/helpers/gadgets/types";
+import { distinct, exclude } from "../utilities/array";
+import { Scenario } from "../utilities/manualTest";
+import { getTestVscodeMessageContext } from "../utilities/vscode";
+
+type ContainerInfo = { name: string, pid: number, mountNsId: number, comm: string, ppid: number, tids: number[] };
+type PodContainers = { [podName: string]: ContainerInfo[] };
+type NamespaceResources = { [namespace: string]: PodContainers };
+type NodeResources = { [node: string]: NamespaceResources };
+
+const nodeResources: NodeResources = {
+    "testnode01": {
+        "kube-system": {
+            "konnectivity-agent-00001": [{name: "konnectivity-agent", pid: 1000, mountNsId: 4000000000, comm: "proxy-agent", ppid: 100, tids: [10000]}],
+            "coredns-00001": [{name: "coredns", pid: 1001, mountNsId: 4000000001, comm: "coredns", ppid: 101, tids: [10001]}]
+        },
+        "default": {
+            "testpod-00001": [
+                {name: "testpod", pid: 1002, mountNsId: 4000000002, comm: "testapp", ppid: 102, tids: [10002]},
+                {name: "testsidecar", pid: 1003, mountNsId: 4000000003, comm: "test2", ppid: 103, tids: [10003,10004]}
+            ]
+        }
+    },
+    "testnode02": {
+        "kube-system": {
+            "konnectivity-agent-00002": [{name: "konnectivity-agent", pid: 2000, mountNsId: 4000000000, comm: "proxy-agent", ppid: 200, tids: [20000]}],
+            "coredns-00002": [{name: "coredns", pid: 2001, mountNsId: 4000000001, comm: "coredns", ppid: 201, tids: [20001]}]
+        },
+        "default": {
+            "testpod-00002": [
+                {name: "testpod", pid: 2002, mountNsId: 4000000002, comm: "testapp", ppid: 202, tids: [20002]},
+                {name: "testsidecar", pid: 2003, mountNsId: 4000000003, comm: "test2", ppid: 203, tids: [20003,20004]}
+            ]
+        }
+    }
+}
+
+function getNamespaces(node: string): string[] {
+    const thisNodeResources = nodeResources[node];
+    if (!thisNodeResources) {
+        return [];
+    }
+    return Object.keys(thisNodeResources);
+}
+
+function getPodNames(node: string, namespace: string): string[] {
+    if (!getNamespaces(node).includes(namespace)) {
+        return [];
+    }
+    return Object.keys(nodeResources[node][namespace]);
+}
+
+function getContainers(node: string, namespace: string, pod: string): string[] {
+    if (!getPodNames(node, namespace).includes(pod)) {
+        return [];
+    }
+    return nodeResources[node][namespace][pod].map(c => c.name);
+}
+
+const nodes = Object.keys(nodeResources);
+
+export function getInspektorGadgetScenarios() {
+    let version: GadgetVersion = {client: "1.0.0", server: "1.0.0" };
+    let watchTimer: NodeJS.Timer;
+
+    const webview = getTestVscodeMessageContext<"gadget">();
+    const messageHandler: ToVsCodeMessageHandler<"gadget"> = {
+        getVersionRequest: handleGetVersionRequest,
+        deployRequest: handleDeployRequest,
+        undeployRequest: handleUndeployRequest,
+        runStreamingTraceRequest: args => handleRunStreamingTraceRequest(args.traceId, args.arguments),
+        runBlockingTraceRequest: args => handleRunBlockingTraceRequest(args.traceId, args.arguments),
+        stopStreamingTraceRequest: handleStopWatchingTraceRequest,
+        getNodesRequest: handleGetNodesRequest,
+        getNamespacesRequest: handleGetNamespacesRequest,
+        getPodsRequest: args => handleGetPodsRequest(args.namespace),
+        getContainersRequest: args => handleGetContainersRequest(args.namespace, args.podName)
+    };
+
+    async function handleGetVersionRequest() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        webview.postMessage({ command: "updateVersion", parameters: version });
+    }
+
+    async function handleDeployRequest() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        version = { client: "1.0.0", server: "1.0.0" };
+        webview.postMessage({ command: "updateVersion", parameters: version });
+    }
+
+    async function handleUndeployRequest() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        version = { client: "1.0.0", server: null };
+        webview.postMessage({ command: "updateVersion", parameters: version });
+    }
+
+    function handleRunStreamingTraceRequest(traceId: number, args: GadgetArguments) {
+        if (watchTimer) {
+            clearInterval(watchTimer);
+        }
+
+        const refreshIntervalMs = (args.interval || 1) * 1000;
+        watchTimer = setInterval(() => emitTraceOutput(args, traceId), refreshIntervalMs);
+    }
+
+    async function handleRunBlockingTraceRequest(traceId: number, args: GadgetArguments) {
+        const useSpecifiedTimeout = args.gadgetCategory === "profile" && args.timeout;
+        const waitTime = useSpecifiedTimeout ? args.timeout! * 1000 : 2000;
+        await new Promise(resolve => setTimeout(resolve, waitTime));
+        const items = Array.from({ length: 10 }, _ => getTraceItem(args));
+        webview.postMessage({ command: "runTraceResponse", parameters: {items, traceId} });
+    }
+
+    function handleStopWatchingTraceRequest() {
+        if (watchTimer) {
+            clearInterval(watchTimer);
+        }
+    }
+
+    async function handleGetNodesRequest() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        webview.postMessage({ command: "getNodesResponse", parameters: {nodes} });
+    }
+
+    async function handleGetNamespacesRequest() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const namespaces = distinct(nodes.flatMap(node => getNamespaces(node)));
+        webview.postMessage({ command: "getNamespacesResponse", parameters: {namespaces} });
+    }
+
+    async function handleGetPodsRequest(namespace: string) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const podNames = distinct(nodes.flatMap(node => getPodNames(node, namespace)));
+        webview.postMessage({ command: "getPodsResponse", parameters: {namespace, podNames} });
+    }
+
+    async function handleGetContainersRequest(namespace: string, podName: string) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const containerNames = distinct(nodes.flatMap(node => getContainers(node, namespace, podName)));
+        webview.postMessage({ command: "getContainersResponse", parameters: {namespace, podName, containerNames} });
+    }
+
+    function emitTraceOutput(config: GadgetArguments, traceId: number) {
+        const isTopTrace = config.gadgetCategory === "top";
+        if (isTopTrace) {
+            const maxRows = config.maxRows!;
+            const items = Array.from({ length: maxRows }, _ => getTraceItem(config));
+            webview.postMessage({ command: "runTraceResponse", parameters: {items, traceId}  });
+        } else {
+            const items = [getTraceItem(config)];
+            webview.postMessage({ command: "runTraceResponse", parameters: {items, traceId} });
+        }
+    }
+
+    function getTraceItem(gadgetArgs: GadgetArguments): TraceOutputItem {
+        const gadgetMetadata = getGadgetMetadata(gadgetArgs.gadgetCategory as GadgetCategory, gadgetArgs.gadgetResource);
+        const expectedKeys = gadgetMetadata?.allProperties.filter(p => !isDerivedProperty(p)).map(p => p.key) || [];
+        const node = nodes[~~(Math.random() * nodes.length)];
+        const namespaces = Object.keys(nodeResources[node]);
+        const namespace = namespaces[~~(Math.random() * namespaces.length)];
+        const pods = Object.keys(nodeResources[node][namespace]);
+        const pod = pods[~~(Math.random() * pods.length)];
+        const containers = nodeResources[node][namespace][pod];
+        const container = containers[~~(Math.random() * containers.length)];
+        const threadIds = [container.pid, ...container.tids];
+        const threadId = threadIds[~~(Math.random() * threadIds.length)];
+
+        const stats = {
+            "k8s.node": node,
+            "k8s.namespace": namespace,
+            "k8s.podName": pod,
+            "k8s.containerName": container.name,
+            "processes.pid": container.pid,
+            "processes.comm": container.comm,
+            pid: container.pid,
+            mountnsid: container.mountNsId,
+            comm: container.comm,
+            ppid: container.ppid,
+            uid: 0,
+            gid: 1,
+            tid: threadId
+        };
+
+        const populatedKeys = Object.keys(stats);
+        const remainingColumns = exclude(expectedKeys, populatedKeys);
+
+        return remainingColumns.reduce<TraceOutputItem>(
+            (stats, key) => {
+                stats[key] = getTraceStatsValue(key);
+                return stats;
+            },
+            stats
+        );
+    }
+
+    function getTraceStatsValue(columnKey: string): any {
+        const operations = ["accept", "close"];
+        const protocols = ["TCP", "UDP"];
+        const qrValues = ["Q", "R"];
+        const packetTypes = ["HOST", "OUTGOING", "OTHERHOST"];
+        const queryTypes = ["A", "AAAA"];
+        const socketStatuses = ["ESTABLISHED", "LISTEN", "TIME_WAIT", "INACTIVE", "ACTIVE"];
+        switch (columnKey) {
+            case "family":
+                return 2;
+            case "ipversion":
+                return 4;
+            case "src.addr":
+                return "10.244.0.11";
+            case "dst.addr":
+                return "52.191.16.54";
+            case "src.port":
+                return "55555";
+            case "dst.port":
+                return "443";
+            case "sent":
+                return ~~(Math.random() * 1000);
+            case "received":
+                return ~~(Math.random() * 1000);
+            case "type":
+                return "normal";
+            case "message":
+                return undefined; // Set when type is in (ERR, WARN, DEBUG, INFO)
+            case "operation":
+                return operations[~~(Math.random() * operations.length)];
+            case "netnsid":
+                return ~~(Math.random() * 1000000000) + 4000000000;
+            case "protocol":
+                return protocols[~~(Math.random() * protocols.length)];
+            case "status":
+                return socketStatuses[~~(Math.random() * socketStatuses.length)];
+            case "inodeNumber":
+                return ~~(Math.random() * 65535);
+            case "reads":
+                return ~~(Math.random() * 100);
+            case "writes":
+                return ~~(Math.random() * 10);
+            case "rbytes":
+                return ~~(Math.random() * 10000);
+            case "wbytes":
+                return ~~(Math.random() * 1000);
+            case "fileType":
+                return 'R'.charCodeAt(0);
+            case "filename":
+                return "file.txt";
+            case "write":
+                return !~~(Math.random() * 2);
+            case "major":
+                return ~~(Math.random() * 10);
+            case "minor":
+                return undefined;
+            case "bytes":
+                return ~~(Math.random() * 1000);
+            case "us":
+                return ~~(Math.random() * 1000);
+            case "ops":
+                return ~~(Math.random() * 100);
+            case "currentRuntime":
+                return ~~(Math.random() * 1000);
+            case "currentRunCount":
+                return ~~(Math.random() * 10);
+            case "cumulRuntime":
+                return ~~(Math.random() * 10000);
+            case "cumulRunCount":
+                return ~~(Math.random() * 100);
+            case "totalRuntime":
+                return ~~(Math.random() * 20000);
+            case "totalRunCount":
+                return ~~(Math.random() * 200);
+            case "mapMemory":
+                return ~~(Math.random() * 10000);
+            case "mapCount":
+                return ~~(Math.random() * 10);
+            case "totalCpuUsage":
+                return ~~(Math.random() * 100) * 0.0001;
+            case "perCpuUsage":
+                return ~~(Math.random() * 100) * 0.0001;
+            case "kernelStack":
+                return `["hrtimer_active", "do_nanosleep", "hrtimer_nanosleep", "__x64_sys_nanosleep", "do_syscall_64", "entry_SYSCALL_64_after_hwframe"]`;
+            case "userStack":
+                return `["[unknown]", "[unknown]", "[unknown]", "[unknown]", "[unknown]", "[unknown]", "[unknown]"]`;
+            case "count":
+                return ~~(Math.random() * 5);
+            case "timestamp":
+                return new Date().getTime() * 1000000 + ~~(Math.random() * 1000000); // fake nanosecond resolution
+            case "id":
+                return Array.from({length: 4}, _ => ~~(Math.random() * 16)).map(byte => (byte & 0xff).toString(16)).join(''); // Random 4-character hex string
+            case "qr":
+                return qrValues[~~(Math.random() * qrValues.length)];
+            case "nameserver":
+                return "168.61.144.22";
+            case "pktType":
+                return packetTypes[~~(Math.random() * packetTypes.length)];
+            case "qtype":
+                return queryTypes[~~(Math.random() * queryTypes.length)];
+            case "name":
+                return "some.domain.com";
+            case "rcode":
+                return "NoError";
+            case "numAnswers":
+                return 1;
+            case "addresses":
+                return `["20.40.70.210"]`;
+            case "ret":
+                return 0;
+            case "args":
+                return `["-arg", "14"]`;
+            case "cwd":
+                return "/path/to/cwd";
+            default:
+                return `${columnKey}?`;
+        }
+    }
+
+    const initialState: InitialState = {};
+
+    return [
+        Scenario.create("Inspektor Gadget", () => <InspektorGadget {...initialState} />).withSubscription(webview, messageHandler)
+    ];
+}

--- a/webview-ui/src/manualTest/main.tsx
+++ b/webview-ui/src/manualTest/main.tsx
@@ -6,6 +6,7 @@ import { TestScenarioSelector } from "./TestScenarioSelector/TestScenarioSelecto
 import { getTestStyleViewerScenarios } from "./testStyleViewerTests";
 import { getPeriscopeScenarios } from "./periscopeTests";
 import { getDetectorScenarios } from "./detectorTests";
+import { getInspektorGadgetScenarios } from "./inspektorGadgetTests";
 import { ContentId } from "../../../src/webview-contract/webviewTypes";
 import { Scenario } from "../utilities/manualTest";
 
@@ -24,7 +25,8 @@ const rootElem = document.getElementById("root");
 const contentTestScenarios: Record<ContentId, Scenario[]> = {
     style: getTestStyleViewerScenarios(),
     periscope: getPeriscopeScenarios(),
-    detector: getDetectorScenarios()
+    detector: getDetectorScenarios(),
+    gadget: getInspektorGadgetScenarios()
 };
 
 const testScenarios = Object.values(contentTestScenarios).flatMap(s => s);

--- a/webview-ui/src/manualTest/periscopeTests.tsx
+++ b/webview-ui/src/manualTest/periscopeTests.tsx
@@ -1,5 +1,5 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
-import { InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/periscope";
+import { InitialState, ToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { Scenario } from "../utilities/manualTest";
 import { getTestVscodeMessageContext } from "../utilities/vscode";
 import { Periscope } from "../Periscope/Periscope";
@@ -51,7 +51,7 @@ export function getPeriscopeScenarios() {
         shareableSas
     };
 
-    const webview = getTestVscodeMessageContext<ToWebViewMsgDef, ToVsCodeMsgDef>();
+    const webview = getTestVscodeMessageContext<"periscope">();
     const messageHandler: MessageHandler<ToVsCodeMsgDef> = {
         nodeLogsRequest: args => handleNodeLogsRequest(args.nodeName),
         uploadStatusRequest: handleUploadStatusRequest

--- a/webview-ui/src/manualTest/testStyleViewerTests.tsx
+++ b/webview-ui/src/manualTest/testStyleViewerTests.tsx
@@ -1,11 +1,11 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
-import { CssRule, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
+import { CssRule, InitialState, ToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
 import { Scenario } from "./../utilities/manualTest";
 import { getTestVscodeMessageContext } from "./../utilities/vscode";
 import { TestStyleViewer } from "./../TestStyleViewer/TestStyleViewer";
 
 export function getTestStyleViewerScenarios() {
-    const webview = getTestVscodeMessageContext<ToWebViewMsgDef, ToVsCodeMsgDef>();
+    const webview = getTestVscodeMessageContext<"style">();
     const messageHandler: MessageHandler<ToVsCodeMsgDef> = {
         reportCssRules: args => handleReportCssRules(args.rules),
         reportCssVars: args => handleReportCssVars(args.cssVars)

--- a/webview-ui/src/utilities/array.ts
+++ b/webview-ui/src/utilities/array.ts
@@ -1,0 +1,30 @@
+export type Lookup<T> = {
+    [key: string]: T
+};
+
+export function asLookup<T>(items: T[], keyFn: (value: T) => string): Lookup<T> {
+    const entries = items.map(val => [keyFn(val), val]);
+    return Object.fromEntries(entries);
+}
+
+export function replaceItem<T>(items: T[], predicate: (item: T) => boolean, replacer: (item: T) => T): T[] {
+    const index = items.findIndex(predicate);
+    if (index === -1) {
+        return items;
+    }
+
+    const newItem = replacer(items[index]);
+    return [...items.slice(0, index), newItem, ...items.slice(index + 1)];
+}
+
+export function distinct(items: string[]) {
+    return [...new Set(items)];
+}
+
+export function intersection<T>(itemsA: T[], itemsB: T[]): T[] {
+    return itemsA.filter(a => itemsB.includes(a));
+}
+
+export function exclude<T>(take: T[], exclude: T[]): T[] {
+    return take.filter(a => !exclude.includes(a));
+}

--- a/webview-ui/src/utilities/lazy.ts
+++ b/webview-ui/src/utilities/lazy.ts
@@ -1,0 +1,56 @@
+enum LoadingState {
+    NotLoaded,
+    Loading,
+    Loaded
+}
+
+export type NotLoaded = {
+    loadingState: LoadingState.NotLoaded
+};
+
+export type Loading = {
+    loadingState: LoadingState.Loading
+};
+
+export type Loaded<T> = {
+    loadingState: LoadingState.Loaded
+    value: T
+};
+
+export type Lazy<T> = NotLoaded | Loading | Loaded<T>;
+
+export function isNotLoaded<T>(l: Lazy<T>): l is NotLoaded {
+    return l.loadingState === LoadingState.NotLoaded;
+}
+
+export function isLoading<T>(l: Lazy<T>): l is Loading {
+    return l.loadingState === LoadingState.Loading;
+}
+
+export function isLoaded<T>(l: Lazy<T>): l is Loaded<T> {
+    return l.loadingState === LoadingState.Loaded;
+}
+
+export function newNotLoaded(): NotLoaded {
+    return { loadingState: LoadingState.NotLoaded };
+}
+
+export function newLoading(): Loading {
+    return { loadingState: LoadingState.Loading };
+}
+
+export function newLoaded<T>(value: T): Loaded<T> {
+    return { loadingState: LoadingState.Loaded, value };
+}
+
+export function orDefault<T>(lazy: Lazy<T>, fallback: T): T {
+    return isLoaded(lazy) ? lazy.value : fallback;
+}
+
+export function map<T1, T2>(l: Lazy<T1>, fn: (f: T1) => T2): Lazy<T2> {
+    if (!isLoaded(l)) {
+        return l;
+    }
+
+    return newLoaded(fn(l.value));
+}

--- a/webview-ui/src/utilities/state.ts
+++ b/webview-ui/src/utilities/state.ts
@@ -1,0 +1,83 @@
+import { Command, MessageDefinition, MessageHandler } from "../../../src/webview-contract/messaging";
+
+/**
+ * The type used to define handlers for messages that change the state of a component
+ * when using a reducer (https://react.dev/reference/react/useReducer).
+ */
+export type StateMessageHandler<TMsgDef extends MessageDefinition, TState> = {
+    [P in Command<TMsgDef>]: (state: TState, msg: TMsgDef[P]) => TState
+};
+
+/**
+ * The type of the 'action' in the reducer.
+ */
+export type StateMessage = {
+    command: string,
+    args?: any
+};
+
+/**
+ * A reducer type that uses the `StateMessage` action. This is a function that applies an action
+ * to a state to return another state.
+ */
+export type StateUpdater<TState> = React.Reducer<TState, StateMessage>;
+
+/**
+ * Takes a message handler for updating state and creates a reducer that can be used in the
+ * `useReducer` function.
+ */
+export function toStateUpdater<TMsgDef extends MessageDefinition, TState>(handler: StateMessageHandler<TMsgDef, TState>): StateUpdater<TState> {
+    return (state, msg) => {
+        if (msg.command in handler) {
+            return handler[msg.command](state, msg.args);
+        }
+
+        return state;
+    }
+}
+
+/**
+ * Allows multiple reducers to be combined into a single one (used when processing different types of message).
+ */
+export function chainStateUpdaters<TState>(...stateUpdaters: StateUpdater<TState>[]): StateUpdater<TState> {
+    return stateUpdaters.reduce((prev, curr) => {
+        return (state, msg) => curr(prev(state, msg), msg);
+    }, state => state);
+}
+
+/**
+ * An event handler type for a particular kind of message. Each command in the message definition is prefixed
+ * with `on`.
+ */
+export type EventHandlers<TMsgDef extends MessageDefinition> = {
+    [P in Command<TMsgDef> as `on${Capitalize<P>}`]: (args: TMsgDef[P]) => void
+};
+
+/**
+ * Any object containing all the keys (commands) for a message definition.
+ */
+export type CommandKeys<TMsgDef> = {
+    [P in Command<TMsgDef>]: any
+};
+
+/**
+ * Creates event handlers for a message definition which forward calls to the `dispatch` function
+ * (https://react.dev/reference/react/useReducer#dispatch)
+ */
+export function getEventHandlers<TMsgDef extends MessageDefinition>(dispatch: React.Dispatch<StateMessage>, keys: CommandKeys<TMsgDef>): EventHandlers<TMsgDef> {
+    const entries = Object.keys(keys).map(command => [asEvent(command), (args: any) => dispatch({command: command, args})]);
+    return Object.fromEntries(entries);
+}
+
+function asEvent(str: string) {
+    return "on" + str[0].toUpperCase() + str.slice(1);
+}
+
+/**
+ * Creates a handler for a message definition which can be used by a message subscriber, and which
+ * forwards invocations to the `dispatch` function.
+ */
+export function getMessageHandler<TMsgDef extends MessageDefinition>(dispatch: React.Dispatch<StateMessage>, keys: CommandKeys<TMsgDef>): MessageHandler<TMsgDef> {
+    const entries = Object.keys(keys).map(command => [command, (args: any) => dispatch({command: command, args})]);
+    return Object.fromEntries(entries);
+}


### PR DESCRIPTION
The outcome of discussion #203.

Replaces all the previous Inspektor Gadget commands in the nested context menu with a single 'Show Inspektor Gadget' command, which launches a webview providing all the functionality previously supplied by the individual commands.

Example view:
![ig-webview-4](https://github.com/Azure/vscode-aks-tools/assets/1817696/4869d21b-1958-4073-a9a2-1db21debf92f)
