### PR TITLE
Add common OpenAI code with example usage in kubectl webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "js-yaml": "^3.14.0",
                 "move-file": "^3.0.0",
                 "neverthrow": "^4.3.0",
+                "openai": "^4.6.0",
                 "rxjs": "^7.8.0",
                 "semver": "^7.3.7",
                 "sinon": "^12.0.1",
@@ -1467,6 +1468,17 @@
                 "node": ">= 6.0.0"
             }
         },
+        "node_modules/agentkeepalive": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+            "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+            "dependencies": {
+                "humanize-ms": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "license": "MIT",
@@ -1731,6 +1743,11 @@
             "version": "1.0.0",
             "license": "MIT"
         },
+        "node_modules/base-64": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+            "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "funding": [
@@ -1992,6 +2009,14 @@
                 "traverse": ">=0.3.0 <0.4"
             }
         },
+        "node_modules/charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/check-error": {
             "version": "1.0.2",
             "dev": true,
@@ -2240,6 +2265,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/dayjs": {
@@ -2632,6 +2665,15 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/digest-fetch": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+            "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+            "dependencies": {
+                "base-64": "^0.1.0",
+                "md5": "^2.3.0"
             }
         },
         "node_modules/dir-glob": {
@@ -3682,6 +3724,23 @@
                 "node": ">= 0.12"
             }
         },
+        "node_modules/form-data-encoder": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+            "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+        },
+        "node_modules/formdata-node": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+            "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+            "dependencies": {
+                "node-domexception": "1.0.0",
+                "web-streams-polyfill": "4.0.0-beta.3"
+            },
+            "engines": {
+                "node": ">= 12.20"
+            }
+        },
         "node_modules/from2": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4039,6 +4098,14 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "dependencies": {
+                "ms": "^2.0.0"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "funding": [
@@ -4174,6 +4241,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-callable": {
             "version": "1.2.0",
@@ -4755,6 +4827,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "dependencies": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "license": "MIT"
@@ -5084,6 +5166,24 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -5190,6 +5290,29 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/openai": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-4.6.0.tgz",
+            "integrity": "sha512-LuONkTgoe4D172raQCv+eEK5OdLGnY/M4JrUz/pxRGevZwqDqy3xhBbCeWX8QLCbFcnITYsu/VBJXZJ0rDAMpA==",
+            "dependencies": {
+                "@types/node": "^18.11.18",
+                "@types/node-fetch": "^2.6.4",
+                "abort-controller": "^3.0.0",
+                "agentkeepalive": "^4.2.1",
+                "digest-fetch": "^1.3.0",
+                "form-data-encoder": "1.7.2",
+                "formdata-node": "^4.3.2",
+                "node-fetch": "^2.6.7"
+            },
+            "bin": {
+                "openai": "bin/cli"
+            }
+        },
+        "node_modules/openai/node_modules/@types/node": {
+            "version": "18.17.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+            "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
         },
         "node_modules/optionator": {
             "version": "0.9.1",
@@ -6505,6 +6628,14 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "4.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+            "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/webidl-conversions": {
@@ -7896,6 +8027,14 @@
                 "debug": "4"
             }
         },
+        "agentkeepalive": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+            "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+            "requires": {
+                "humanize-ms": "^1.2.1"
+            }
+        },
         "aggregate-error": {
             "version": "3.1.0",
             "requires": {
@@ -8078,6 +8217,11 @@
         "balanced-match": {
             "version": "1.0.0"
         },
+        "base-64": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+            "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+        },
         "base64-js": {
             "version": "1.5.1"
         },
@@ -8226,6 +8370,11 @@
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
+        },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
         },
         "check-error": {
             "version": "1.0.2",
@@ -8393,6 +8542,11 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
         },
         "dayjs": {
             "version": "1.11.3"
@@ -8647,6 +8801,15 @@
         "diagnostic-channel-publishers": {
             "version": "0.3.5",
             "requires": {}
+        },
+        "digest-fetch": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+            "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+            "requires": {
+                "base-64": "^0.1.0",
+                "md5": "^2.3.0"
+            }
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -9363,6 +9526,20 @@
                 "mime-types": "^2.1.12"
             }
         },
