### PR TITLE
Abort last operation on cluster.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^8.4.1",
-                "@azure/arm-containerservice": "^17.2.0",
+                "@azure/arm-containerservice": "^19.3.0",
                 "@azure/arm-monitor": "^6.0.0",
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-subscriptions": "^2.0.1",
@@ -98,16 +98,16 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@azure/arm-containerservice": {
-            "version": "17.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-17.2.0.tgz",
-            "integrity": "sha512-Ofl9G57wrDYQ7ueELT/vR1Tv3/Qg9IUq6TpXWT3UckRltj3BV/tZdTDuueJoA6k23wPFHbDRrDO0AJt19D8EKg==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-19.3.0.tgz",
+            "integrity": "sha512-SZ1kLB0GLPC3/cMCW2ISqD4IjAeqBe5QHb5F9sCKUHaa96gLwuHE842WDuIzS5NQ9oCuw2+uCBLIxBJbxea9Gw==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
+                "@azure/core-rest-pipeline": "^1.12.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -338,20 +338,19 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.0.tgz",
-            "integrity": "sha512-m6c4iAalfaf6sytOOQhLKFprEHSkSjQuRgkW7MTMnAN+GENDDL4XZJp7WKFnq9VpKUE+ggq+rp5xX9GI93lumw==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.1.tgz",
+            "integrity": "sha512-SsyWQ+T5MFQRX+M8H/66AlaI6HyCbQStGfFngx2fuiW+vKI2DkhtOvbYodPyf9fOe/ARLWWc3ohX54lQ5Kmaog==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.0.0",
+                "@azure/core-util": "^1.3.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
+                "tslib": "^2.2.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -6866,16 +6865,16 @@
             }
         },
         "@azure/arm-containerservice": {
-            "version": "17.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-17.2.0.tgz",
-            "integrity": "sha512-Ofl9G57wrDYQ7ueELT/vR1Tv3/Qg9IUq6TpXWT3UckRltj3BV/tZdTDuueJoA6k23wPFHbDRrDO0AJt19D8EKg==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-19.3.0.tgz",
+            "integrity": "sha512-SZ1kLB0GLPC3/cMCW2ISqD4IjAeqBe5QHb5F9sCKUHaa96gLwuHE842WDuIzS5NQ9oCuw2+uCBLIxBJbxea9Gw==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
+                "@azure/core-rest-pipeline": "^1.12.0",
                 "tslib": "^2.2.0"
             }
         },
@@ -7065,20 +7064,19 @@
             }
         },
         "@azure/core-rest-pipeline": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.0.tgz",
-            "integrity": "sha512-m6c4iAalfaf6sytOOQhLKFprEHSkSjQuRgkW7MTMnAN+GENDDL4XZJp7WKFnq9VpKUE+ggq+rp5xX9GI93lumw==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.1.tgz",
+            "integrity": "sha512-SsyWQ+T5MFQRX+M8H/66AlaI6HyCbQStGfFngx2fuiW+vKI2DkhtOvbYodPyf9fOe/ARLWWc3ohX54lQ5Kmaog==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.0.0",
+                "@azure/core-util": "^1.3.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
+                "tslib": "^2.2.0"
             },
             "dependencies": {
                 "@azure/core-tracing": {

--- a/package.json
+++ b/package.json
@@ -219,6 +219,10 @@
                 "title": "Rotate Cluster Certificate"
             },
             {
+                "command": "aks.aksAbortLastOperationInCluster",
+                "title": "Abort Last Operation"
+            },
+            {
                 "command": "aks.aksInspektorGadgetShow",
                 "title": "Show Inspektor Gadget"
             },
@@ -355,6 +359,10 @@
                 {
                     "command": "aks.aksRotateClusterCert",
                     "group": "navigation"
+                }, 
+                {
+                    "command": "aks.aksAbortLastOperationInCluster",
+                    "group": "navigation"
                 }
             ]
         },
