### PR TITLE
Move portal URL generation into a common function

### DIFF
--- a/src/commands/aksCreateCluster/aksCreateCluster.ts
+++ b/src/commands/aksCreateCluster/aksCreateCluster.ts
@@ -33,12 +33,10 @@ export default async function aksCreateCluster(_context: IActionContext, target:
 
     const resourceManagementClient = getResourceManagementClient(subscriptionTreeItem);
     const containerServiceClient = getContainerClient(subscriptionTreeItem);
-    const portalUrl = subscriptionTreeItem.subscription.environment.portalUrl;
     const dataProvider = new CreateClusterDataProvider(
         resourceManagementClient,
         containerServiceClient,
-        portalUrl,
-        subscriptionTreeItem.subscription
+        subscriptionTreeItem.subscription,
     );
 
     panel.show(dataProvider);

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -4,7 +4,7 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { getAksClusterTreeItem } from "../utils/clusters";
 import { getExtensionPath } from "../utils/host";
 import { failed } from "../utils/errorable";
-import meta from "../../../package.json";
+import { getPortalResourceUrl } from "../utils/env";
 
 export default async function aksNavToPortal(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
@@ -22,10 +22,6 @@ export default async function aksNavToPortal(_context: IActionContext, target: u
     }
 
     // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
-    const portalUrl = cluster.result.subscription.environment.portalUrl.replace(/\/$/, "");
-    vscode.env.openExternal(
-        vscode.Uri.parse(
-            `${portalUrl}/#resource${cluster.result.armId}/overview?referrer_source=vscode&referrer_context=${meta.name}`,
-        ),
-    );
+    const resourceUrl = getPortalResourceUrl(cluster.result.subscription.environment, cluster.result.armId);
+    vscode.env.openExternal(vscode.Uri.parse(resourceUrl));
 }

--- a/src/commands/detectors/detectors.ts
+++ b/src/commands/detectors/detectors.ts
@@ -78,6 +78,11 @@ async function getDataProvider(
         return detectors;
     }
 
-    const dataProvider = new DetectorDataProvider(cloudTarget.name, detectorInfo.result, detectors.result);
+    const dataProvider = new DetectorDataProvider(
+        cloudTarget.subscription.environment,
+        cloudTarget.name,
+        detectorInfo.result,
+        detectors.result,
+    );
     return { succeeded: true, result: dataProvider };
 }

--- a/src/commands/utils/detectors.ts
+++ b/src/commands/utils/detectors.ts
@@ -10,7 +10,8 @@ import {
 } from "../../webview-contract/webviewDefinitions/detector";
 import { getResourceManagementClient } from "./clusters";
 import { dirSync } from "tmp";