+        "form-data-encoder": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+            "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+        },
+        "formdata-node": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+            "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+            "requires": {
+                "node-domexception": "1.0.0",
+                "web-streams-polyfill": "4.0.0-beta.3"
+            }
+        },
         "from2": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -9606,6 +9783,14 @@
                 "debug": "4"
             }
         },
+        "humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "requires": {
+                "ms": "^2.0.0"
+            }
+        },
         "ieee754": {
             "version": "1.2.1"
         },
@@ -9678,6 +9863,11 @@
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-callable": {
             "version": "1.2.0"
@@ -10059,6 +10249,16 @@
                 }
             }
         },
+        "md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "requires": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
+            }
+        },
         "merge-stream": {
             "version": "2.0.0"
         },
@@ -10263,6 +10463,11 @@
                 }
             }
         },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+        },
         "node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -10319,6 +10524,28 @@
                     "requires": {
                         "is-docker": "^2.0.0"
                     }
+                }
+            }
+        },
+        "openai": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-4.6.0.tgz",
+            "integrity": "sha512-LuONkTgoe4D172raQCv+eEK5OdLGnY/M4JrUz/pxRGevZwqDqy3xhBbCeWX8QLCbFcnITYsu/VBJXZJ0rDAMpA==",
+            "requires": {
+                "@types/node": "^18.11.18",
+                "@types/node-fetch": "^2.6.4",
+                "abort-controller": "^3.0.0",
+                "agentkeepalive": "^4.2.1",
+                "digest-fetch": "^1.3.0",
+                "form-data-encoder": "1.7.2",
+                "formdata-node": "^4.3.2",
+                "node-fetch": "^2.6.7"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "18.17.15",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+                    "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
                 }
             }
         },
