### PR TITLE
Add outfiles to webview UI launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,9 @@
             "request": "launch",
             "url": "http://localhost:3000",
             "webRoot": "${workspaceFolder}/webview-ui",
+            "outFiles": [
+                "${workspaceFolder}/webview-ui/dist/**/*.js"
+            ],
             "preLaunchTask": "dev:webview"
         }
     ]


### PR DESCRIPTION
I was getting a warning in my VS Code environment that breakpoints were slow loading because I hadn't set "outFiles" in the launch configuration for the webview-ui manual testing debug profile.

Adding this supposedly allows VS Code to locate the sourcemaps, which are in the `webview-ui/dist` folder, making it faster to start debugging sessions. I haven't done any benchmarking to verify this is the case, but I have noticed the debugger frequently taking a long time to start, and this _seems_ to help for me, and breakpoints still seem to work, so I think it at least can't do any harm.