@@ -412,7 +420,7 @@
     },
     "dependencies": {
         "@azure/arm-authorization": "^8.4.1",
-        "@azure/arm-containerservice": "^17.2.0",
+        "@azure/arm-containerservice": "^19.3.0",
         "@azure/arm-monitor": "^6.0.0",
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-subscriptions": "^2.0.1",

--- a/src/commands/aksAbortLastOperation/aksAbortLastOperation.ts
+++ b/src/commands/aksAbortLastOperation/aksAbortLastOperation.ts
@@ -25,8 +25,8 @@ export default async function aksAbortLastOperation(
     return;
   }
 
-  if (clusterProvisioingState.succeeded && clusterProvisioingState.result === "Succeeded") {
-    vscode.window.showInformationMessage(`Cluster provisioning state is ${clusterProvisioingState} and there is no operation to abort.`);
+  if (clusterProvisioingState.result === "Succeeded" || clusterProvisioingState.result === "Canceled") {
+    vscode.window.showInformationMessage(`Cluster provisioning state is ${clusterProvisioingState.result} and there is no operation to abort.`);
     return;
   }
   const answer = await vscode.window.showInformationMessage(`Do you want to abort last operation in cluster ${clusterName}?`, "Yes", "No");

--- a/src/commands/aksAbortLastOperation/aksAbortLastOperation.ts
+++ b/src/commands/aksAbortLastOperation/aksAbortLastOperation.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { abortLastOperationInCluster, getAksClusterTreeItem } from '../utils/clusters';
+import { failed, succeeded } from '../utils/errorable';
+import { longRunning } from '../utils/host';
+
+export default async function aksAbortLastOperation(
+  _context: IActionContext,
+  target: any
+): Promise<void> {
+  const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+  const cluster = getAksClusterTreeItem(target, cloudExplorer);
+  if (failed(cluster)) {
+    vscode.window.showErrorMessage(cluster.error);
+    return;
+  }
+
+  const clusterName = cluster.result.name;
+
+  const answer = await vscode.window.showInformationMessage(`Do you want to abort last operation in cluster ${clusterName}?`, "Yes", "No");
+
+  if (answer === "Yes") {
+    const result = await longRunning(`Aborting last cluster operation in ${clusterName}.`, async () => { return await abortLastOperationInCluster(cluster.result, clusterName) });
+
+    if (failed(result)) {
+      vscode.window.showErrorMessage(result.error);
+    }
+
+    if (succeeded(result)) {
+      vscode.window.showInformationMessage(result.result);
+    }
+  }
+}

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -447,6 +447,20 @@ export async function deleteCluster(
     }
 }
 
+export async function abortLastOperationInCluster(
+    target: AksClusterTreeItem,
+    clusterName: string
+): Promise<Errorable<string>> {
+    try {
+        const containerClient = getContainerClient(target);
+        await containerClient.managedClusters.beginAbortLatestOperationAndWait(target.resourceGroupName, clusterName)
+
+        return { succeeded: true, result: "Abort last operation in cluster succeeded." };
+    } catch (ex) {
+        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${getErrorMessage(ex)}` };
+    }
+}
+
 export async function rotateClusterCert(
     target: AksClusterTreeItem,
     clusterName: string

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -338,6 +338,21 @@ export async function determineClusterState(
     }
 }
 
+export async function determineProvisioningState(
+    target: AksClusterTreeItem,
+    clusterName: string
+): Promise<Errorable<string>> {
+    try {
+        const containerClient = getContainerClient(target);
+        const clusterInfo = (await containerClient.managedClusters.get(target.resourceGroupName, clusterName));
+
+        return { succeeded: true, result:  clusterInfo.provisioningState ?? "" };
+
+    } catch (ex) {
+        return { succeeded: false, error: `Error invoking ${clusterName} managed cluster: ${ex}` };
+    }
+}
+
 export async function startCluster(
     target: AksClusterTreeItem,
     clusterName: string,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import aksDeleteCluster from './commands/aksDeleteCluster/aksDeleteCluster';
 import aksRotateClusterCert from './commands/aksRotateClusterCert/aksRotateClusterCert';
 import { aksInspektorGadgetShow } from './commands/aksInspektorGadget/aksInspektorGadget';
 import aksCreateCluster from './commands/aksCreateCluster/aksCreateCluster';
+import aksAbortLastOperation from './commands/aksAbortLastOperation/aksAbortLastOperation';
 
 export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -71,6 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry('aks.aksCategoryConnectivity', aksCategoryConnectivity);
         registerCommandWithTelemetry('aks.aksDeleteCluster', aksDeleteCluster);
         registerCommandWithTelemetry('aks.aksRotateClusterCert', aksRotateClusterCert);
+        registerCommandWithTelemetry('aks.aksAbortLastOperationInCluster', aksAbortLastOperation);
         registerCommandWithTelemetry('aks.aksInspektorGadgetShow', aksInspektorGadgetShow);
         registerCommandWithTelemetry('aks.createCluster', aksCreateCluster);
 


### PR DESCRIPTION
This PR enables the quick to `Abort Last Operation` managed cluster API via Vscode, bringing user experience feature closer to their favourite editor.

https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/abort-latest-operation?tabs=HTTP

Than you so much, fyi @peterbom, @gambtho, @hsubramanianaks  and @qpetraroia 

how it will work et. al. very handy command and as an upgrade in next drop we can integrate this in the `ClusterProperty` page.

<img width="545" alt="Screenshot 2023-10-06 at 10 48 42 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/48a2e4ad-19c6-4859-8a2a-fa1c915bcd6c">

<img width="1363" alt="Screenshot 2023-10-06 at 10 47 13 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/4c38da51-d3e4-4521-9fd4-24bc674bb408">

<img width="580" alt="Screenshot 2023-10-06 at 10 34 24 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/6bafad3e-c58a-4cf9-9253-94caecba9451">
<img width="547" alt="Screenshot 2023-10-06 at 10 46 33 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/ce720fe4-47f4-4f6a-8be4-2e3151d08db9">
 
<img width="563" alt="Screenshot 2023-10-06 at 10 35 27 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/7be33ab3-34e8-4001-92dc-9ee4de0ca054">



<img width="560" alt="Screenshot 2023-10-06 at 10 34 02 AM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/2a642f73-90f8-4fc0-9c34-2a328280770a">

