### PR TITLE
Add dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/webview-ui/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
From #286: "This needs to be done for GH workflows, the main extension project, and the webview-ui project."

#298 overlooked the configuration for GH workflows. That is added here.