### PR TITLE
Simplify definitions of messages and handlers for webviews

### DIFF
--- a/src/panels/DetectorPanel.ts
+++ b/src/panels/DetectorPanel.ts
@@ -1,16 +1,16 @@
 import { Uri } from "vscode";
-import { MessageSink, MessageSubscriber } from "../webview-contract/messaging";
+import { MessageHandler, MessageSink } from "../webview-contract/messaging";
 import { DetectorTypes } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 const meta = require('../../package.json');
 
-export class DetectorPanel extends BasePanel<DetectorTypes.InitialState, never, never> {
+export class DetectorPanel extends BasePanel<DetectorTypes.InitialState, DetectorTypes.ToWebViewMsgDef, DetectorTypes.ToVsCodeMsgDef> {
     constructor(extensionUri: Uri) {
         super(extensionUri, DetectorTypes.contentId);
     }
 }
 
-export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.InitialState, never, never> {
+export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.InitialState, DetectorTypes.ToWebViewMsgDef, DetectorTypes.ToVsCodeMsgDef> {
     public constructor(
         readonly clusterName: string,
         readonly categoryDetector: DetectorTypes.CategoryDetectorARMResponse,
@@ -39,8 +39,8 @@ export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.Ini
         };
     }
 
-    createSubscriber(_webview: MessageSink<never>): MessageSubscriber<never> | null {
-        return null;
+    getMessageHandler(_webview: MessageSink<DetectorTypes.ToWebViewMsgDef>): MessageHandler<DetectorTypes.ToVsCodeMsgDef> {
+        return {};
     }
 }
 

--- a/src/webview-contract/messaging.ts
+++ b/src/webview-contract/messaging.ts
@@ -1,8 +1,16 @@
 /**
+ * A type for defining a set of related messages (all messages going to or from a particular webview).
+ * The keys are the command names, and the values are the types of the parameters.
+ */
+export type MessageDefinition = {
+    [commandName: string]: any
+};
+
+/**
  * A component that messages can be sent to. Both Webviews and the
  * VS Code extension can act as `MessageSink` instances.
  */
-export interface MessageSink<TPostMsgDef> {
+export interface MessageSink<TPostMsgDef extends MessageDefinition> {
     postMessage(message: Message<TPostMsgDef>): void
 }
 
@@ -10,7 +18,7 @@ export interface MessageSink<TPostMsgDef> {
  * A component that emits messages that can be subscribed to. Both
  * Webviews and the VS Code extension can act as `MessageSink` instances.
  */
-export interface MessageSource<TListenMsgDef> {
+export interface MessageSource<TListenMsgDef extends MessageDefinition> {
     subscribeToMessages(handler: MessageHandler<TListenMsgDef>): void
 }
 
@@ -19,21 +27,28 @@ export interface MessageSource<TListenMsgDef> {
  * can both send and receive messages. Both Webviews and the VS Code
  * extension can be instances of a `MessageContext`.
  */
-export type MessageContext<TPostMsgDef, TListenMsgDef> = MessageSink<TPostMsgDef> & MessageSource<TListenMsgDef>;
+export type MessageContext<TPostMsgDef extends MessageDefinition, TListenMsgDef extends MessageDefinition> = MessageSink<TPostMsgDef> & MessageSource<TListenMsgDef>;
 
-// Shortcut type for creating mapped types using only the `string` keys of object types.
+// Shortcut type for creating mapped types using only the `string` keys of object types (to exclude symbols).
 type StringProperties<T> = Extract<keyof T, string>;
 
 /**
  * A discriminated union of the message types produced from the message definition `TMsgDef`.
  */
-export type Message<TMsgDef> = {[P in StringProperties<TMsgDef>]: {command: P, parameters: TMsgDef[P]}}[StringProperties<TMsgDef>];
+export type Message<TMsgDef extends MessageDefinition> = {
+    [P in StringProperties<TMsgDef>]: {
+        command: P,
+        parameters: TMsgDef[P]
+    }
+}[StringProperties<TMsgDef>];
 
 /**
  * The handler type for all the messages defined in `TMsgDef`.
  */
-export type MessageHandler<TMsgDef> = {[P in StringProperties<TMsgDef>]: (args: TMsgDef[P]) => void};
+export type MessageHandler<TMsgDef extends MessageDefinition> = {
+    [P in keyof TMsgDef]: (args: TMsgDef[P]) => void
+};
 
-export function isValidMessage<TMsgDef>(message: any): message is Message<TMsgDef> {
+export function isValidMessage<TMsgDef extends MessageDefinition>(message: any): message is Message<TMsgDef> {
     return message && !!message.command;
 }

--- a/src/webview-contract/messaging.ts
+++ b/src/webview-contract/messaging.ts
@@ -1,26 +1,17 @@
 /**
- * The type of any command that's passed between the VS Code extension
- * and a Webview.
- * 
- * For each Webview, the `command` property uniquely determines the
- * kind of message, and what handler will subscribe to it.
- */
-export interface Command<TName extends string> { command: TName };
-
-/**
  * A component that messages can be sent to. Both Webviews and the
  * VS Code extension can act as `MessageSink` instances.
  */
-export interface MessageSink<TPostMsg> {
-    postMessage(message: TPostMsg): void
+export interface MessageSink<TPostMsgDef> {
+    postMessage(message: Message<TPostMsgDef>): void
 }
 
 /**
  * A component that emits messages that can be subscribed to. Both
  * Webviews and the VS Code extension can act as `MessageSink` instances.
  */
-export interface MessageSource<TListenMsg> {
-    subscribeToMessages(subscriber: MessageSubscriber<TListenMsg>): void
+export interface MessageSource<TListenMsgDef> {
+    subscribeToMessages(handler: MessageHandler<TListenMsgDef>): void
 }
 
 /**
@@ -28,46 +19,21 @@ export interface MessageSource<TListenMsg> {
  * can both send and receive messages. Both Webviews and the VS Code
  * extension can be instances of a `MessageContext`.
  */
-export type MessageContext<TPostMsg, TListenMsg> = MessageSink<TPostMsg> & MessageSource<TListenMsg>;
+export type MessageContext<TPostMsgDef, TListenMsgDef> = MessageSink<TPostMsgDef> & MessageSource<TListenMsgDef>;
 
-type MessageHandlers<TMessage> = {
-    [command: string]: (message: TMessage) => void
-};
+// Shortcut type for creating mapped types using only the `string` keys of object types.
+type StringProperties<T> = Extract<keyof T, string>;
 
 /**
- * A holder for all the handlers of a collection of commands.
- * 
- * `TMessage` is expected to be a union type containing all the command
- * types for a particular `MessageSource`.
- * 
- * It can be instantiated using `create()` and chaining `withHandler()`
- * methods for each command type.
+ * A discriminated union of the message types produced from the message definition `TMsgDef`.
  */
-export class MessageSubscriber<TMessage> {
-    private constructor(
-        private readonly handlers: MessageHandlers<TMessage>
-    ) { }
+export type Message<TMsgDef> = {[P in StringProperties<TMsgDef>]: {command: P, parameters: TMsgDef[P]}}[StringProperties<TMsgDef>];
 
-    static create<TMessage>(): MessageSubscriber<TMessage> {
-        return new MessageSubscriber({});
-    }
+/**
+ * The handler type for all the messages defined in `TMsgDef`.
+ */
+export type MessageHandler<TMsgDef> = {[P in StringProperties<TMsgDef>]: (args: TMsgDef[P]) => void};
 
-    getCommands() {
-        return Object.keys(this.handlers);
-    }
-
-    getHandler(command: string): (message: TMessage) => void {
-        const handler = this.handlers[command];
-        if (!handler) {
-            throw new Error(`No handler found for command ${command}`);
-        }
-        return handler;
-    }
-
-    withHandler<TCommand extends string>(command: TCommand, fn: (message: (Command<TCommand> & TMessage)) => void) {
-        let newHandler: MessageHandlers<TMessage> = {};
-        newHandler[command] = msg => fn(msg as Command<TCommand> & TMessage);
-        const mergedHandlers = { ...this.handlers, ...newHandler };
-        return new MessageSubscriber<TMessage>(mergedHandlers);
-    }
+export function isValidMessage<TMsgDef>(message: any): message is Message<TMsgDef> {
+    return message && !!message.command;
 }

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -56,7 +56,7 @@ export module PeriscopeTypes {
     }
 
     export type ToVsCodeMsgDef = {
-        uploadStatusRequest: null,
+        uploadStatusRequest: void,
         nodeLogsRequest: {
             nodeName: string
         }

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -1,5 +1,3 @@
-import { Command } from "./messaging";
-
 export module TestStyleViewerTypes {
     export const contentId = "style";
 
@@ -7,21 +5,21 @@ export module TestStyleViewerTypes {
         isVSCode: boolean
     }
 
-    export interface ReportCssVars extends Command<"reportCssVars"> {
-        cssVars: string[]
-    }
-
-    export interface ReportCssRules extends Command<"reportCssRules"> {
-        rules: CssRule[]
-    }
-
     export interface CssRule {
         selector: string,
         text: string
     }
 
-    export type ToVsCodeCommands = ReportCssVars | ReportCssRules;
-    export type ToWebViewCommands = never;
+    export type ToVsCodeMsgDef = {
+        reportCssVars: {
+            cssVars: string[]
+        },
+        reportCssRules: {
+            rules: CssRule[]
+        }
+    };
+
+    export type ToWebViewMsgDef = {};
 }
 
 export module PeriscopeTypes {
@@ -57,23 +55,22 @@ export module PeriscopeTypes {
         shareableSas: string
     }
 
-    export interface UploadStatusRequest extends Command<"uploadStatusRequest"> { }
-
-    export interface NodeLogsRequest extends Command<"nodeLogsRequest"> {
-        nodeName: string
-    }
-
-    export interface UploadStatusResponse extends Command<"uploadStatusResponse"> {
-        uploadStatuses: NodeUploadStatus[]
+    export type ToVsCodeMsgDef = {
+        uploadStatusRequest: null,
+        nodeLogsRequest: {
+            nodeName: string
+        }
     };
 
-    export interface NodeLogsResponse extends Command<"nodeLogsResponse"> {
-        nodeName: string
-        logs: PodLogs[]
-    }
-
-    export type ToVsCodeCommands = UploadStatusRequest | NodeLogsRequest;
-    export type ToWebViewCommands = UploadStatusResponse | NodeLogsResponse;
+    export type ToWebViewMsgDef = {
+        uploadStatusResponse: {
+            uploadStatuses: NodeUploadStatus[]
+        },
+        nodeLogsResponse: {
+            nodeName: string,
+            logs: PodLogs[]
+        }
+    };
 }
 
 export module DetectorTypes {
@@ -148,4 +145,7 @@ export module DetectorTypes {
     export function isCategoryDataset(dataset: CategoryDataset | SingleDataset): dataset is CategoryDataset {
         return (dataset as CategoryDataset).renderingProperties.detectorIds !== undefined;
     }
+
+    export type ToVsCodeMsgDef = {};
+    export type ToWebViewMsgDef = {};
 }

--- a/webview-ui/src/Periscope/Periscope.tsx
+++ b/webview-ui/src/Periscope/Periscope.tsx
@@ -22,7 +22,7 @@ export function Periscope(props: PeriscopeTypes.InitialState) {
     }, []); // Empty list of dependencies to run only once: https://react.dev/reference/react/useEffect#useeffect
 
     function handleRequestUploadStatusCheck() {
-        vscode.postMessage({ command: "uploadStatusRequest", parameters: null });
+        vscode.postMessage({ command: "uploadStatusRequest", parameters: undefined });
     }
 
     function handleUploadStatusResponse(uploadStatuses: PeriscopeTypes.NodeUploadStatus[]) {

--- a/webview-ui/src/Periscope/Periscope.tsx
+++ b/webview-ui/src/Periscope/Periscope.tsx
@@ -1,6 +1,5 @@
 import { VSCodeDivider, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { useEffect, useState } from "react";
-import { MessageSubscriber } from "../../../src/webview-contract/messaging";
 import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes";
 import { getWebviewMessageContext } from "../utilities/vscode";
 import { ErrorView } from "./ErrorView";
@@ -8,39 +7,36 @@ import { NoDiagnosticSettingView } from "./NoDiagnosticSettingView";
 import { SuccessView } from "./SuccessView";
 
 export function Periscope(props: PeriscopeTypes.InitialState) {
-    const vscode = getWebviewMessageContext<PeriscopeTypes.ToVsCodeCommands, PeriscopeTypes.ToWebViewCommands>();
+    const vscode = getWebviewMessageContext<PeriscopeTypes.ToVsCodeMsgDef, PeriscopeTypes.ToWebViewMsgDef>();
 
     const [nodeUploadStatuses, setNodeUploadStatuses] = useState<PeriscopeTypes.NodeUploadStatus[]>(props.nodes.map(n => ({ nodeName: n, isUploaded: false })));
     const [selectedNode, setSelectedNode] = useState<string>("");
     const [nodePodLogs, setNodePodLogs] = useState<PeriscopeTypes.PodLogs[] | null>(null);
 
     useEffect(() => {
-        vscode.subscribeToMessages(createMessageSubscriber());
+        vscode.subscribeToMessages({
+            nodeLogsResponse: args => handleNodeLogsResponse(args.logs),
+            uploadStatusResponse: args => handleUploadStatusResponse(args.uploadStatuses)
+        });
         handleRequestUploadStatusCheck();
     }, []); // Empty list of dependencies to run only once: https://react.dev/reference/react/useEffect#useeffect
 
-    function createMessageSubscriber(): MessageSubscriber<PeriscopeTypes.ToWebViewCommands> {
-        return MessageSubscriber.create<PeriscopeTypes.ToWebViewCommands>()
-            .withHandler("uploadStatusResponse", handleUploadStatusResponse)
-            .withHandler("nodeLogsResponse", handleNodeLogsResponse);
-    }
-
     function handleRequestUploadStatusCheck() {
-        vscode.postMessage({ command: "uploadStatusRequest" });
+        vscode.postMessage({ command: "uploadStatusRequest", parameters: null });
     }
 
-    function handleUploadStatusResponse(message: PeriscopeTypes.UploadStatusResponse) {
-        setNodeUploadStatuses(message.uploadStatuses);
+    function handleUploadStatusResponse(uploadStatuses: PeriscopeTypes.NodeUploadStatus[]) {
+        setNodeUploadStatuses(uploadStatuses);
     }
 
     function handleNodeClick(node: string) {
         setSelectedNode(node);
         setNodePodLogs(null);
-        vscode.postMessage({ command: "nodeLogsRequest", nodeName: node });
+        vscode.postMessage({ command: "nodeLogsRequest", parameters: {nodeName: node} });
     }
 
-    function handleNodeLogsResponse(message: PeriscopeTypes.NodeLogsResponse) {
-        setNodePodLogs(message.logs);
+    function handleNodeLogsResponse(logs: PeriscopeTypes.PodLogs[]) {
+        setNodePodLogs(logs);
     }
 
     return (

--- a/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
+++ b/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
@@ -3,7 +3,7 @@ import { TestStyleViewerTypes } from "../../../src/webview-contract/webviewTypes
 import { getWebviewMessageContext } from "../utilities/vscode";
 
 export function TestStyleViewer(props: TestStyleViewerTypes.InitialState) {
-    const vscode = getWebviewMessageContext<TestStyleViewerTypes.ToVsCodeCommands, never>();
+    const vscode = getWebviewMessageContext<TestStyleViewerTypes.ToVsCodeMsgDef, TestStyleViewerTypes.ToWebViewMsgDef>();
 
     const [cssVars, setCssVars] = useState<string[]>([]);
     const [cssRules, setCssRules] = useState<TestStyleViewerTypes.CssRule[]>([]);
@@ -15,8 +15,8 @@ export function TestStyleViewer(props: TestStyleViewerTypes.InitialState) {
         const cssRules = getCssRules();
         setCssRules(cssRules);
 
-        vscode.postMessage({ command: "reportCssVars", cssVars });
-        vscode.postMessage({ command: "reportCssRules", rules: cssRules });
+        vscode.postMessage({ command: "reportCssVars", parameters: {cssVars} });
+        vscode.postMessage({ command: "reportCssRules", parameters: {rules: cssRules} });
     }, []);
 
     function getCssVarsForVsCode(): string[] {

--- a/webview-ui/src/manualTest/testStyleViewerTests.tsx
+++ b/webview-ui/src/manualTest/testStyleViewerTests.tsx
@@ -1,21 +1,22 @@
-import { MessageSubscriber } from "../../../src/webview-contract/messaging";
+import { MessageHandler } from "../../../src/webview-contract/messaging";
 import { TestStyleViewerTypes } from "../../../src/webview-contract/webviewTypes";
 import { Scenario } from "./../utilities/manualTest";
 import { getTestVscodeMessageContext } from "./../utilities/vscode";
 import { TestStyleViewer } from "./../TestStyleViewer/TestStyleViewer";
 
 export function getTestStyleViewerScenarios() {
-    const webview = getTestVscodeMessageContext<TestStyleViewerTypes.ToWebViewCommands, TestStyleViewerTypes.ToVsCodeCommands>();
-    const subscriber = MessageSubscriber.create<TestStyleViewerTypes.ToVsCodeCommands>()
-        .withHandler("reportCssVars", handleReportCssVars)
-        .withHandler("reportCssRules", handleReportCssRules);
+    const webview = getTestVscodeMessageContext<TestStyleViewerTypes.ToWebViewMsgDef, TestStyleViewerTypes.ToVsCodeMsgDef>();
+    const messageHandler: MessageHandler<TestStyleViewerTypes.ToVsCodeMsgDef> = {
+        reportCssRules: args => handleReportCssRules(args.rules),
+        reportCssVars: args => handleReportCssVars(args.cssVars)
+    };
 
-    function handleReportCssVars(message: TestStyleViewerTypes.ReportCssVars) {
-        console.log(message.cssVars.join('\n'));
+    function handleReportCssVars(cssVars: string[]) {
+        console.log(cssVars.join('\n'));
     }
 
-    function handleReportCssRules(message: TestStyleViewerTypes.ReportCssRules) {
-        console.log(message.rules.map(r => r.text).join('\n'));
+    function handleReportCssRules(rules: TestStyleViewerTypes.CssRule[]) {
+        console.log(rules.map(r => r.text).join('\n'));
     }
 
     const initialState: TestStyleViewerTypes.InitialState = {
@@ -23,6 +24,6 @@ export function getTestStyleViewerScenarios() {
     };
 
     return [
-        Scenario.create(TestStyleViewerTypes.contentId, () => <TestStyleViewer {...initialState} />).withSubscription(webview, subscriber)
+        Scenario.create(TestStyleViewerTypes.contentId, () => <TestStyleViewer {...initialState} />).withSubscription(webview, messageHandler)
     ];
 }

--- a/webview-ui/src/utilities/manualTest.ts
+++ b/webview-ui/src/utilities/manualTest.ts
@@ -1,4 +1,4 @@
-import { MessageHandler, MessageSource } from "../../../src/webview-contract/messaging";
+import { MessageDefinition, MessageHandler, MessageSource } from "../../../src/webview-contract/messaging";
 
 /**
  * Represents scenarios for manual testing webviews in a browser.
@@ -15,7 +15,7 @@ export class Scenario {
         return new Scenario(name, factory);
     }
 
-    withSubscription<TListenMsg>(context: MessageSource<TListenMsg>, handler: MessageHandler<TListenMsg>): Scenario {
+    withSubscription<TListenMsg extends MessageDefinition>(context: MessageSource<TListenMsg>, handler: MessageHandler<TListenMsg>): Scenario {
         const factory = () => {
             // Set up the subscription before creating the element
             context.subscribeToMessages(handler);

--- a/webview-ui/src/utilities/manualTest.ts
+++ b/webview-ui/src/utilities/manualTest.ts
@@ -1,4 +1,4 @@
-import { MessageSource, MessageSubscriber } from "../../../src/webview-contract/messaging";
+import { MessageHandler, MessageSource } from "../../../src/webview-contract/messaging";
 
 /**
  * Represents scenarios for manual testing webviews in a browser.
@@ -15,10 +15,10 @@ export class Scenario {
         return new Scenario(name, factory);
     }
 
-    withSubscription<TListenMsg>(context: MessageSource<TListenMsg>, subscriber: MessageSubscriber<TListenMsg>): Scenario {
+    withSubscription<TListenMsg>(context: MessageSource<TListenMsg>, handler: MessageHandler<TListenMsg>): Scenario {
         const factory = () => {
             // Set up the subscription before creating the element
-            context.subscribeToMessages(subscriber);
+            context.subscribeToMessages(handler);
             return this.factory();
         };
         return new Scenario(this.name, factory);

--- a/webview-ui/src/utilities/vscode.ts
+++ b/webview-ui/src/utilities/vscode.ts
@@ -1,5 +1,5 @@
 import type { WebviewApi } from "vscode-webview";
-import { MessageContext, MessageSubscriber } from "../../../src/webview-contract/messaging";
+import { Message, MessageContext, MessageHandler, isValidMessage } from "../../../src/webview-contract/messaging";
 
 const vsCodeApi: WebviewApi<unknown> | undefined = (typeof acquireVsCodeApi === "function") ? acquireVsCodeApi() : undefined;
 
@@ -20,8 +20,8 @@ const interceptorEventTarget: NamedEventTarget = { target: new EventTarget(), na
 let windowEventListener: EventListenerWithCommands | null = null;
 let interceptorEventListener: EventListenerWithCommands | null = null;
 
-class WebviewMessageContext<TToVsCodeCommands, TToWebviewCommands> implements MessageContext<TToVsCodeCommands, TToWebviewCommands> {
-    postMessage(message: TToVsCodeCommands) {
+class WebviewMessageContext<TToVsCodeMsgDef, TToWebviewMsgDef> implements MessageContext<TToVsCodeMsgDef, TToWebviewMsgDef> {
+    postMessage(message: Message<TToVsCodeMsgDef>) {
         if (vsCodeApi) {
             vsCodeApi.postMessage(message);
         } else {
@@ -30,8 +30,8 @@ class WebviewMessageContext<TToVsCodeCommands, TToWebviewCommands> implements Me
         }
     }
 
-    subscribeToMessages(subscriber: MessageSubscriber<TToWebviewCommands>) {
-        windowEventListener = subscribeToMessages(windowEventTarget, windowEventListener, subscriber, 'message');
+    subscribeToMessages(handler: MessageHandler<TToWebviewMsgDef>) {
+        windowEventListener = subscribeToMessages(windowEventTarget, windowEventListener, handler, 'message');
     }
 }
 
@@ -39,18 +39,18 @@ class WebviewMessageContext<TToVsCodeCommands, TToWebviewCommands> implements Me
  * @returns the `MessageContext` used by the webviews, i.e. that post messages to the VS Code extension
  * and listen to messages from the VS Code extension.
  */
-export function getWebviewMessageContext<TToVsCodeCommands, TToWebviewCommands>(): MessageContext<TToVsCodeCommands, TToWebviewCommands> {
-    return new WebviewMessageContext<TToVsCodeCommands, TToWebviewCommands>();
+export function getWebviewMessageContext<TToVsCodeMsgDef, TToWebviewMsgDef>(): MessageContext<TToVsCodeMsgDef, TToWebviewMsgDef> {
+    return new WebviewMessageContext<TToVsCodeMsgDef, TToWebviewMsgDef>();
 }
 
-class VscodeInterceptorMessageContext<TToWebviewCommands, TToVsCodeCommands> implements MessageContext<TToWebviewCommands, TToVsCodeCommands> {
-    postMessage(message: TToWebviewCommands) {
+class VscodeInterceptorMessageContext<TToWebviewMsgDef, TToVsCodeMsgDef> implements MessageContext<TToWebviewMsgDef, TToVsCodeMsgDef> {
+    postMessage(message: Message<TToWebviewMsgDef>) {
         console.log(`Dispatching ${JSON.stringify(message)} to '${windowEventTarget.name}'`);
         windowEventTarget.target.dispatchEvent(new MessageEvent('message', { data: message }));
     }
 
-    subscribeToMessages(subscriber: MessageSubscriber<TToVsCodeCommands>) {
-        interceptorEventListener = subscribeToMessages(interceptorEventTarget, interceptorEventListener, subscriber, 'vscode-message');
+    subscribeToMessages(handler: MessageHandler<TToVsCodeMsgDef>) {
+        interceptorEventListener = subscribeToMessages(interceptorEventTarget, interceptorEventListener, handler, 'vscode-message');
     }
 }
 
@@ -59,14 +59,14 @@ class VscodeInterceptorMessageContext<TToWebviewCommands, TToVsCodeCommands> imp
  * React application code acts as the VS Code extension, intercepting messages from the Webview
  * and posting back its own messages.
  */
-export function getTestVscodeMessageContext<TToWebviewCommands, TToVsCodeCommands>(): MessageContext<TToWebviewCommands, TToVsCodeCommands> {
-    return new VscodeInterceptorMessageContext<TToWebviewCommands, TToVsCodeCommands>();
+export function getTestVscodeMessageContext<TToWebviewMsgDef, TToVsCodeMsgDef>(): MessageContext<TToWebviewMsgDef, TToVsCodeMsgDef> {
+    return new VscodeInterceptorMessageContext<TToWebviewMsgDef, TToVsCodeMsgDef>();
 }
 
-function subscribeToMessages<TMessage>(
+function subscribeToMessages<TMsgDef>(
     eventTarget: NamedEventTarget,
     currentEventListener: EventListenerWithCommands | null,
-    subscriber: MessageSubscriber<TMessage>,
+    handler: MessageHandler<TMsgDef>,
     eventType: string
 ): EventListenerWithCommands {
     if (currentEventListener) {
@@ -74,16 +74,20 @@ function subscribeToMessages<TMessage>(
         eventTarget.target.removeEventListener(eventType, currentEventListener.listener);
     }
 
-    const commands = subscriber.getCommands();
-    const newListener = (message: any) => {
-        const command = message.data.command;
-        if (!command) {
+    const commands = Object.keys(handler);
+    const newListener = (messageEvent: any) => {
+        const message = messageEvent.data;
+        if (!isValidMessage<TMsgDef>(message)) {
             return;
         }
 
-        console.log(`'${eventTarget.name}' is handling command '${command}' (able to handle [${commands.join(',')}])`);
-        const handler = subscriber.getHandler(command);
-        handler(message.data);
+        console.log(`'${eventTarget.name}' is handling command '${message.command}' (able to handle [${commands.join(',')}])`);
+        const action = handler[message.command];
+        if (action) {
+            action(message.parameters);
+        } else {
+            console.error(`No handler found for command ${message.command}`);
+        }
     };
 
     console.log(`Adding listeners for [${commands.join(',')}] to '${eventTarget.name}'`);


### PR DESCRIPTION
Addresses some shortcomings of the way messages between VSCode and Webviews were being defined:
- Individual messages had to be defined as their own types and then combined together into discriminated unions for each component (Periscope, detectors, etc.).
- Message types needed to be defined with a string `command` property matching the type name, which was error prone.
- When creating subscriptions to messages, it was possible to 'miss' message types by forgetting to add handlers for some types. This would result in a runtime error that could be hard to notice and debug.

These changes introduce a convention whereby all messages (in each direction) for a component are defined in a single type, avoiding the need to manually create discriminated unions. This message definition type looks like:
```typescript
type SampleMsgDef = {
    firstMessage: {
        param1: number,
        param2: string
    },
    secondMessage: void // No parameters
}
```

The type for the individual messages corresponding to this definition can be referred to as `Message<SampleMsgDef>`, which is equivalent to:
```typescript
{ command: "firstMessage", parameters: {param1: number, param2: string} } |
{ command: "secondMessage", parameters: void }
```

Handlers must now be defined as a single object with keys for each message type, so that no messages can be missed. The type of this object can be referred to as `MessageHandler<SampleMsgDef>`, which is equivalent to:
```typescript
{
    firstMessage: (arguments: {param1: number, param2: string}) => void,
    secondMessage: (arguments: void) => void
}
```

Handlers of this type can then by passed directly to subscription logic, and the type system will ensure that no message types are missing.