### PR TITLE
Reorganize type structure of webview definitions

### DIFF
--- a/src/panels/BasePanel.ts
+++ b/src/panels/BasePanel.ts
@@ -1,7 +1,8 @@
 import { Disposable, Webview, window, Uri, ViewColumn } from "vscode";
-import { Message, MessageContext, MessageDefinition, MessageHandler, MessageSink, isValidMessage } from "../webview-contract/messaging";
+import { MessageDefinition, MessageHandler, MessageSink, isValidMessage } from "../webview-contract/messaging";
 import { getNonce, getUri } from "./utilities/webview";
 import { encodeState } from "../webview-contract/initialState";
+import { ContentId, InitialState, ToVsCodeMessage, ToVsCodeMessageHandler, ToVsCodeMsgDef, ToWebviewMessage, ToWebviewMsgDef, VsCodeMessageContext } from "../webview-contract/webviewTypes";
 
 const viewType = "aksVsCodeTools";
 
@@ -10,10 +11,10 @@ const viewType = "aksVsCodeTools";
  * - supplying it with initial data
  * - handling messages from the webview and posting messages back
  */
-export interface PanelDataProvider<TInitialState, TToWebview extends MessageDefinition, TToVsCode extends MessageDefinition> {
+export interface PanelDataProvider<TContent extends ContentId> {
     getTitle(): string
-    getInitialState(): TInitialState
-    getMessageHandler(webview: MessageSink<TToWebview>): MessageHandler<TToVsCode>
+    getInitialState(): InitialState<TContent>
+    getMessageHandler(webview: MessageSink<ToWebviewMsgDef<TContent>>): MessageHandler<ToVsCodeMsgDef<TContent>>
 }
 
 /**
@@ -25,13 +26,13 @@ export interface PanelDataProvider<TInitialState, TToWebview extends MessageDefi
  * - TToWebview: A definition of the `Command` types that will be posted to the Webview.
  * - TToVsCode: A definition of the `Command` types that the extension will listen for from the Webview.
  */
-export abstract class BasePanel<TInitialState, TToWebview extends MessageDefinition, TToVsCode extends MessageDefinition> {
+export abstract class BasePanel<TContent extends ContentId> {
     protected constructor(
         readonly extensionUri: Uri,
-        readonly contentId: string
+        readonly contentId: TContent
     ) { }
 
-    show(dataProvider: PanelDataProvider<TInitialState, TToWebview, TToVsCode>, ...disposables: Disposable[]) {
+    show(dataProvider: PanelDataProvider<TContent>, ...disposables: Disposable[]) {
         const panelOptions = {
             enableScripts: true,
             // Restrict the webview to only load resources from the `webview-ui/dist` directory
@@ -43,7 +44,7 @@ export abstract class BasePanel<TInitialState, TToWebview extends MessageDefinit
         const panel = window.createWebviewPanel(viewType, title, ViewColumn.One, panelOptions);
 
         // Set up messaging between VSCode and the webview.
-        const messageContext = new WebviewMessageContext<TToWebview, TToVsCode>(panel.webview, disposables);
+        const messageContext = new MessageContext<TContent>(panel.webview, disposables);
         const messageHandler = dataProvider.getMessageHandler(messageContext);
         messageContext.subscribeToMessages(messageHandler);
 
@@ -59,7 +60,7 @@ export abstract class BasePanel<TInitialState, TToWebview extends MessageDefinit
         panel.webview.html = this._getWebviewContent(panel.webview, this.extensionUri, title, initialState);
     }
 
-    private _getWebviewContent(webview: Webview, extensionUri: Uri, title: string, initialState: TInitialState | undefined) {
+    private _getWebviewContent(webview: Webview, extensionUri: Uri, title: string, initialState: InitialState<TContent> | undefined) {
         // Get URIs for the React build output.
         const stylesUri = getUri(webview, extensionUri, ["assets", "main.css"]);
         const scriptUri = getUri(webview, extensionUri, ["assets", "main.js"]);
@@ -90,26 +91,27 @@ export abstract class BasePanel<TInitialState, TToWebview extends MessageDefinit
 }
 
 /**
- * A `MessageContext` that represents the Webview.
+ * A `MessageContext` that represents the VSCode end of the communication,
+ * i.e. it posts messages to the webview, and listens to messages to VS Code.
  */
-class WebviewMessageContext<TToWebview extends MessageDefinition, TToVsCode extends MessageDefinition> implements MessageContext<TToWebview, TToVsCode> {
+class MessageContext<TContent extends ContentId> implements VsCodeMessageContext<TContent> {
     constructor(
         private readonly _webview: Webview,
         private readonly _disposables: Disposable[]
     ) { }
 
-    postMessage(message: Message<TToWebview>) {
+    postMessage(message: ToWebviewMessage<TContent>) {
         this._webview.postMessage(message);
     }
 
-    subscribeToMessages(handler: MessageHandler<TToVsCode>) {
+    subscribeToMessages(handler: ToVsCodeMessageHandler<TContent>) {
         this._webview.onDidReceiveMessage(
             (message: any) => {
-                if (!isValidMessage<TToVsCode>(message)) {
+                if (!isValidMessage<ToVsCodeMessage<TContent>>(message)) {
                     throw new Error(`Invalid message to VsCode: ${JSON.stringify(message)}`);
                 }
 
-                const action = handler[message.command];
+                const action = (handler as MessageHandler<MessageDefinition>)[message.command];
                 if (action) {
                     action(message.parameters);
                 } else {

--- a/src/panels/BasePanel.ts
+++ b/src/panels/BasePanel.ts
@@ -1,8 +1,8 @@
 import { Disposable, Webview, window, Uri, ViewColumn } from "vscode";
-import { MessageDefinition, MessageHandler, MessageSink, isValidMessage } from "../webview-contract/messaging";
+import { MessageDefinition, MessageHandler, isValidMessage } from "../webview-contract/messaging";
 import { getNonce, getUri } from "./utilities/webview";
 import { encodeState } from "../webview-contract/initialState";
-import { ContentId, InitialState, ToVsCodeMessage, ToVsCodeMessageHandler, ToVsCodeMsgDef, ToWebviewMessage, ToWebviewMsgDef, VsCodeMessageContext } from "../webview-contract/webviewTypes";
+import { ContentId, InitialState, ToVsCodeMessage, ToVsCodeMessageHandler, ToWebviewMessage, ToWebviewMessageSink, VsCodeMessageContext } from "../webview-contract/webviewTypes";
 
 const viewType = "aksVsCodeTools";
 
@@ -14,17 +14,11 @@ const viewType = "aksVsCodeTools";
 export interface PanelDataProvider<TContent extends ContentId> {
     getTitle(): string
     getInitialState(): InitialState<TContent>
-    getMessageHandler(webview: MessageSink<ToWebviewMsgDef<TContent>>): MessageHandler<ToVsCodeMsgDef<TContent>>
+    getMessageHandler(webview: ToWebviewMessageSink<TContent>): ToVsCodeMessageHandler<TContent>
 }
 
 /**
  * Common base class for VS Code Webview panels.
- * 
- * The generic types are:
- * - TInitialState: The initial state object (passed as `props` to the corresponding React component),
- *   or `void` if not required.
- * - TToWebview: A definition of the `Command` types that will be posted to the Webview.
- * - TToVsCode: A definition of the `Command` types that the extension will listen for from the Webview.
  */
 export abstract class BasePanel<TContent extends ContentId> {
     protected constructor(

--- a/src/panels/DetectorPanel.ts
+++ b/src/panels/DetectorPanel.ts
@@ -1,20 +1,20 @@
 import { Uri } from "vscode";
 import { MessageHandler, MessageSink } from "../webview-contract/messaging";
-import { DetectorTypes } from "../webview-contract/webviewTypes";
+import { ARMResponse, CategoryDetectorARMResponse, InitialState, SingleDetectorARMResponse, ToVsCodeMsgDef, ToWebViewMsgDef } from "../webview-contract/webviewDefinitions/detector";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 const meta = require('../../package.json');
 
-export class DetectorPanel extends BasePanel<DetectorTypes.InitialState, DetectorTypes.ToWebViewMsgDef, DetectorTypes.ToVsCodeMsgDef> {
+export class DetectorPanel extends BasePanel<"detector"> {
     constructor(extensionUri: Uri) {
-        super(extensionUri, DetectorTypes.contentId);
+        super(extensionUri, "detector");
     }
 }
 
-export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.InitialState, DetectorTypes.ToWebViewMsgDef, DetectorTypes.ToVsCodeMsgDef> {
+export class DetectorDataProvider implements PanelDataProvider<"detector"> {
     public constructor(
         readonly clusterName: string,
-        readonly categoryDetector: DetectorTypes.CategoryDetectorARMResponse,
-        readonly detectors: DetectorTypes.SingleDetectorARMResponse[]
+        readonly categoryDetector: CategoryDetectorARMResponse,
+        readonly detectors: SingleDetectorARMResponse[]
     ) {
         this.detectorName = categoryDetector.properties.metadata.name;
         this.detectorDescription = categoryDetector.properties.metadata.description;
@@ -29,7 +29,7 @@ export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.Ini
         return `${this.detectorName} diagnostics for ${this.clusterName}`;
     }
 
-    getInitialState(): DetectorTypes.InitialState {
+    getInitialState(): InitialState {
         return {
             name: this.clusterName,
             description: this.detectorDescription,
@@ -39,11 +39,11 @@ export class DetectorDataProvider implements PanelDataProvider<DetectorTypes.Ini
         };
     }
 
-    getMessageHandler(_webview: MessageSink<DetectorTypes.ToWebViewMsgDef>): MessageHandler<DetectorTypes.ToVsCodeMsgDef> {
+    getMessageHandler(_webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {
         return {};
     }
 }
 
-function getClusterArmId(response: DetectorTypes.ARMResponse<any>): string {
+function getClusterArmId(response: ARMResponse<any>): string {
     return response.id.split('detectors')[0];
 }

--- a/src/tests/suite/webview.test.ts
+++ b/src/tests/suite/webview.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { MessageHandler, MessageSink } from '../../webview-contract/messaging';
-import { TestStyleViewerTypes } from '../../webview-contract/webviewTypes';
+import { CssRule, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from '../../webview-contract/webviewDefinitions/testStyleViewer';
 import { BasePanel, PanelDataProvider } from '../../panels/BasePanel';
 import { getExtensionPath } from '../../commands/utils/host';
 import { map as errmap, Succeeded, succeeded } from '../../commands/utils/errorable';
@@ -26,18 +26,18 @@ describe('Webview Styles', () => {
     });
 });
 
-class StyleTestPanel extends BasePanel<TestStyleViewerTypes.InitialState, TestStyleViewerTypes.ToWebViewMsgDef, TestStyleViewerTypes.ToVsCodeMsgDef> {
+class StyleTestPanel extends BasePanel<"style"> {
     constructor(extensionUri: vscode.Uri) {
-        super(extensionUri, TestStyleViewerTypes.contentId);
+        super(extensionUri, "style");
     }
 }
 
-class StyleTestDataProvider implements PanelDataProvider<TestStyleViewerTypes.InitialState, TestStyleViewerTypes.ToWebViewMsgDef, TestStyleViewerTypes.ToVsCodeMsgDef> {
+class StyleTestDataProvider implements PanelDataProvider<"style"> {
     readonly cssVarsPromise: Promise<string[]>;
     private _cssVarsResolve?: (cssVars: string[]) => void;
 
-    readonly rulesPromise: Promise<TestStyleViewerTypes.CssRule[]>;
-    private _rulesResolve?: (rules: TestStyleViewerTypes.CssRule[]) => void;
+    readonly rulesPromise: Promise<CssRule[]>;
+    private _rulesResolve?: (rules: CssRule[]) => void;
 
     constructor() {
         this.cssVarsPromise = new Promise(resolve => this._cssVarsResolve = resolve);
@@ -48,11 +48,11 @@ class StyleTestDataProvider implements PanelDataProvider<TestStyleViewerTypes.In
         return "Style Test";
     }
 
-    getInitialState(): TestStyleViewerTypes.InitialState {
+    getInitialState(): InitialState {
         return { isVSCode: true };
     }
 
-    getMessageHandler(_webview: MessageSink<TestStyleViewerTypes.ToWebViewMsgDef>): MessageHandler<TestStyleViewerTypes.ToVsCodeMsgDef> {
+    getMessageHandler(_webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {
         return {
             reportCssRules: args => this._rulesResolve && this._rulesResolve(args.rules),
             reportCssVars: args => this._cssVarsResolve && this._cssVarsResolve(args.cssVars)

--- a/src/webview-contract/README.md
+++ b/src/webview-contract/README.md
@@ -5,10 +5,13 @@ This folder contains code that's shared between the VS Code extension and the `w
 The intent is to provide a single source of truth for the data types that both parties need to communicate.
 
 This includes:
-- Unique view identifiers
+- Unique Webview identifiers (content IDs)
 - Initial state
 - Command message types
 - Other types that make up components of Webviews
 - Message subscription logic
 
-Types that are specific to individual Webviews are in `webviewTypes.ts`.
+Types that are specific to individual Webviews are in the `webviewDefinitions` directory. Each of these
+exports a `WebviewDefinition` type that combines the common types for each Webview.
+
+Each Webview's types are associated with a `ContentId` key in `AllWebviewDefinitions`, spefified in `webviewTypes.ts`.

--- a/src/webview-contract/webviewDefinitions/detector.ts
+++ b/src/webview-contract/webviewDefinitions/detector.ts
@@ -1,0 +1,77 @@
+import { WebviewDefinition } from "../webviewTypes"
+
+export interface InitialState {
+    name: string
+    description: string
+    clusterArmId: string
+    portalReferrerContext: string
+    detectors: SingleDetectorARMResponse[]
+}
+
+export interface ARMResponse<TDatasets> {
+    id: string
+    name: string
+    type: string
+    location: string
+    properties: {
+        dataset: TDatasets
+        metadata: {
+            category: string
+            description: string
+            id: string
+            name: string
+            type: string
+        }
+        status: {
+            message: string | null
+            statusId: number
+        }
+    }
+}
+
+interface Column {
+    columnName: string
+    columnType: null
+    dataType: string
+}
+
+interface Dataset<TRenderingProperties> {
+    renderingProperties: TRenderingProperties
+    table: {
+        columns: Column[]
+        rows: any[][]
+        tableName: string
+    }
+}
+
+interface RenderingProperties {
+    description: string | null
+    isVisible: boolean
+    title: string | null
+    type: number
+}
+
+interface CategoryDetectorRenderingProperties extends RenderingProperties {
+    additionalParams: string
+    detectorIds: string[]
+    messageIfCritical: string | null
+    resourceUri: string
+}
+
+export type CategoryDataset = Dataset<CategoryDetectorRenderingProperties>;
+
+export type SingleDataset = Dataset<RenderingProperties>;
+
+export type CategoryDetectorARMResponse = ARMResponse<(CategoryDataset | SingleDataset)[]>;
+
+export type SingleDetectorARMResponse = ARMResponse<SingleDataset[]>
+
+export function isCategoryDataset(dataset: CategoryDataset | SingleDataset): dataset is CategoryDataset {
+    return (dataset as CategoryDataset).renderingProperties.detectorIds !== undefined;
+}
+
+export type ToWebViewMsgDef = {};
+
+export type ToVsCodeMsgDef = {};
+
+export type DetectorDefinition = WebviewDefinition<InitialState, ToWebViewMsgDef, ToVsCodeMsgDef>;

--- a/src/webview-contract/webviewDefinitions/periscope.ts
+++ b/src/webview-contract/webviewDefinitions/periscope.ts
@@ -1,0 +1,50 @@
+import { WebviewDefinition } from "../webviewTypes";
+
+export interface NodeUploadStatus {
+    nodeName: string
+    isUploaded: boolean
+}
+
+export interface PodLogs {
+    podName: string
+    logs: string
+}
+
+export type DeploymentState = "error" | "noDiagnosticsConfigured" | "success";
+
+export interface KustomizeConfig {
+    repoOrg: string
+    containerRegistry: string
+    imageVersion: string
+    releaseTag: string
+}
+
+export interface InitialState {
+    clusterName: string
+    runId: string
+    state: DeploymentState
+    message: string
+    nodes: string[]
+    kustomizeConfig: KustomizeConfig | null
+    blobContainerUrl: string
+    shareableSas: string
+}
+
+export type ToVsCodeMsgDef = {
+    uploadStatusRequest: void,
+    nodeLogsRequest: {
+        nodeName: string
+    }
+};
+
+export type ToWebViewMsgDef = {
+    uploadStatusResponse: {
+        uploadStatuses: NodeUploadStatus[]
+    },
+    nodeLogsResponse: {
+        nodeName: string,
+        logs: PodLogs[]
+    }
+};
+
+export type PeriscopeDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewDefinitions/testStyleViewer.ts
+++ b/src/webview-contract/webviewDefinitions/testStyleViewer.ts
@@ -1,0 +1,23 @@
+import { WebviewDefinition } from "../webviewTypes";
+
+export interface InitialState {
+    isVSCode: boolean
+}
+
+export interface CssRule {
+    selector: string,
+    text: string
+}
+
+export type ToVsCodeMsgDef = {
+    reportCssVars: {
+        cssVars: string[]
+    },
+    reportCssRules: {
+        rules: CssRule[]
+    }
+};
+
+export type ToWebViewMsgDef = {};
+
+export type TestStyleViewerDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -1,14 +1,21 @@
-import { Message, MessageContext, MessageDefinition, MessageHandler } from "./messaging";
+import { Message, MessageContext, MessageDefinition, MessageHandler, MessageSink } from "./messaging";
 import { DetectorDefinition } from "./webviewDefinitions/detector";
 import { PeriscopeDefinition } from "./webviewDefinitions/periscope";
 import { TestStyleViewerDefinition } from "./webviewDefinitions/testStyleViewer";
 
+/**
+ * Groups all the related types for a single webview.
+ */
 export type WebviewDefinition<TInitialState extends object, TToVsCode extends MessageDefinition, TToWebview extends MessageDefinition> = {
     initialState: TInitialState,
     toVsCodeMsgDef: TToVsCode,
     toWebviewMsgDef: TToWebview
 };
 
+/**
+ * Defines all the types for all the Webviews. All content IDs and common types for all webviews
+ * are defined here.
+ */
 type AllWebviewDefinitions = {
     style: TestStyleViewerDefinition,
     periscope: PeriscopeDefinition,
@@ -19,14 +26,21 @@ type ContentIdLookup = {
     [id in keyof AllWebviewDefinitions]: id
 };
 
+/**
+ * A union of all possible content ID values (the identifier for each Webview).
+ */
 export type ContentId = ContentIdLookup[keyof ContentIdLookup];
 
+// Shortcuts for types for each webview...
 export type InitialState<T extends ContentId> = AllWebviewDefinitions[T]["initialState"];
 export type ToVsCodeMsgDef<T extends ContentId> = AllWebviewDefinitions[T]["toVsCodeMsgDef"];
 export type ToWebviewMsgDef<T extends ContentId> = AllWebviewDefinitions[T]["toWebviewMsgDef"];
 
 export type ToVsCodeMessageHandler<T extends ContentId> = MessageHandler<ToVsCodeMsgDef<T>>;
 export type ToWebviewMessageHandler<T extends ContentId> = MessageHandler<ToWebviewMsgDef<T>>;
+
+export type ToVsCodeMessageSink<T extends ContentId> = MessageSink<ToVsCodeMsgDef<T>>;
+export type ToWebviewMessageSink<T extends ContentId> = MessageSink<ToWebviewMsgDef<T>>;
 
 export type ToVsCodeMessage<T extends ContentId> = Message<ToVsCodeMsgDef<T>>;
 export type ToWebviewMessage<T extends ContentId> = Message<ToWebviewMsgDef<T>>;

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -1,151 +1,35 @@
-export module TestStyleViewerTypes {
-    export const contentId = "style";
+import { Message, MessageContext, MessageDefinition, MessageHandler } from "./messaging";
+import { DetectorDefinition } from "./webviewDefinitions/detector";
+import { PeriscopeDefinition } from "./webviewDefinitions/periscope";
+import { TestStyleViewerDefinition } from "./webviewDefinitions/testStyleViewer";
 
-    export interface InitialState {
-        isVSCode: boolean
-    }
+export type WebviewDefinition<TInitialState extends object, TToVsCode extends MessageDefinition, TToWebview extends MessageDefinition> = {
+    initialState: TInitialState,
+    toVsCodeMsgDef: TToVsCode,
+    toWebviewMsgDef: TToWebview
+};
 
-    export interface CssRule {
-        selector: string,
-        text: string
-    }
+type AllWebviewDefinitions = {
+    style: TestStyleViewerDefinition,
+    periscope: PeriscopeDefinition,
+    detector: DetectorDefinition
+};
 
-    export type ToVsCodeMsgDef = {
-        reportCssVars: {
-            cssVars: string[]
-        },
-        reportCssRules: {
-            rules: CssRule[]
-        }
-    };
+type ContentIdLookup = {
+    [id in keyof AllWebviewDefinitions]: id
+};
 
-    export type ToWebViewMsgDef = {};
-}
+export type ContentId = ContentIdLookup[keyof ContentIdLookup];
 
-export module PeriscopeTypes {
-    export const contentId = "periscope";
+export type InitialState<T extends ContentId> = AllWebviewDefinitions[T]["initialState"];
+export type ToVsCodeMsgDef<T extends ContentId> = AllWebviewDefinitions[T]["toVsCodeMsgDef"];
+export type ToWebviewMsgDef<T extends ContentId> = AllWebviewDefinitions[T]["toWebviewMsgDef"];
 
-    export interface NodeUploadStatus {
-        nodeName: string
-        isUploaded: boolean
-    }
+export type ToVsCodeMessageHandler<T extends ContentId> = MessageHandler<ToVsCodeMsgDef<T>>;
+export type ToWebviewMessageHandler<T extends ContentId> = MessageHandler<ToWebviewMsgDef<T>>;
 
-    export interface PodLogs {
-        podName: string
-        logs: string
-    }
+export type ToVsCodeMessage<T extends ContentId> = Message<ToVsCodeMsgDef<T>>;
+export type ToWebviewMessage<T extends ContentId> = Message<ToWebviewMsgDef<T>>;
 
-    export type DeploymentState = "error" | "noDiagnosticsConfigured" | "success";
-
-    export interface KustomizeConfig {
-        repoOrg: string
-        containerRegistry: string
-        imageVersion: string
-        releaseTag: string
-    }
-
-    export interface InitialState {
-        clusterName: string
-        runId: string
-        state: DeploymentState
-        message: string
-        nodes: string[]
-        kustomizeConfig: KustomizeConfig | null
-        blobContainerUrl: string
-        shareableSas: string
-    }
-
-    export type ToVsCodeMsgDef = {
-        uploadStatusRequest: void,
-        nodeLogsRequest: {
-            nodeName: string
-        }
-    };
-
-    export type ToWebViewMsgDef = {
-        uploadStatusResponse: {
-            uploadStatuses: NodeUploadStatus[]
-        },
-        nodeLogsResponse: {
-            nodeName: string,
-            logs: PodLogs[]
-        }
-    };
-}
-
-export module DetectorTypes {
-    export const contentId = "detector";
-
-    export interface InitialState {
-        name: string
-        description: string
-        clusterArmId: string
-        portalReferrerContext: string
-        detectors: SingleDetectorARMResponse[]
-    }
-
-    export interface ARMResponse<TDatasets> {
-        id: string
-        name: string
-        type: string
-        location: string
-        properties: {
-            dataset: TDatasets
-            metadata: {
-                category: string
-                description: string
-                id: string
-                name: string
-                type: string
-            }
-            status: {
-                message: string | null
-                statusId: number
-            }
-        }
-    }
-
-    export interface Column {
-        columnName: string
-        columnType: null
-        dataType: string
-    }
-
-    export interface Dataset<TRenderingProperties> {
-        renderingProperties: TRenderingProperties
-        table: {
-            columns: Column[]
-            rows: any[][]
-            tableName: string
-        }
-    }
-
-    export interface RenderingProperties {
-        description: string | null
-        isVisible: boolean
-        title: string | null
-        type: number
-    }
-
-    export interface CategoryDetectorRenderingProperties extends RenderingProperties {
-        additionalParams: string
-        detectorIds: string[]
-        messageIfCritical: string | null
-        resourceUri: string
-    }
-
-    export type CategoryDataset = Dataset<CategoryDetectorRenderingProperties>;
-
-    export type SingleDataset = Dataset<RenderingProperties>;
-
-    export type CategoryDetectorARMResponse = ARMResponse<(CategoryDataset | SingleDataset)[]>;
-
-    export type SingleDetectorARMResponse = ARMResponse<SingleDataset[]>
-
-    export function isCategoryDataset(dataset: CategoryDataset | SingleDataset): dataset is CategoryDataset {
-        return (dataset as CategoryDataset).renderingProperties.detectorIds !== undefined;
-    }
-
-    export type ToVsCodeMsgDef = {};
-    export type ToWebViewMsgDef = {};
-}
+export type VsCodeMessageContext<T extends ContentId> = MessageContext<ToWebviewMsgDef<T>, ToVsCodeMsgDef<T>>;
+export type WebviewMessageContext<T extends ContentId> = MessageContext<ToVsCodeMsgDef<T>, ToWebviewMsgDef<T>>;

--- a/webview-ui/src/Detector/Detector.tsx
+++ b/webview-ui/src/Detector/Detector.tsx
@@ -1,8 +1,8 @@
 import { VSCodeDivider, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
-import { DetectorTypes } from "../../../src/webview-contract/webviewTypes";
+import { InitialState } from "../../../src/webview-contract/webviewDefinitions/detector";
 import { SingleDetector } from './SingleDetector';
 
-export function Detector(props: DetectorTypes.InitialState) {
+export function Detector(props: InitialState) {
     const portalUrl = `https://portal.azure.com/#resource${props.clusterArmId}aksDiagnostics?referrer_source=vscode&referrer_context=${props.portalReferrerContext}`;
 
     return (

--- a/webview-ui/src/Detector/SingleDetector.tsx
+++ b/webview-ui/src/Detector/SingleDetector.tsx
@@ -1,10 +1,10 @@
-import { DetectorTypes } from "../../../src/webview-contract/webviewTypes";
+import { SingleDataset, SingleDetectorARMResponse } from "../../../src/webview-contract/webviewDefinitions/detector";
 import { InsightsRenderer } from "./renderers/InsightsRenderer";
 import { MarkdownRenderer } from "./renderers/MarkdownRenderer";
 import { Status, getOverallStatus } from "./utils";
 import styles from "./Detector.module.css";
 
-export function SingleDetector(detector: DetectorTypes.SingleDetectorARMResponse) {
+export function SingleDetector(detector: SingleDetectorARMResponse) {
     const status = getOverallStatus(detector);
     const panelClassNames = getPanelClassNames(status);
 
@@ -20,7 +20,7 @@ export function SingleDetector(detector: DetectorTypes.SingleDetectorARMResponse
     )
 }
 
-function getRenderer(dataset: DetectorTypes.SingleDataset, index: number) {
+function getRenderer(dataset: SingleDataset, index: number) {
     switch (dataset.renderingProperties.type) {
         case 7: return <InsightsRenderer key={index} {...dataset} />
         case 9: return <MarkdownRenderer key={index} {...dataset} />

--- a/webview-ui/src/Detector/renderers/InsightsRenderer.tsx
+++ b/webview-ui/src/Detector/renderers/InsightsRenderer.tsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleCheck, faCircleXmark, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { DetectorTypes } from "../../../../src/webview-contract/webviewTypes";
+import { SingleDataset } from '../../../../src/webview-contract/webviewDefinitions/detector';
 import { Error } from "./Error";
 import { Status, getStatusForInsightDataset, isInsightResult } from '../utils';
 import styles from "../Detector.module.css";
@@ -10,7 +10,7 @@ import { getMarkdownComponents } from './common';
 
 const markdownComponents = getMarkdownComponents();
 
-export function InsightsRenderer(props: DetectorTypes.SingleDataset) {
+export function InsightsRenderer(props: SingleDataset) {
     const statusResult = getStatusForInsightDataset(props);
     if (!isInsightResult(statusResult)) {
         return Error({ message: statusResult.error, data: statusResult.data });
@@ -43,7 +43,7 @@ export function InsightsRenderer(props: DetectorTypes.SingleDataset) {
     );
 }
 
-function hasExtraData(dataset: DetectorTypes.SingleDataset) {
+function hasExtraData(dataset: SingleDataset) {
     return dataset.table.rows.filter(r => r[2] || r[3]).length > 0;
 }
 

--- a/webview-ui/src/Detector/renderers/MarkdownRenderer.tsx
+++ b/webview-ui/src/Detector/renderers/MarkdownRenderer.tsx
@@ -1,11 +1,11 @@
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
-import { DetectorTypes } from "../../../../src/webview-contract/webviewTypes";
+import { SingleDataset } from '../../../../src/webview-contract/webviewDefinitions/detector';
 import { getMarkdownComponents } from './common';
 
 const markdownComponents = getMarkdownComponents();
 
-export function MarkdownRenderer(props: DetectorTypes.SingleDataset) {
+export function MarkdownRenderer(props: SingleDataset) {
     return (
     <>
         <h4>{props.renderingProperties.title}</h4>

--- a/webview-ui/src/Detector/utils.ts
+++ b/webview-ui/src/Detector/utils.ts
@@ -1,4 +1,4 @@
-import { DetectorTypes } from "../../../src/webview-contract/webviewTypes";
+import { SingleDataset, SingleDetectorARMResponse } from "../../../src/webview-contract/webviewDefinitions/detector";
 
 const insightDatasetType = 7;
 
@@ -17,7 +17,7 @@ export enum Status {
     Error
 }
 
-export function getOverallStatus(response: DetectorTypes.SingleDetectorARMResponse): Status {
+export function getOverallStatus(response: SingleDetectorARMResponse): Status {
     const statuses = response.properties.dataset
         .filter(d => d.renderingProperties.type === insightDatasetType)
         .map(getStatusForInsightDataset)
@@ -41,7 +41,7 @@ export function isInsightResult(result: InsightResult | ErrorInfo): result is In
     return (result as InsightResult).status !== undefined;
 }
 
-export function getStatusForInsightDataset(dataset: DetectorTypes.SingleDataset): InsightResult | ErrorInfo {
+export function getStatusForInsightDataset(dataset: SingleDataset): InsightResult | ErrorInfo {
     // One insight has a single overall `Status` and `Message`, even if it contains several rows.
     if (dataset.table.rows.length === 0) {
         return {

--- a/webview-ui/src/Periscope/ErrorView.tsx
+++ b/webview-ui/src/Periscope/ErrorView.tsx
@@ -1,5 +1,5 @@
 import { VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
-import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes";
+import { KustomizeConfig } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import styles from "./Periscope.module.css";
@@ -7,7 +7,7 @@ import styles from "./Periscope.module.css";
 export interface ErrorViewProps {
     clusterName: string
     message: string
-    config: PeriscopeTypes.KustomizeConfig
+    config: KustomizeConfig
 }
 
 export function ErrorView(props: ErrorViewProps) {

--- a/webview-ui/src/Periscope/NodeLogs.tsx
+++ b/webview-ui/src/Periscope/NodeLogs.tsx
@@ -1,8 +1,8 @@
-import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes"
+import { PodLogs } from "../../../src/webview-contract/webviewDefinitions/periscope";
 
 export interface NodeLogsProps {
     node: string
-    podLogs: PeriscopeTypes.PodLogs[]
+    podLogs: PodLogs[]
 }
 
 export function NodeLogs(props: NodeLogsProps) {

--- a/webview-ui/src/Periscope/Periscope.tsx
+++ b/webview-ui/src/Periscope/Periscope.tsx
@@ -1,17 +1,17 @@
 import { VSCodeDivider, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { useEffect, useState } from "react";
-import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes";
+import { InitialState, NodeUploadStatus, PodLogs, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { getWebviewMessageContext } from "../utilities/vscode";
 import { ErrorView } from "./ErrorView";
 import { NoDiagnosticSettingView } from "./NoDiagnosticSettingView";
 import { SuccessView } from "./SuccessView";
 
-export function Periscope(props: PeriscopeTypes.InitialState) {
-    const vscode = getWebviewMessageContext<PeriscopeTypes.ToVsCodeMsgDef, PeriscopeTypes.ToWebViewMsgDef>();
+export function Periscope(props: InitialState) {
+    const vscode = getWebviewMessageContext<ToVsCodeMsgDef, ToWebViewMsgDef>();
 
-    const [nodeUploadStatuses, setNodeUploadStatuses] = useState<PeriscopeTypes.NodeUploadStatus[]>(props.nodes.map(n => ({ nodeName: n, isUploaded: false })));
+    const [nodeUploadStatuses, setNodeUploadStatuses] = useState<NodeUploadStatus[]>(props.nodes.map(n => ({ nodeName: n, isUploaded: false })));
     const [selectedNode, setSelectedNode] = useState<string>("");
-    const [nodePodLogs, setNodePodLogs] = useState<PeriscopeTypes.PodLogs[] | null>(null);
+    const [nodePodLogs, setNodePodLogs] = useState<PodLogs[] | null>(null);
 
     useEffect(() => {
         vscode.subscribeToMessages({
@@ -25,7 +25,7 @@ export function Periscope(props: PeriscopeTypes.InitialState) {
         vscode.postMessage({ command: "uploadStatusRequest", parameters: undefined });
     }
 
-    function handleUploadStatusResponse(uploadStatuses: PeriscopeTypes.NodeUploadStatus[]) {
+    function handleUploadStatusResponse(uploadStatuses: NodeUploadStatus[]) {
         setNodeUploadStatuses(uploadStatuses);
     }
 
@@ -35,7 +35,7 @@ export function Periscope(props: PeriscopeTypes.InitialState) {
         vscode.postMessage({ command: "nodeLogsRequest", parameters: {nodeName: node} });
     }
 
-    function handleNodeLogsResponse(logs: PeriscopeTypes.PodLogs[]) {
+    function handleNodeLogsResponse(logs: PodLogs[]) {
         setNodePodLogs(logs);
     }
 

--- a/webview-ui/src/Periscope/SuccessView.tsx
+++ b/webview-ui/src/Periscope/SuccessView.tsx
@@ -1,6 +1,6 @@
 import { VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useEffect } from "react";
-import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes";
+import { NodeUploadStatus, PodLogs } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { NodeActions } from "./NodeActions";
 import { NodeLogs } from "./NodeLogs";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -10,11 +10,11 @@ import styles from "./Periscope.module.css";
 export interface SuccessViewProps {
     runId: string
     clusterName: string
-    uploadStatuses: PeriscopeTypes.NodeUploadStatus[]
+    uploadStatuses: NodeUploadStatus[]
     onRequestUploadStatusCheck: () => void
     onNodeClick: (node: string) => void
     selectedNode: string
-    nodePodLogs: PeriscopeTypes.PodLogs[] | null
+    nodePodLogs: PodLogs[] | null
     containerUrl: string
     shareableSas: string
 }

--- a/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
+++ b/webview-ui/src/TestStyleViewer/TestStyleViewer.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import { TestStyleViewerTypes } from "../../../src/webview-contract/webviewTypes";
+import { CssRule, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
 import { getWebviewMessageContext } from "../utilities/vscode";
 
-export function TestStyleViewer(props: TestStyleViewerTypes.InitialState) {
-    const vscode = getWebviewMessageContext<TestStyleViewerTypes.ToVsCodeMsgDef, TestStyleViewerTypes.ToWebViewMsgDef>();
+export function TestStyleViewer(props: InitialState) {
+    const vscode = getWebviewMessageContext<ToVsCodeMsgDef, ToWebViewMsgDef>();
 
     const [cssVars, setCssVars] = useState<string[]>([]);
-    const [cssRules, setCssRules] = useState<TestStyleViewerTypes.CssRule[]>([]);
+    const [cssRules, setCssRules] = useState<CssRule[]>([]);
 
     useEffect(() => {
         const cssVars = props.isVSCode ? getCssVarsForVsCode() : getCssVarsForWebview();
@@ -48,7 +48,7 @@ export function TestStyleViewer(props: TestStyleViewerTypes.InitialState) {
         return styleProperties.split(';').map(s => s.trim()).filter(s => s.startsWith('--vscode-')).sort();
     }
 
-    function getCssRules(): TestStyleViewerTypes.CssRule[] {
+    function getCssRules(): CssRule[] {
         const defaultStyleSheetNode = getStyleSheetNode();
         let [defaultStyleSheet] = [...document.styleSheets].filter(s => s.ownerNode === defaultStyleSheetNode);
         if (!defaultStyleSheet) {

--- a/webview-ui/src/main.tsx
+++ b/webview-ui/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import './main.css';
 import { decodeState } from "../../src/webview-contract/initialState";
-import * as ContractTypes from "../../src/webview-contract/webviewTypes";
+import { ContentId } from "../../src/webview-contract/webviewTypes";
 import { TestStyleViewer } from "./TestStyleViewer/TestStyleViewer";
 import { Periscope } from "./Periscope/Periscope";
 import { Detector } from "./Detector/Detector";
@@ -24,18 +24,19 @@ function getVsCodeContent(): JSX.Element {
     if (!rootElem) {
         return <>Error: Element with ID 'root' is not found.</>;
     }
-    const vscodeContentId = rootElem?.dataset.contentid;
+    const vscodeContentId = rootElem?.dataset.contentid as ContentId;
     if (!vscodeContentId) {
         return <>Error: 'content-id' attribute is not set on root element.</>;
     }
 
     const vsCodeInitialState = decodeState<any>(rootElem?.dataset.initialstate);
-    switch (vscodeContentId) {
-        case ContractTypes.TestStyleViewerTypes.contentId: return <TestStyleViewer {...vsCodeInitialState} />
-        case ContractTypes.PeriscopeTypes.contentId: return <Periscope {...vsCodeInitialState} />
-        case ContractTypes.DetectorTypes.contentId: return <Detector {...vsCodeInitialState} />
-        default: return <>`Error: Unexpected content ID: '${vscodeContentId}'`</>;
-    }
+    const rendererLookup: Record<ContentId, () => JSX.Element> = {
+        style: () => <TestStyleViewer {...vsCodeInitialState} />,
+        periscope: () => <Periscope {...vsCodeInitialState} />,
+        detector: () => <Detector {...vsCodeInitialState} />
+    };
+
+    return rendererLookup[vscodeContentId]();
 }
 
 ReactDOM.render(

--- a/webview-ui/src/manualTest/detectorTests.tsx
+++ b/webview-ui/src/manualTest/detectorTests.tsx
@@ -1,4 +1,3 @@
-import { DetectorTypes } from "../../../src/webview-contract/webviewTypes";
 import { Scenario } from "../utilities/manualTest";
 import { Detector } from "../Detector/Detector";
 
@@ -63,12 +62,13 @@ import * as rotateClusterCertificate from "./detectorData/rotate-cluster-certifi
 import * as snatUsage from "./detectorData/snat-usage.json"
 import * as userDefinedRouting from "./detectorData/user-defined-routing.json"
 import * as windowsRegressionK8sv124 from "./detectorData/windowsregresionk8sv124.json"
+import { ARMResponse, CategoryDetectorARMResponse, InitialState, SingleDetectorARMResponse, isCategoryDataset } from "../../../src/webview-contract/webviewDefinitions/detector";
 
 type DetectorDataMap = {
-    [detectorId: string]: DetectorTypes.SingleDetectorARMResponse
+    [detectorId: string]: SingleDetectorARMResponse
 };
 
-const categoryDetectors: DetectorTypes.CategoryDetectorARMResponse[] = [
+const categoryDetectors: CategoryDetectorARMResponse[] = [
     aksCategoryAvailabilityPerf,
     aksCategoryConnectivity,
     aksCategoryCrud,
@@ -77,7 +77,7 @@ const categoryDetectors: DetectorTypes.CategoryDetectorARMResponse[] = [
     aksCategoryRiskAssessment
 ];
 
-const singleDetectors: DetectorTypes.SingleDetectorARMResponse[] = [
+const singleDetectors: SingleDetectorARMResponse[] = [
     aadIssues,
     advisorAutoscalingClusters,
     advisorBSeriesVms,
@@ -140,8 +140,8 @@ const singleDetectorLookup: DetectorDataMap = singleDetectors.reduce((result: De
 
 export function getDetectorScenarios() {
     return categoryDetectors.map(categoryDetector => {
-        const detectorIds = categoryDetector.properties.dataset.filter(DetectorTypes.isCategoryDataset)[0].renderingProperties.detectorIds;
-        const initialState: DetectorTypes.InitialState = {
+        const detectorIds = categoryDetector.properties.dataset.filter(isCategoryDataset)[0].renderingProperties.detectorIds;
+        const initialState: InitialState = {
             name: categoryDetector.properties.metadata.name,
             description: categoryDetector.properties.metadata.description,
             clusterArmId: getClusterArmId(categoryDetector),
@@ -149,10 +149,10 @@ export function getDetectorScenarios() {
             detectors: detectorIds.map(id => singleDetectorLookup[id])
         };
 
-        return Scenario.create(`${DetectorTypes.contentId} (${initialState.name})`, () => <Detector {...initialState} />);
+        return Scenario.create(`Detectors (${initialState.name})`, () => <Detector {...initialState} />);
     });
 }
 
-function getClusterArmId(response: DetectorTypes.ARMResponse<any>): string {
+function getClusterArmId(response: ARMResponse<any>): string {
     return response.id.split('detectors')[0];
 }

--- a/webview-ui/src/manualTest/main.tsx
+++ b/webview-ui/src/manualTest/main.tsx
@@ -6,6 +6,8 @@ import { TestScenarioSelector } from "./TestScenarioSelector/TestScenarioSelecto
 import { getTestStyleViewerScenarios } from "./testStyleViewerTests";
 import { getPeriscopeScenarios } from "./periscopeTests";
 import { getDetectorScenarios } from "./detectorTests";
+import { ContentId } from "../../../src/webview-contract/webviewTypes";
+import { Scenario } from "../utilities/manualTest";
 
 // There are two modes of launching this application:
 // 1. Via the VS Code extension inside a Webview.
@@ -19,11 +21,13 @@ import { getDetectorScenarios } from "./detectorTests";
 
 const rootElem = document.getElementById("root");
 
-const testScenarios = [
-    ...getTestStyleViewerScenarios(),
-    ...getPeriscopeScenarios(),
-    ...getDetectorScenarios()
-];
+const contentTestScenarios: Record<ContentId, Scenario[]> = {
+    style: getTestStyleViewerScenarios(),
+    periscope: getPeriscopeScenarios(),
+    detector: getDetectorScenarios()
+};
+
+const testScenarios = Object.values(contentTestScenarios).flatMap(s => s);
 
 const testScenarioNames = testScenarios.map(f => f.name);
 

--- a/webview-ui/src/manualTest/periscopeTests.tsx
+++ b/webview-ui/src/manualTest/periscopeTests.tsx
@@ -1,12 +1,12 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
-import { PeriscopeTypes } from "../../../src/webview-contract/webviewTypes";
+import { InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { Scenario } from "../utilities/manualTest";
 import { getTestVscodeMessageContext } from "../utilities/vscode";
 import { Periscope } from "../Periscope/Periscope";
 
 export function getPeriscopeScenarios() {
     const clusterName = "test-cluster";
-    const noDiagnosticsState: PeriscopeTypes.InitialState = {
+    const noDiagnosticsState: InitialState = {
         state: "noDiagnosticsConfigured",
         clusterName,
         runId: "",
@@ -29,7 +29,7 @@ export function getPeriscopeScenarios() {
     const blobContainerUrl = `https://teststgaccount.net/${clusterName}-logs`;
     const shareableSas = "?saskey";
 
-    const errorState: PeriscopeTypes.InitialState = {
+    const errorState: InitialState = {
         state: "error",
         clusterName,
         runId,
@@ -40,7 +40,7 @@ export function getPeriscopeScenarios() {
         shareableSas
     }
 
-    const successState: PeriscopeTypes.InitialState = {
+    const successState: InitialState = {
         state: "success",
         clusterName,
         runId,
@@ -51,8 +51,8 @@ export function getPeriscopeScenarios() {
         shareableSas
     };
 
-    const webview = getTestVscodeMessageContext<PeriscopeTypes.ToWebViewMsgDef, PeriscopeTypes.ToVsCodeMsgDef>();
-    const messageHandler: MessageHandler<PeriscopeTypes.ToVsCodeMsgDef> = {
+    const webview = getTestVscodeMessageContext<ToWebViewMsgDef, ToVsCodeMsgDef>();
+    const messageHandler: MessageHandler<ToVsCodeMsgDef> = {
         nodeLogsRequest: args => handleNodeLogsRequest(args.nodeName),
         uploadStatusRequest: handleUploadStatusRequest
     };
@@ -86,8 +86,8 @@ export function getPeriscopeScenarios() {
     }
 
     return [
-        Scenario.create(`${PeriscopeTypes.contentId} (no diagnostics)`, () => <Periscope {...noDiagnosticsState} />),
-        Scenario.create(`${PeriscopeTypes.contentId} (error)`, () => <Periscope {...errorState} />),
-        Scenario.create(`${PeriscopeTypes.contentId} (deployed)`, () => <Periscope {...successState} />).withSubscription(webview, messageHandler)
+        Scenario.create(`Periscope (no diagnostics)`, () => <Periscope {...noDiagnosticsState} />),
+        Scenario.create(`Periscope (error)`, () => <Periscope {...errorState} />),
+        Scenario.create(`Periscope (deployed)`, () => <Periscope {...successState} />).withSubscription(webview, messageHandler)
     ]
 }

--- a/webview-ui/src/manualTest/testStyleViewerTests.tsx
+++ b/webview-ui/src/manualTest/testStyleViewerTests.tsx
@@ -1,12 +1,12 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
-import { TestStyleViewerTypes } from "../../../src/webview-contract/webviewTypes";
+import { CssRule, InitialState, ToVsCodeMsgDef, ToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/testStyleViewer";
 import { Scenario } from "./../utilities/manualTest";
 import { getTestVscodeMessageContext } from "./../utilities/vscode";
 import { TestStyleViewer } from "./../TestStyleViewer/TestStyleViewer";
 
 export function getTestStyleViewerScenarios() {
-    const webview = getTestVscodeMessageContext<TestStyleViewerTypes.ToWebViewMsgDef, TestStyleViewerTypes.ToVsCodeMsgDef>();
-    const messageHandler: MessageHandler<TestStyleViewerTypes.ToVsCodeMsgDef> = {
+    const webview = getTestVscodeMessageContext<ToWebViewMsgDef, ToVsCodeMsgDef>();
+    const messageHandler: MessageHandler<ToVsCodeMsgDef> = {
         reportCssRules: args => handleReportCssRules(args.rules),
         reportCssVars: args => handleReportCssVars(args.cssVars)
     };
@@ -15,15 +15,15 @@ export function getTestStyleViewerScenarios() {
         console.log(cssVars.join('\n'));
     }
 
-    function handleReportCssRules(rules: TestStyleViewerTypes.CssRule[]) {
+    function handleReportCssRules(rules: CssRule[]) {
         console.log(rules.map(r => r.text).join('\n'));
     }
 
-    const initialState: TestStyleViewerTypes.InitialState = {
+    const initialState: InitialState = {
         isVSCode: false
     };
 
     return [
-        Scenario.create(TestStyleViewerTypes.contentId, () => <TestStyleViewer {...initialState} />).withSubscription(webview, messageHandler)
+        Scenario.create("Test Style Viewer", () => <TestStyleViewer {...initialState} />).withSubscription(webview, messageHandler)
     ];
 }


### PR DESCRIPTION
This introduces a combined type definition for all the webviews and associated identifiers. This allows the complete set of webviews to be known at compile time, meaning code that handles _all_ webviews can be type-checked to ensure that none have been missed, making the addition of new webviews less error-prone.

Because all types for a Webview can be determined from its content ID, generic type parameters are much shorter, e.g.:
```typescript
class DetectorPanel extends BasePanel<DetectorTypes.InitialState, DetectorTypes.ToWebViewMsgDef, DetectorTypes.ToVsCodeMsgDef>
```
is now
```typescript
class DetectorPanel extends BasePanel<"detector">
```
The `"detector"` string in the above example is also type-checked to allow intellisense and prevent mis-spelling.

The shared types (between VS Code and Webview projects) are moved into their own directory, with a separate file for each Webview, to prevent the `webviewTypes.ts` file getting too large.