### PR TITLE
fix build.

### DIFF
--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -150,7 +150,7 @@ async function createCluster(
     const poller = await containerServiceClient.managedClusters.beginCreateOrUpdate(group.name, name, clusterSpec);
 
     poller.onProgress(state => {
-        if (state.isCancelled) {
+        if (state.status === "canceled") {
             webview.postMessage({
                 command: "progressUpdate",
                 parameters: {
@@ -169,7 +169,7 @@ async function createCluster(
                     errorMessage: getErrorMessage(state.error)
                 }
             });
-        } else if (state.isCompleted) {
+        } else if (state.status === "succeeded") {
             window.showInformationMessage(`Successfully created AKS cluster ${name}.`);
             webview.postMessage({
                 command: "progressUpdate",

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -159,14 +159,15 @@ async function createCluster(
                     errorMessage: null
                 }
             });
-        } else if (state.error) {
-            window.showErrorMessage(`Error creating AKS cluster ${name}: ${getErrorMessage(state.error)}`);
+        } else if (state.status === "failed") {
+            const errorMessage = state.error ? getErrorMessage(state.error) : "Unknown error";
+            window.showErrorMessage(`Error creating AKS cluster ${name}: ${errorMessage}`);
             webview.postMessage({
                 command: "progressUpdate",
                 parameters: {
                     event: ProgressEventType.Failed,
                     operationDescription,
-                    errorMessage: getErrorMessage(state.error)
+                    errorMessage
                 }
             });
         } else if (state.status === "succeeded") {


### PR DESCRIPTION
This PR fixes the ripple effect of updating `"@azure/arm-containerservice": "^19.3.0",` from `17.*` which changed the way status is passed. hence there was a build failure on create cluster.

FYi and cc: @peterbom, thanks heaps.

https://learn.microsoft.com/en-us/javascript/api/%40azure/arm-containerservice/managedcluster?view=azure-node-latest

<img width="980" alt="Screenshot 2023-10-09 at 10 06 33 PM" src="https://github.com/Azure/vscode-aks-tools/assets/6233295/be58290d-5a5c-47be-84d2-78c9f7ef717b">