@@ -11162,6 +11389,11 @@
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             }
+        },
+        "web-streams-polyfill": {
+            "version": "4.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+            "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
         },
         "webidl-conversions": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
         "configuration": {
             "title": "AKS",
             "properties": {
+                "aks.openai.apiKey": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Open AI API Key",
+                    "description": "API Key from the OpenAI API keys profile."
+                },
                 "aks.periscope.repoOrg": {
                     "type": "string",
                     "default": "azure",
@@ -443,6 +449,7 @@
         "js-yaml": "^3.14.0",
         "move-file": "^3.0.0",
         "neverthrow": "^4.3.0",
+        "openai": "^4.6.0",
         "rxjs": "^7.8.0",
         "semver": "^7.3.7",
         "sinon": "^12.0.1",

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -3,6 +3,34 @@ import { combine, failed, Errorable } from './errorable';
 import { KubeloginConfig, KustomizeConfig } from '../periscope/models/config';
 import * as semver from "semver";
 import { CommandCategory, PresetCommand } from '../../webview-contract/webviewDefinitions/kubectl';
+import { OpenAIConfig } from './helper/openaiConfig';
+
+export function getOpenAIConfig(): Errorable<OpenAIConfig> {
+    const openaiConfig = vscode.workspace.getConfiguration('aks.openai');
+    const config = getConfigValue(openaiConfig, 'apiKey');
+
+    if (failed(config)) {
+        return {
+            succeeded: false,
+            error: `Failed to read aks.openai configuration: ${config.error}`
+        };
+    } else if (!config.result) {
+        return {
+            succeeded: false,
+            error: `OpenAI key is not specified in aks.openai configuration. AI function will be disabled.`
+        };
+    }
+
+    const configresult = {
+        apiKey: config.result
+    };
+
+    return { succeeded: true, result: configresult };
+}
+
+export async function setOpenAIConfigApiKey(apiKey: string) {
+    await vscode.workspace.getConfiguration().update('aks.openai.apiKey', apiKey, vscode.ConfigurationTarget.Global, true);
+}
 
 export function getKustomizeConfig(): Errorable<KustomizeConfig> {
     const periscopeConfig = vscode.workspace.getConfiguration('aks.periscope');

--- a/src/commands/utils/helper/openaiConfig.ts
+++ b/src/commands/utils/helper/openaiConfig.ts
@@ -1,0 +1,3 @@
+export interface OpenAIConfig {
+    apiKey: string;
+ }

--- a/src/commands/utils/helper/openaiHelper.ts
+++ b/src/commands/utils/helper/openaiHelper.ts
@@ -1,0 +1,35 @@
+import OpenAI from 'openai';
+import { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat';
+import { Errorable, getErrorMessage } from '../errorable';
+import { Observable, filter, from, map } from 'rxjs';
+import { Stream } from 'openai/streaming';
+import { OpenAIConfig } from './openaiConfig';
+
+export async function getOpenAIResult(config: OpenAIConfig, message: string): Promise<Errorable<Observable<string>>> {
+    const openai = new OpenAI({
+        apiKey: config.apiKey
+    });
+
+    const body: ChatCompletionCreateParamsStreaming = {
+        messages: [{ role: 'user', content: message }],
+        model: 'gpt-3.5-turbo',
+        stream: true
+    };
+
+    const options = { timeout: 30000 };
+    let responseStream: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
+    try {
+        responseStream = await openai.chat.completions.create(body, options);
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
+
+    const response = from(responseStream).pipe(
+        map(chunk => chunk.choices[0].delta?.content || null),
+        filter(s => s !== null)) as Observable<string>; // Cast is safe because we're filtering out nulls.
+
+    return {
+        succeeded: true,
+        result: response
+    };
+}

--- a/src/panels/utilities/openai.ts
+++ b/src/panels/utilities/openai.ts
@@ -1,0 +1,57 @@
+import { getOpenAIConfig, setOpenAIConfigApiKey } from "../../commands/utils/config";
+import { failed, getErrorMessage, succeeded } from "../../commands/utils/errorable";
+import { getOpenAIResult } from "../../commands/utils/helper/openaiHelper";
+import { MessageHandler, MessageSink } from "../../webview-contract/messaging";
+import { AIKeyStatus, AIToVsCodeMsgDef, AIToWebViewMsgDef } from "../../webview-contract/webviewDefinitions/shared";
+
+export class OpenAIHelper {
+    public config = getOpenAIConfig();
+    public keyStatus = failed(this.config) ? AIKeyStatus.Missing : AIKeyStatus.Unverified;
+
+    public getMessageHandler<TMsgDef extends AIToWebViewMsgDef>(webview: MessageSink<TMsgDef>): MessageHandler<AIToVsCodeMsgDef> {
+        const aiWebview = webview as any as MessageSink<AIToWebViewMsgDef>;
+        return {
+            getAIKeyStatus: _args => this._handleGetAIKeyStatus(aiWebview),
+            updateAIKeyRequest: args => this._handleUpdateAIKeyRequest(args.apiKey, aiWebview)
+        };
+    }
+
+    public async runOpenAIRequest<TMsgDef extends AIToWebViewMsgDef>(prompt: string, webview: MessageSink<TMsgDef>): Promise<void> {
+        const aiWebview = webview as any as MessageSink<AIToWebViewMsgDef>;
+        if (failed(this.config)) {
+            this._updateAIKeyStatus(AIKeyStatus.Missing, null, aiWebview);
+            return;
+        }
+
+        const response = await getOpenAIResult(this.config.result, prompt);
+        if (failed(response)) {
+            this._updateAIKeyStatus(AIKeyStatus.Invalid, this.config.result.apiKey, aiWebview);
+            return;
+        }
+
+        this._updateAIKeyStatus(AIKeyStatus.Valid, null, aiWebview);
+
+        aiWebview.postMessage( {command: "startAIResponse", parameters: undefined });
+        response.result.subscribe({
+            next: chunk => aiWebview.postMessage({ command: "appendAIResponse", parameters: {chunk} }),
+            error: err => aiWebview.postMessage({ command: "errorStreamingAIResponse", parameters: {error: getErrorMessage(err)} }),
+            complete: () => aiWebview.postMessage({ command: "completeAIResponse", parameters: undefined })
+        });
+    }
+
+    private _handleGetAIKeyStatus(webview: MessageSink<AIToWebViewMsgDef>) {
+        const invalidKey = succeeded(this.config) && this.keyStatus === AIKeyStatus.Invalid ? this.config.result.apiKey : null;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: this.keyStatus, invalidKey} });
+    }
+
+    private async _handleUpdateAIKeyRequest(apiKey: string, webview: MessageSink<AIToWebViewMsgDef>) {
+        await setOpenAIConfigApiKey(apiKey);
+        this.config = getOpenAIConfig();
+        this._updateAIKeyStatus(AIKeyStatus.Unverified, null, webview);
+    }
+
+    private _updateAIKeyStatus(keyStatus: AIKeyStatus, invalidKey: string | null, webview: MessageSink<AIToWebViewMsgDef>) {
+        this.keyStatus = keyStatus;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus, invalidKey} });
+    }
+}

