### PR TITLE
Revert "Bump @microsoft/vscode-azext-utils from 2.1.3 to 2.1.4 (#367)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@azure/storage-blob": "^12.7.0",
                 "@microsoft/microsoft-graph-client": "^3.0.7",
                 "@microsoft/vscode-azext-azureutils": "^2.0.2",
-                "@microsoft/vscode-azext-utils": "^2.1.4",
+                "@microsoft/vscode-azext-utils": "^2.1.3",
                 "cross-fetch": "^4.0.0",
                 "decompress": "^4.2.1",
                 "download": "^8.0.0",
@@ -820,147 +820,41 @@
             }
         },
         "node_modules/@microsoft/1ds-core-js": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.4.tgz",
-            "integrity": "sha512-QOCE0fTDOMNptB791chnVlfnRvb7faDQTaUIO3DfPBkvjF3PUAJJCsqJKWitw7nwVn8L82TFx+K22UifIr0zkg==",
+            "version": "3.2.4",
+            "license": "MIT",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "3.0.5",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/applicationinsights-core-js": "2.8.5",
+                "@microsoft/applicationinsights-shims": "^2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             }
         },
         "node_modules/@microsoft/1ds-post-js": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.4.tgz",
-            "integrity": "sha512-jlPNL16iRXzmXfriGXv0INzrAl3AeDx+eCORjq8ZjRhIvohB6Q88m5E28nL6Drf5hJWE2ehoW4q8Vh612VoEHw==",
+            "version": "3.2.4",
+            "license": "MIT",
             "dependencies": {
-                "@microsoft/1ds-core-js": "4.0.4",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-channel-js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.6.tgz",
-            "integrity": "sha512-nWcElBm7OKUv7w0xvegxrQFbMH2NSLBU8WBSaTaiqo48aXqWnKWrqEaGvCGKpOCH5G33of3XC7DUJ6f4gdOEcA==",
-            "dependencies": {
-                "@microsoft/applicationinsights-common": "3.0.6",
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-            "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-            "dependencies": {
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-common": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.6.tgz",
-            "integrity": "sha512-GlmuaE+U1G7IbfGuElOYdKjmFMErI5b1iJpDfWXY6qpoL2a/sBIc1dviw7NP2/4CwFBkoFGPMDT/3aO3e7Yu3w==",
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-            "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-            "dependencies": {
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
+                "@microsoft/1ds-core-js": "3.2.4",
+                "@microsoft/applicationinsights-shims": "^2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             }
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.5.tgz",
-            "integrity": "sha512-/x+tkxsVALNWSvwGMyaLwFPdD3p156Pef9WHftXrzrKkJ+685nhrwm9MqHIyEHHpSW09ElOdpJ3rfFVqpKRQyQ==",
+            "version": "2.8.5",
+            "license": "MIT",
             "dependencies": {
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             },
             "peerDependencies": {
                 "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-shims": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
-            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
-            "dependencies": {
-                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-web-basic": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.6.tgz",
-            "integrity": "sha512-HwhZha6c78BVrkgRX5OaZBCO4hX4FlikvVHMKAQHLv1Le9nN7sBnt5VNiV5ikjA3ir04vRXmrDCn0GomMiKZ0g==",
-            "dependencies": {
-                "@microsoft/applicationinsights-channel-js": "3.0.6",
-                "@microsoft/applicationinsights-common": "3.0.6",
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-            "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-            "dependencies": {
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
+            "version": "2.0.1",
+            "license": "MIT"
         },
         "node_modules/@microsoft/dynamicproto-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
-            "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
-            "dependencies": {
-                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-            }
+            "version": "1.1.6",
+            "license": "MIT"
         },
         "node_modules/@microsoft/microsoft-graph-client": {
             "version": "3.0.7",
@@ -1022,12 +916,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.4.tgz",
-            "integrity": "sha512-l9kbmyOtYHljNlelFM8BxPWNAvQeMeZoHHN+CoFBf6O6pzg/nxNt+abSikUnDInwA+BfPPqDpMwXpxw/FBMf0g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
+            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.9.0",
+                "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -1066,19 +960,6 @@
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
             }
-        },
-        "node_modules/@nevware21/ts-async": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.3.0.tgz",
-            "integrity": "sha512-ZUcgUH12LN/F6nzN0cYd0F/rJaMLmXr0EHVTyYfaYmK55bdwE4338uue4UiVoRqHVqNW4KDUrJc49iGogHKeWA==",
-            "dependencies": {
-                "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
-            }
-        },
-        "node_modules/@nevware21/ts-utils": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.1.tgz",
-            "integrity": "sha512-pMny25NnF2/MJwdqC3Iyjm2pGIXNxni4AROpcqDeWa+td9JMUY4bUS9uU9XW+BoBRqTLUL+WURF9SOd/6OQzRg=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1594,16 +1475,14 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.0.tgz",
-            "integrity": "sha512-37RxGHXrs3GoXPgCUKQhghEu0gxs8j27RLjQwwtSf4WhPdJKz8UrqMYzpsXlliQ05zURYmtdGZst9C6+hfWXaQ==",
+            "version": "0.6.2",
+            "license": "MIT",
             "dependencies": {
-                "@microsoft/1ds-core-js": "^4.0.3",
-                "@microsoft/1ds-post-js": "^4.0.3",
-                "@microsoft/applicationinsights-web-basic": "^3.0.4"
+                "@microsoft/1ds-core-js": "^3.2.3",
+                "@microsoft/1ds-post-js": "^3.2.3"
             },
             "engines": {
-                "vscode": "^1.75.0"
+                "vscode": "^1.60.0"
             }
         },
         "node_modules/@vscode/test-electron": {
@@ -7769,132 +7648,33 @@
             }
         },
         "@microsoft/1ds-core-js": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.4.tgz",
