### PR TITLE
Avoid lengthy kubectl output changing the layout of containing elements

### DIFF
--- a/webview-ui/src/Kubectl/Kubectl.module.css
+++ b/webview-ui/src/Kubectl/Kubectl.module.css
@@ -4,7 +4,8 @@
     grid-template-areas:
         "header header"
         "nav    content";
-    grid-template-columns: 1fr 3fr;
+    /* https://css-tricks.com/preventing-a-grid-blowout/ */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
 }
 
 .mainHeading {
@@ -17,6 +18,11 @@
 
 .mainContent {
     grid-area: content;
+}
+
+.mainContent pre {
+    /* Prevent <pre> elements from pushing out the width of the containing page */
+    overflow-x: auto;
 }
 
 ul.commandCategoryList {

--- a/webview-ui/src/manualTest/kubectlTests.tsx
+++ b/webview-ui/src/manualTest/kubectlTests.tsx
@@ -32,7 +32,7 @@ export function getKubectlScenarios() {
             webview.postMessage({
                 command: "runCommandResponse",
                 parameters: {
-                    output: Array.from({length: 20}, (_, i) => `This is the output of "kubectl ${command}" line ${i + 1}`).join('\n'),
+                    output: Array.from({length: 20}, (_, i) => `This is the output of "kubectl ${command}" line ${i + 1} and it's quite a long line so that we can adequately test whether the output scrolls or wraps correctly.`).join('\n'),
                     errorMessage: ""
                 }
             });


### PR DESCRIPTION
Fixes a display issue where wide output of a `kubectl` command would increase the width of containing elements, which could push the 'Run' button out of the visible area of the screen.

This ensures that the `pre` element containing the output remains at the size dictated by its parent containers, and handles any scrolling itself.