-import meta from "../../../package.json";
+import { Environment } from "@azure/ms-rest-azure-env";
+import { getPortalResourceUrl } from "./env";
 
 /**
  * Can be used to store the JSON responses for a collection of category detectors and all their child detectors.
@@ -96,8 +97,7 @@ export async function getDetectorInfo(
     }
 }
 
-export function getPortalUrl(clusterdata: ARMResponse<unknown>) {
-    return `https://portal.azure.com/#resource${
-        clusterdata.id.split("detectors")[0]
-    }aksDiagnostics?referrer_source=vscode&referrer_context=${meta.name}`;
+export function getPortalUrl(environment: Environment, clusterdata: ARMResponse<unknown>) {
+    const armId = `${clusterdata.id.split("detectors")[0]}aksDiagnostics`;
+    return getPortalResourceUrl(environment, armId);
 }

--- a/src/commands/utils/env.ts
+++ b/src/commands/utils/env.ts
@@ -1,4 +1,6 @@
+import { Environment } from "@azure/ms-rest-azure-env";
 import path from "path";
+import meta from "../../../package.json";
 
 export function ensureDirectoryInPath(directoryPath: string) {
     if (process.env.PATH === undefined) {
@@ -6,4 +8,9 @@ export function ensureDirectoryInPath(directoryPath: string) {
     } else if (process.env.PATH.indexOf(directoryPath) < 0) {
         process.env.PATH = directoryPath + path.delimiter + process.env.PATH;
     }
+}
+
+export function getPortalResourceUrl(environment: Environment, armId: string): string {
+    const portalUrl = environment.portalUrl.replace(/\/$/, "");
+    return `${portalUrl}/#resource${armId}?referrer_source=vscode&referrer_context=${meta.name}`;
 }

--- a/src/panels/DetectorPanel.ts
+++ b/src/panels/DetectorPanel.ts
@@ -1,14 +1,14 @@
 import { Uri } from "vscode";
 import { MessageHandler } from "../webview-contract/messaging";
 import {
-    ARMResponse,
     CategoryDetectorARMResponse,
     InitialState,
     SingleDetectorARMResponse,
     ToVsCodeMsgDef,
 } from "../webview-contract/webviewDefinitions/detector";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
-import meta from "../../package.json";
+import { getPortalUrl } from "../commands/utils/detectors";
+import { Environment } from "@azure/ms-rest-azure-env";
 
 export class DetectorPanel extends BasePanel<"detector"> {
     constructor(extensionUri: Uri) {
@@ -18,18 +18,19 @@ export class DetectorPanel extends BasePanel<"detector"> {
 
 export class DetectorDataProvider implements PanelDataProvider<"detector"> {
     public constructor(
+        readonly environment: Environment,
         readonly clusterName: string,
         readonly categoryDetector: CategoryDetectorARMResponse,
         readonly detectors: SingleDetectorARMResponse[],
     ) {
         this.detectorName = categoryDetector.properties.metadata.name;
         this.detectorDescription = categoryDetector.properties.metadata.description;
-        this.clusterArmId = getClusterArmId(categoryDetector);
+        this.detectorPortalUrl = getPortalUrl(environment, categoryDetector);
     }
 
     readonly detectorName: string;
     readonly detectorDescription: string;
-    readonly clusterArmId: string;
+    readonly detectorPortalUrl: string;
 
     getTitle(): string {
         return `${this.detectorName} diagnostics for ${this.clusterName}`;
@@ -39,8 +40,7 @@ export class DetectorDataProvider implements PanelDataProvider<"detector"> {
         return {
             name: this.clusterName,
             description: this.detectorDescription,
-            clusterArmId: this.clusterArmId,
-            portalReferrerContext: meta.name,
+            portalDetectorUrl: this.detectorPortalUrl,
             detectors: this.detectors,
         };
     }
@@ -48,8 +48,4 @@ export class DetectorDataProvider implements PanelDataProvider<"detector"> {
     getMessageHandler(): MessageHandler<ToVsCodeMsgDef> {
         return {};
     }
-}
-
-function getClusterArmId(response: ARMResponse<unknown>): string {
-    return response.id.split("detectors")[0];
 }

--- a/src/webview-contract/webviewDefinitions/createCluster.ts
+++ b/src/webview-contract/webviewDefinitions/createCluster.ts
@@ -1,8 +1,6 @@
 import { WebviewDefinition } from "../webviewTypes";
 
 export interface InitialState {
-    portalUrl: string;
-    portalReferrerContext: string;
     subscriptionId: string;
     subscriptionName: string;
 }
@@ -18,6 +16,10 @@ export enum ProgressEventType {
     Failed,
     Success,
 }
+
+export type CreatedCluster = {
+    portalUrl: string;
+};
 
 export interface CreateClusterParams {
     isNewResourceGroup: boolean;
@@ -47,6 +49,8 @@ export type ToWebViewMsgDef = {
         operationDescription: string;
         event: ProgressEventType;
         errorMessage: string | null;
+        deploymentPortalUrl: string | null;
+        createdCluster: CreatedCluster | null;
     };
 };
 

--- a/src/webview-contract/webviewDefinitions/detector.ts
+++ b/src/webview-contract/webviewDefinitions/detector.ts
@@ -3,8 +3,7 @@ import { WebviewDefinition } from "../webviewTypes";
 export interface InitialState {
     name: string;
     description: string;
-    clusterArmId: string;
-    portalReferrerContext: string;
+    portalDetectorUrl: string;
     detectors: SingleDetectorARMResponse[];
 }
 

--- a/webview-ui/src/CreateCluster/CreateCluster.tsx
+++ b/webview-ui/src/CreateCluster/CreateCluster.tsx
@@ -3,7 +3,7 @@ import { CreateClusterInput } from "./CreateClusterInput";
 import { Success } from "./Success";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/createCluster";
 import { Stage, stateUpdater, vscode } from "./helpers/state";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeLink, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useStateManagement } from "../utilities/state";
 
 export function CreateCluster(initialState: InitialState) {
@@ -43,6 +43,13 @@ export function CreateCluster(initialState: InitialState) {
                         <h3>
                             Creating Cluster {state.createParams!.name} in {state.createParams!.location}
                         </h3>
+                        {state.deploymentPortalUrl && (
+                            <p>
+                                Click <VSCodeLink href={state.deploymentPortalUrl}>here</VSCodeLink> to view the
+                                deployment in the Azure Portal.
+                            </p>
+                        )}
+
                         <VSCodeProgressRing />
                     </>
                 );
@@ -55,13 +62,7 @@ export function CreateCluster(initialState: InitialState) {
                 );
             case Stage.Succeeded:
                 return (
-                    <Success
-                        portalUrl={state.portalUrl}
-                        portalReferrerContext={state.portalReferrerContext}
-                        subscriptionId={state.subscriptionId}
-                        resourceGroup={state.createParams!.resourceGroupName}
-                        name={state.createParams!.name}
-                    />
+                    <Success portalClusterUrl={state.createdCluster?.portalUrl || ""} name={state.createParams!.name} />
                 );
             default:
                 throw new Error(`Unexpected stage ${state.stage}`);

--- a/webview-ui/src/CreateCluster/Success.tsx
+++ b/webview-ui/src/CreateCluster/Success.tsx
@@ -1,25 +1,17 @@
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 
 interface SuccessProps {
-    portalUrl: string;
-    portalReferrerContext: string;
-    subscriptionId: string;
-    resourceGroup: string;
+    portalClusterUrl: string;
     name: string;
 }
 
 export function Success(props: SuccessProps) {
-    const armId = `/subscriptions/${props.subscriptionId}/resourceGroups/${props.resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${props.name}`;
-    const portalUrl = `${props.portalUrl.replace(
-        /\/$/,
-        "",
-    )}/#resource${armId}/overview?referrer_source=vscode&referrer_context=${props.portalReferrerContext}`;
-
     return (
         <>
             <h3>Cluster {props.name} was created successfully</h3>
             <p>
-                Click <VSCodeLink href={portalUrl}>here</VSCodeLink> to view your cluster in the Azure Portal.
+                Click <VSCodeLink href={props.portalClusterUrl}>here</VSCodeLink> to view your cluster in the Azure
+                Portal.
             </p>
         </>
     );

--- a/webview-ui/src/CreateCluster/helpers/state.ts
+++ b/webview-ui/src/CreateCluster/helpers/state.ts
@@ -1,5 +1,6 @@
 import {
     CreateClusterParams,
+    CreatedCluster,
     InitialState,
     ProgressEventType,
     ResourceGroup,
@@ -22,6 +23,8 @@ export type CreateClusterState = InitialState & {
     locations: string[] | null;
     resourceGroups: ResourceGroup[] | null;
     createParams: CreateClusterParams | null;
+    deploymentPortalUrl: string | null;
+    createdCluster: CreatedCluster | null;
 };
 
 export type EventDef = {
@@ -40,6 +43,8 @@ export const stateUpdater: WebviewStateUpdater<"createCluster", EventDef, Create
         locations: null,
         resourceGroups: null,
         createParams: null,
+        deploymentPortalUrl: null,
+        createdCluster: null,
     }),
     vscodeMessageHandler: {
         getLocationsResponse: (state, args) => ({ ...state, locations: args.locations }),
@@ -47,6 +52,8 @@ export const stateUpdater: WebviewStateUpdater<"createCluster", EventDef, Create
         progressUpdate: (state, args) => ({
             ...state,
             ...getStageAndMessage(args.operationDescription, args.event, args.errorMessage),
+            deploymentPortalUrl: args.deploymentPortalUrl,
+            createdCluster: args.createdCluster,
         }),
     },
     eventHandler: {

--- a/webview-ui/src/Detector/Detector.tsx
+++ b/webview-ui/src/Detector/Detector.tsx
@@ -12,7 +12,7 @@ export function Detector(initialState: InitialState) {
             <h2>{state.name}</h2>
             {state.description && state.description !== "test" && <p>{state.description}</p>}
             To perform more checks on your cluster, visit{" "}
-            <VSCodeLink href={state.portalUrl}>AKS Diagnostics</VSCodeLink>.
+            <VSCodeLink href={state.portalDetectorUrl}>AKS Diagnostics</VSCodeLink>.
             <VSCodeDivider style={{ marginTop: "16px" }} />
             {state.detectors.map((detector) => (
                 <SingleDetector key={detector.name} {...detector}></SingleDetector>

--- a/webview-ui/src/Detector/state.ts
+++ b/webview-ui/src/Detector/state.ts
@@ -4,15 +4,10 @@ import { getWebviewMessageContext } from "../utilities/vscode";
 
 export type EventDef = Record<string, never>;
 
-export type DetectorState = InitialState & {
-    portalUrl: string;
-};
+export type DetectorState = InitialState;
 
 export const stateUpdater: WebviewStateUpdater<"detector", EventDef, DetectorState> = {
-    createState: (initialState) => ({
-        ...initialState,
-        portalUrl: `https://portal.azure.com/#resource${initialState.clusterArmId}aksDiagnostics?referrer_source=vscode&referrer_context=${initialState.portalReferrerContext}`,
-    }),
+    createState: (initialState) => ({ ...initialState }),
     vscodeMessageHandler: {},
     eventHandler: {},
 };

--- a/webview-ui/src/manualTest/createClusterTests.tsx
+++ b/webview-ui/src/manualTest/createClusterTests.tsx
@@ -25,8 +25,6 @@ const resourceGroups = locations.map((l) => ({ name: `rg_${l}`, location: l }));
 
 export function getCreateClusterScenarios() {
     const initialState: InitialState = {
-        portalUrl: "https://portal.azure.com/",
-        portalReferrerContext: "vscode-aks-tools-test",
         subscriptionId: "7f9c8a5b-3e9d-4f1c-8c0f-6a3b2a0d2e7c",
         subscriptionName: "Test Sub",
     };
@@ -68,6 +66,8 @@ export function getCreateClusterScenarios() {
                 operationDescription: `Creating Resource Group ${groupName} in ${location}`,
                 event: ProgressEventType.InProgress,
                 errorMessage: null,
+                deploymentPortalUrl: null,
+                createdCluster: null,
             });
 
             await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -75,13 +75,18 @@ export function getCreateClusterScenarios() {
                 operationDescription: `Successfully created ${groupName} in ${location}`,
                 event: ProgressEventType.InProgress,
                 errorMessage: null,
+                deploymentPortalUrl: null,
+                createdCluster: null,
             });
         }
 
+        const deploymentPortalUrl = `https://portal.azure.com/#resource/subscriptions/${initialState.subscriptionId}/resourceGroups/${groupName}/providers/Microsoft.Resources/deployments/testdeployment?referrer_source=vscode&referrer_context=vscode-aks-tools-test`;
         webview.postProgressUpdate({
             operationDescription: `Creating Cluster ${name}`,
             event: ProgressEventType.InProgress,
             errorMessage: null,
+            deploymentPortalUrl,
+            createdCluster: null,
         });
 
         const waitMs = location === failLocationMarker ? 500 : location === cancelLocationMarker ? 3000 : 10000;
@@ -100,6 +105,13 @@ export function getCreateClusterScenarios() {
             operationDescription: "Creating Cluster",
             event,
             errorMessage,
+            deploymentPortalUrl,
+            createdCluster:
+                event === ProgressEventType.Success
+                    ? {
+                          portalUrl: `https://portal.azure.com/#resource/subscriptions/${initialState.subscriptionId}/resourceGroups/${groupName}/providers/Microsoft.ContainerService/managedClusters/${name}?referrer_source=vscode&referrer_context=vscode-aks-tools-test`,
+                      }
+                    : null,
         });
     }
 

--- a/webview-ui/src/manualTest/detectorTests.tsx
+++ b/webview-ui/src/manualTest/detectorTests.tsx
@@ -158,8 +158,7 @@ export function getDetectorScenarios() {
         const initialState: InitialState = {
             name: categoryDetector.properties.metadata.name,
             description: categoryDetector.properties.metadata.description,
-            clusterArmId: getClusterArmId(categoryDetector),
-            portalReferrerContext: "vscode-aks-tools-test",
+            portalDetectorUrl: getPortalDetectorUrl(categoryDetector),
             detectors: detectorIds.map((id) => singleDetectorLookup[id]),
         };
 
@@ -173,6 +172,7 @@ export function getDetectorScenarios() {
     });
 }
 
-function getClusterArmId(response: ARMResponse<unknown>): string {
-    return response.id.split("detectors")[0];
+function getPortalDetectorUrl(response: ARMResponse<unknown>): string {
+    const clusterArmId = response.id.split("detectors")[0];
+    return `https://testportal.azure.com/#resource${clusterArmId}aksDiagnostics?referrer_source=vscode&referrer_context=testing`;
 }


### PR DESCRIPTION
We have a lot of duplicate code for generating URLs representing Azure resources in the Portal. There is some complexity to this, around ensuring we use the appropriate domain name for the user's cloud, and setting the correct query strings for identifying the referrer.

This moves that logic into a single function, which I thought would be really useful for #335.

**EDIT**: This has now been rebased on top of `main` after merging #335. It also includes a small change to display a link to the Portal for the deployment while the cluster creation is in progress.

~~Unfortunately, this had a far larger blast radius than I anticipated. Even more unfortunately, it conflicts heavily with #335 which is otherwise almost ready to merge.~~

~~So, I'm opening this as a draft to make clear the _kind_ of changes we'd need to make, and @hsubramanianaks can make use of any of these changes that look useful for displaying the Portal link in Create Cluster. I can tidy this up and add the remaining bits (mostly around Detectors) after #335 is merged.~~

~~@hsubramanianaks, @Tatsinnit: what do you think?~~