### PR TITLE
Remove incorrect use of isObject

### DIFF
--- a/src/commands/utils/azureAccount.ts
+++ b/src/commands/utils/azureAccount.ts
@@ -11,7 +11,6 @@ import {
     TokenCredentialAuthenticationProviderOptions,
 } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials";
 import { AuthorizationManagementClient } from "@azure/arm-authorization";
-import { isObject } from "./runtimeTypes";
 import { RoleAssignment } from "@azure/arm-authorization";
 
 export interface AzureAccountExtensionApi {
@@ -226,5 +225,12 @@ async function getSubscriptionAccess(
 }
 
 function isUnauthorizedError(e: unknown): boolean {
-    return isObject(e) && "code" in e && "statusCode" in e && e.code === "AuthorizationFailed" && e.statusCode === 403;
+    return (
+        typeof e === "object" &&
+        e !== null &&
+        "code" in e &&
+        "statusCode" in e &&
+        e.code === "AuthorizationFailed" &&
+        e.statusCode === 403
+    );
 }


### PR DESCRIPTION
Fixes a bug introduced by my earlier refactoring.

The `isObject` function checks the argument's constructor name is equal to 'object'. In the case of errors, that's generally incorrect, because errors have been created with other constructors, like `new RestError(...)`.

This changes the error check to in `azureAccount.ts` to avoid using `isObject`.

Also searched the codebase for other incorrect usages, but there weren't any.