-            "integrity": "sha512-QOCE0fTDOMNptB791chnVlfnRvb7faDQTaUIO3DfPBkvjF3PUAJJCsqJKWitw7nwVn8L82TFx+K22UifIr0zkg==",
+            "version": "3.2.4",
             "requires": {
-                "@microsoft/applicationinsights-core-js": "3.0.5",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/applicationinsights-core-js": "2.8.5",
+                "@microsoft/applicationinsights-shims": "^2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             }
         },
         "@microsoft/1ds-post-js": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.4.tgz",
-            "integrity": "sha512-jlPNL16iRXzmXfriGXv0INzrAl3AeDx+eCORjq8ZjRhIvohB6Q88m5E28nL6Drf5hJWE2ehoW4q8Vh612VoEHw==",
+            "version": "3.2.4",
             "requires": {
-                "@microsoft/1ds-core-js": "4.0.4",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            }
-        },
-        "@microsoft/applicationinsights-channel-js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.6.tgz",
-            "integrity": "sha512-nWcElBm7OKUv7w0xvegxrQFbMH2NSLBU8WBSaTaiqo48aXqWnKWrqEaGvCGKpOCH5G33of3XC7DUJ6f4gdOEcA==",
-            "requires": {
-                "@microsoft/applicationinsights-common": "3.0.6",
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": {
-                    "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-                    "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-                    "requires": {
-                        "@microsoft/applicationinsights-shims": "3.0.1",
-                        "@microsoft/dynamicproto-js": "^2.0.2",
-                        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-                    }
-                }
-            }
-        },
-        "@microsoft/applicationinsights-common": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.6.tgz",
-            "integrity": "sha512-GlmuaE+U1G7IbfGuElOYdKjmFMErI5b1iJpDfWXY6qpoL2a/sBIc1dviw7NP2/4CwFBkoFGPMDT/3aO3e7Yu3w==",
-            "requires": {
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": {
-                    "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-                    "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-                    "requires": {
-                        "@microsoft/applicationinsights-shims": "3.0.1",
-                        "@microsoft/dynamicproto-js": "^2.0.2",
-                        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-                    }
-                }
+                "@microsoft/1ds-core-js": "3.2.4",
+                "@microsoft/applicationinsights-shims": "^2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             }
         },
         "@microsoft/applicationinsights-core-js": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.5.tgz",
-            "integrity": "sha512-/x+tkxsVALNWSvwGMyaLwFPdD3p156Pef9WHftXrzrKkJ+685nhrwm9MqHIyEHHpSW09ElOdpJ3rfFVqpKRQyQ==",
+            "version": "2.8.5",
             "requires": {
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.6"
             }
         },
         "@microsoft/applicationinsights-shims": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
