### PR TITLE
Fix problem matcher for webview debugging task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,14 +9,15 @@
             "script": "dev:webview",
             "problemMatcher": [
                 {
+                    "fileLocation": "absolute",
                     "background": {
-                        "activeOnStart": false,
-                        "beginsPattern": "npm run dev",
-                        "endsPattern": "➜  Local:"
+                        "activeOnStart": true,
+                        "beginsPattern": "^.* page reload .*",
+                        "endsPattern": "^.*\\[TypeScript\\].*"
                     },
                     "pattern": [
                         {
-                            "regexp": "(ERROR|WARNING)\\(TypeScript\\)  (.*)",
+                            "regexp": "^ (ERROR|WARNING)\\(TypeScript\\)  (.*)",
                             "severity": 1,
                             "message": 2
                         },


### PR DESCRIPTION
This fixes the incorrectly configured pattern matching for the background task when debugging webviews. Specifically, it
- avoids the "task cannot be tracked, make sure to have a problem matcher defined" message
- avoids opening non-existent files from the VS Code 'problems' pane (caused by interpreting the file in the task's output as a relative path, when it's actually an absolute one).
- refreshes errors when changes are saved (previously it stopped monitoring after launching the watch task).