--- a/src/webview-contract/webviewDefinitions/kubectl.ts
+++ b/src/webview-contract/webviewDefinitions/kubectl.ts
@@ -1,4 +1,5 @@
 import { WebviewDefinition } from "../webviewTypes";
+import { AIToVsCodeMsgDef, AIToWebViewMsgDef } from "./shared";
 
 export enum CommandCategory {
     Resources,
@@ -35,7 +36,7 @@ export interface InitialState {
     customCommands: PresetCommand[]
 }
 
-export type ToVsCodeMsgDef = {
+export type ToVsCodeMsgDef = AIToVsCodeMsgDef & {
     runCommandRequest: {
         command: string
     },
@@ -48,7 +49,7 @@ export type ToVsCodeMsgDef = {
     }
 };
 
-export type ToWebViewMsgDef = {
+export type ToWebViewMsgDef = AIToWebViewMsgDef & {
     runCommandResponse: {
         output: string | null
         errorMessage: string | null

--- a/src/webview-contract/webviewDefinitions/shared.ts
+++ b/src/webview-contract/webviewDefinitions/shared.ts
@@ -1,0 +1,29 @@
+
+export enum AIKeyStatus {
+    Missing,
+    Unverified,
+    Invalid,
+    Valid
+}
+
+export type AIToVsCodeMsgDef = {
+    getAIKeyStatus: void,
+    updateAIKeyRequest: {
+        apiKey: string
+    }
+};
+
+export type AIToWebViewMsgDef = {
+    updateAIKeyStatus: {
+        keyStatus: AIKeyStatus,
+        invalidKey: string | null
+    },
+    startAIResponse: void,
+    errorStreamingAIResponse: {
+        error: string
+    }
+    appendAIResponse: {
+        chunk: string
+    },
+    completeAIResponse: void
+};

--- a/webview-ui/src/Kubectl/CommandOutput.tsx
+++ b/webview-ui/src/Kubectl/CommandOutput.tsx
@@ -2,15 +2,23 @@ import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./Kubectl.module.css";
 import { EventHandlers } from "../utilities/state";
 import { UserMsgDef } from "./helpers/userCommands";
+import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/shared";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { OpenAIOutput } from "../components/OpenAIOutput";
 
 export interface CommandOutputProps {
     isCommandRunning: boolean
     output: string | null
     errorMessage: string | null
+    explanation: string | null
+    isExplanationStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
     userMessageHandlers: EventHandlers<UserMsgDef>
 }
 
 export function CommandOutput(props: CommandOutputProps) {
+    const vscode = getWebviewMessageContext<"kubectl">();
     const hasOutput = props.output !== undefined;
     const hasError = props.errorMessage !== undefined;
 
@@ -19,6 +27,14 @@ export function CommandOutput(props: CommandOutputProps) {
         {props.isCommandRunning && <VSCodeProgressRing />}
         {hasOutput && <pre>{props.output}</pre>}
         {hasError && <pre className={styles.error}>{props.errorMessage}</pre>}
+        <OpenAIOutput
+            vscode={vscode}
+            explanation={props.explanation}
+            isOutputStreaming={props.isExplanationStreaming}
+            aiKeyStatus={props.aiKeyStatus}
+            invalidAIKey={props.invalidAIKey}
+            userMessageHandlers={props.userMessageHandlers}
+        />
     </>
     );
 }

--- a/webview-ui/src/Kubectl/Kubectl.tsx
+++ b/webview-ui/src/Kubectl/Kubectl.tsx
@@ -19,6 +19,7 @@ export function Kubectl(props: InitialState) {
     useEffect(() => {
         if (!state.initializationStarted) {
             dispatch({ command: "setInitializing" });
+            vscode.postMessage({ command: "getAIKeyStatus", parameters: undefined });
         }
 
         const msgHandler = getMessageHandler<ToWebViewMsgDef>(dispatch, vscodeMessageHandler);
@@ -91,6 +92,10 @@ export function Kubectl(props: InitialState) {
                 isCommandRunning={state.isCommandRunning}
                 output={state.output}
                 errorMessage={state.errorMessage}
+                explanation={state.aiResponse}
+                isExplanationStreaming={state.isAIResponseStreaming}
+                aiKeyStatus={state.aiKeyStatus}
+                invalidAIKey={state.invalidAIKey}
                 userMessageHandlers={userMessageEventHandlers}
             />
         </div>

--- a/webview-ui/src/Kubectl/helpers/state.ts
+++ b/webview-ui/src/Kubectl/helpers/state.ts
@@ -1,8 +1,9 @@
 import { PresetCommand, ToWebViewMsgDef, presetCommands } from "../../../../src/webview-contract/webviewDefinitions/kubectl"
+import { AIState, createAIState, getAIUserMessageHandler, getAIVscodeMessageHandler } from "../../utilities/openai"
 import { StateMessageHandler, chainStateUpdaters, toStateUpdater } from "../../utilities/state"
 import { UserMsgDef } from "./userCommands"
 
-export interface KubectlState {
+export interface KubectlState extends AIState {
     initializationStarted: boolean
     allCommands: PresetCommand[]
     selectedCommand: string | null
@@ -20,12 +21,14 @@ export function createState(customCommands: PresetCommand[]): KubectlState {
         isCommandRunning: false,
         output: null,
         errorMessage: null,
-        isSaveDialogShown: false
+        isSaveDialogShown: false,
+        ...createAIState()
     };
 }
 
 export const vscodeMessageHandler: StateMessageHandler<ToWebViewMsgDef, KubectlState> = {
-    runCommandResponse: (state, args) => ({...state, output: args.output, errorMessage: args.errorMessage, explanation: null, isCommandRunning: false})
+    runCommandResponse: (state, args) => ({...state, output: args.output, errorMessage: args.errorMessage, explanation: null, isCommandRunning: false}),
+    ...getAIVscodeMessageHandler()
 }
 
 export const userMessageHandler: StateMessageHandler<UserMsgDef, KubectlState> = {
@@ -33,7 +36,8 @@ export const userMessageHandler: StateMessageHandler<UserMsgDef, KubectlState> =
     setSelectedCommand: (state, args) => ({...state, selectedCommand: args.command, output: null, errorMessage: null, explanation: null}),
     setAllCommands: (state, args) => ({...state, allCommands: args.allCommands}),
     setCommandRunning: (state, _args) => ({...state, isCommandRunning: true, output: null, errorMessage: null, explanation: null}),
-    setSaveDialogVisibility: (state, args) => ({...state, isSaveDialogShown: args.shown})
+    setSaveDialogVisibility: (state, args) => ({...state, isSaveDialogShown: args.shown}),
+    ...getAIUserMessageHandler()
 }
 
 export const updateState = chainStateUpdaters(

--- a/webview-ui/src/Kubectl/helpers/userCommands.ts
+++ b/webview-ui/src/Kubectl/helpers/userCommands.ts
@@ -1,7 +1,8 @@
 import { Message } from "../../../../src/webview-contract/messaging"
 import { PresetCommand } from "../../../../src/webview-contract/webviewDefinitions/kubectl"
+import { AIUserMsgDef } from "../../utilities/openai"
 
-export type UserMsgDef = {
+export type UserMsgDef = AIUserMsgDef & {
     setInitializing: void,
     setSelectedCommand: {
         command: string

--- a/webview-ui/src/components/OpenAIOutput.module.css
+++ b/webview-ui/src/components/OpenAIOutput.module.css
@@ -1,0 +1,11 @@
+.labelTextButton {
+    display: grid;
+    grid-template-columns: 4rem 20rem 4rem;
+    grid-gap: 0.5rem;
+    align-items: center;
+}
+
+pre.explanation {
+    color: var(--vscode-editor-foreground);
+    white-space: pre-wrap;
+}

--- a/webview-ui/src/components/OpenAIOutput.tsx
+++ b/webview-ui/src/components/OpenAIOutput.tsx
@@ -1,0 +1,52 @@
+import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import styles from "./OpenAIOutput.module.css";
+import { FormEvent, useState } from "react";
+import { AIKeyStatus, AIToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/shared";
+import { EventHandlers } from "../utilities/state";
+import { AIUserMsgDef } from "../utilities/openai";
+import { MessageSink } from "../../../src/webview-contract/messaging";
+
+type ChangeEvent = Event | FormEvent<HTMLElement>;
+
+export interface OpenAIOutputProps {
+    vscode: MessageSink<AIToVsCodeMsgDef>
+    explanation: string | null
+    isOutputStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
+    userMessageHandlers: EventHandlers<AIUserMsgDef>
+}
+
+export function OpenAIOutput(props: OpenAIOutputProps) {
+    const [apiKey, setApiKey] = useState<string>("");
+
+    function handleAPIKeyChange(e: ChangeEvent) {
+        const input = e.currentTarget as HTMLInputElement;
+        setApiKey(input.value);
+    }
+
+    function handleUpdateClick() {
+        props.vscode.postMessage({ command: "updateAIKeyRequest", parameters: {apiKey} });
+        props.userMessageHandlers.onSetAPIKeySaved();
+    }
+
+    const canUpdate = apiKey && apiKey.trim() && apiKey.trim() !== props.invalidAIKey;
+    const needsNewAIKey = props.aiKeyStatus === AIKeyStatus.Missing || props.aiKeyStatus === AIKeyStatus.Invalid;
+
+    return (
+        <>
+            {needsNewAIKey && (
+                <div>
+                    {props.aiKeyStatus === AIKeyStatus.Invalid && <p>OpenAI API Key is invalid</p>}
+                    {props.aiKeyStatus === AIKeyStatus.Missing && <p>OpenAI API Key is not set</p>}
+                    <div className={styles.labelTextButton}>
+                        <label htmlFor="api-key-input">API Key:</label>
+                        <VSCodeTextField id="api-key-input" value={apiKey} onInput={handleAPIKeyChange} />
+                        <VSCodeButton disabled={!canUpdate} onClick={handleUpdateClick}>{props.invalidAIKey ? 'Update' : 'Set'}</VSCodeButton>
+                    </div>
+                </div>
+            )}
+            {props.explanation && <pre className={styles.explanation}>{props.explanation}</pre>}
+        </>
+    )
+}

--- a/webview-ui/src/manualTest/kubectlTests.tsx
+++ b/webview-ui/src/manualTest/kubectlTests.tsx
@@ -1,5 +1,6 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
 import { CommandCategory, InitialState, PresetCommand, ToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/kubectl";
+import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/shared";
 import { Kubectl } from "../Kubectl/Kubectl";
 import { Scenario } from "../utilities/manualTest";
 import { getTestVscodeMessageContext } from "../utilities/vscode";
@@ -8,6 +9,9 @@ const customCommands: PresetCommand[] = [
     {name: "Test 1", command: "get things", category: CommandCategory.Custom},
     {name: "Test 2", command: "get other things", category: CommandCategory.Custom}
 ];
+
+let apiKey: string | null = null;
+let apiKeyStatus = apiKey ? AIKeyStatus.Unverified : AIKeyStatus.Missing;
 
 export function getKubectlScenarios() {
     const clusterName = "test-cluster";
@@ -22,7 +26,9 @@ export function getKubectlScenarios() {
         return {
             runCommandRequest: args => handleRunCommandRequest(args.command, succeeding),
             addCustomCommandRequest: _ => undefined,
-            deleteCustomCommandRequest: _ => undefined
+            deleteCustomCommandRequest: _ => undefined,
+            getAIKeyStatus: _ => handleGetAIKeyStatus(),
+            updateAIKeyRequest: args => handleUpdateAIKeyRequest(args.apiKey)
         }
     }
 
@@ -37,6 +43,17 @@ export function getKubectlScenarios() {
                 }
             });
         } else {
+            const explanation = "And here's a natural language explanation of what went wrong.";
+            let canStream = false;
+            if (apiKey === "valid") {
+                canStream = true;
+                updateAIKeyStatus(AIKeyStatus.Valid, null);
+            } else if (!apiKey) {
+                updateAIKeyStatus(AIKeyStatus.Missing, null);
+            } else {
+                updateAIKeyStatus(AIKeyStatus.Invalid, apiKey);
+            }
+
             webview.postMessage({
                 command: "runCommandResponse",
                 parameters: {
@@ -44,7 +61,38 @@ export function getKubectlScenarios() {
                     errorMessage: "Something went wrong and this is the error."
                 }
             });
+
+            if (canStream) {
+                for (const word of explanation.split(" ").map((w, i) => `${i > 0 ? ' ': ''}${w}`)) {
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                    webview.postMessage({
+                        command: "appendAIResponse",
+                        parameters: {
+                            chunk: word
+                        }
+                    });
+                }
+                await new Promise(resolve => setTimeout(resolve, 100));
+                webview.postMessage({
+                    command: "completeAIResponse",
+                    parameters: undefined
+                });
+            }
         }
+    }
+
+    function handleGetAIKeyStatus() {
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: apiKeyStatus, invalidKey: apiKeyStatus === AIKeyStatus.Invalid ? apiKey : null} });
+    }
+
+    function handleUpdateAIKeyRequest(newApiKey: string) {
+        apiKey = newApiKey;
+        updateAIKeyStatus(AIKeyStatus.Unverified, null);
+    }
+
+    function updateAIKeyStatus(keyStatus: AIKeyStatus, invalidKey: string | null) {
+        apiKeyStatus = keyStatus;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus, invalidKey} });
     }
 
     return [

--- a/webview-ui/src/utilities/openai.ts
+++ b/webview-ui/src/utilities/openai.ts
@@ -1,0 +1,40 @@
+import { AIKeyStatus, AIToWebViewMsgDef } from "../../../src/webview-contract/webviewDefinitions/shared"
+import { StateMessageHandler } from "./state"
+
+export type AIUserMsgDef = {
+    setAPIKeySaved: void
+}
+
+export interface AIState {
+    aiResponse: string | null
+    aiError: string | null
+    isAIResponseStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
+}
+
+export function createAIState(): AIState {
+    return {
+        aiResponse: null,
+        aiError: null,
+        isAIResponseStreaming: false,
+        aiKeyStatus: AIKeyStatus.Unverified,
+        invalidAIKey: null
+    };
+}
+
+export function getAIVscodeMessageHandler<TState extends AIState>(): StateMessageHandler<AIToWebViewMsgDef, TState> {
+    return {
+        startAIResponse: (state, _args) => ({...state, isAIResponseStreaming: true}),
+        errorStreamingAIResponse: (state, args) => ({...state, aiError: args.error}),
+        appendAIResponse: (state, args) => ({...state, aiResponse: (state.aiResponse || "") + args.chunk}),
+        completeAIResponse: (state, _args) => ({...state, isAIResponseStreaming: false}),
+        updateAIKeyStatus: (state, args) => ({...state, aiKeyStatus: args.keyStatus, invalidAIKey: args.invalidKey})
+    };
+}
+
+export function getAIUserMessageHandler<TState extends AIState>(): StateMessageHandler<AIUserMsgDef, TState> {
+    return {
+        setAPIKeySaved: (state, _args) => ({...state, aiKeyStatus: AIKeyStatus.Unverified, invalidAIKey: null})
+    };
+};


### PR DESCRIPTION
Not to be merged, for now.

Opening this as an example of how we might integrate OpenAI logic into our webviews.

This splits the hackathon work into common files/components that could be reused in different scenarios, as well as an example of how it could be incorporated into the `kubectl` webview.