-            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
-            "requires": {
-                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-            }
-        },
-        "@microsoft/applicationinsights-web-basic": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.6.tgz",
-            "integrity": "sha512-HwhZha6c78BVrkgRX5OaZBCO4hX4FlikvVHMKAQHLv1Le9nN7sBnt5VNiV5ikjA3ir04vRXmrDCn0GomMiKZ0g==",
-            "requires": {
-                "@microsoft/applicationinsights-channel-js": "3.0.6",
-                "@microsoft/applicationinsights-common": "3.0.6",
-                "@microsoft/applicationinsights-core-js": "3.0.6",
-                "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-            },
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": {
-                    "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.6.tgz",
-                    "integrity": "sha512-9OFBYckg/msyllE0NOwXgCvwHochKKUDbydl3LF3UcltGIE14pLYoXiWJd9+m+oRaf0k3CUYl2mVcyytWgPQZw==",
-                    "requires": {
-                        "@microsoft/applicationinsights-shims": "3.0.1",
-                        "@microsoft/dynamicproto-js": "^2.0.2",
-                        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
-                    }
-                }
-            }
+            "version": "2.0.1"
         },
         "@microsoft/dynamicproto-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
-            "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
-            "requires": {
-                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-            }
+            "version": "1.1.6"
         },
         "@microsoft/microsoft-graph-client": {
             "version": "3.0.7",
@@ -7931,12 +7711,12 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.4.tgz",
-            "integrity": "sha512-l9kbmyOtYHljNlelFM8BxPWNAvQeMeZoHHN+CoFBf6O6pzg/nxNt+abSikUnDInwA+BfPPqDpMwXpxw/FBMf0g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
+            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.9.0",
+                "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -7961,19 +7741,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.1.0.tgz",
             "integrity": "sha512-dqjLyHl0OJgnjEtMtZEDvA9YovszWnE2k3ktEcHiTHWZ62luYrhOQhMzJjGArSFH3ANRCWgS6A1q4OTjZoBrKQ==",
             "requires": {}
-        },
-        "@nevware21/ts-async": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.3.0.tgz",
-            "integrity": "sha512-ZUcgUH12LN/F6nzN0cYd0F/rJaMLmXr0EHVTyYfaYmK55bdwE4338uue4UiVoRqHVqNW4KDUrJc49iGogHKeWA==",
-            "requires": {
-                "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
-            }
-        },
-        "@nevware21/ts-utils": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.1.tgz",
-            "integrity": "sha512-pMny25NnF2/MJwdqC3Iyjm2pGIXNxni4AROpcqDeWa+td9JMUY4bUS9uU9XW+BoBRqTLUL+WURF9SOd/6OQzRg=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -8367,13 +8134,10 @@
             "dev": true
         },
         "@vscode/extension-telemetry": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.0.tgz",
-            "integrity": "sha512-37RxGHXrs3GoXPgCUKQhghEu0gxs8j27RLjQwwtSf4WhPdJKz8UrqMYzpsXlliQ05zURYmtdGZst9C6+hfWXaQ==",
+            "version": "0.6.2",
             "requires": {
-                "@microsoft/1ds-core-js": "^4.0.3",
-                "@microsoft/1ds-post-js": "^4.0.3",
-                "@microsoft/applicationinsights-web-basic": "^3.0.4"
+                "@microsoft/1ds-core-js": "^3.2.3",
+                "@microsoft/1ds-post-js": "^3.2.3"
             }
         },
         "@vscode/test-electron": {

--- a/package.json
+++ b/package.json
@@ -463,7 +463,7 @@
         "@azure/storage-blob": "^12.7.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/vscode-azext-azureutils": "^2.0.2",
-        "@microsoft/vscode-azext-utils": "^2.1.4",
+        "@microsoft/vscode-azext-utils": "^2.1.3",
         "cross-fetch": "^4.0.0",
         "decompress": "^4.2.1",
         "download": "^8.0.0",


### PR DESCRIPTION
This reverts commit 00ea0eb9815a0c7689d3f2f0416a9da841ffceb3.

Fixes this @peterbom ☕️🎊

* Commit updated the vscode telemetry as the transitive dependency which does not support AIF keys.

![image](https://github.com/Azure/vscode-aks-tools/assets/6233295/9d97aa4f-715b-4719-a6f1-00d4d4a30a1d)
