### PR TITLE
Add state management to webviews

### DIFF
--- a/src/panels/BasePanel.ts
+++ b/src/panels/BasePanel.ts
@@ -31,6 +31,8 @@ export abstract class BasePanel<TContent extends ContentId> {
             enableScripts: true,
             // Restrict the webview to only load resources from the `webview-ui/dist` directory
             localResourceRoots: [Uri.joinPath(this.extensionUri, "webview-ui/dist")],
+            // persist the state of the webview across restarts
+            retainContextWhenHidden: true
         };
 
         const title = dataProvider.getTitle();


### PR DESCRIPTION
Courtesy of @hsubramanianaks: this avoids webviews losing their state when they are hidden.

See: https://code.visualstudio.com/api/extension-guides/webview#retaincontextwhenhidden

The next step will be to work on an alternative approach to address the documented concern that "this has high memory overhead and should only be used when other persistence techniques will not work".