### PR TITLE
Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/webview-ui/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Relates to #286 - once Dependabot updates are enabled in the upstream fork, this will give us automatic dependency upgrade PRs for both the main extension and the webview project.