### PR TITLE
Add filters for TCPDump

### DIFF
--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -8,8 +8,11 @@ import { MessageHandler, MessageSink } from "../webview-contract/messaging";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { KubectlVersion, getExecOutput, invokeKubectlCommand } from "../commands/utils/kubectl";
 import {
+    CaptureFilters,
     CompletedCapture,
+    FilterPod,
     InitialState,
+    NodeName,
     ToVsCodeMsgDef,
     ToWebViewMsgDef,
 } from "../webview-contract/webviewDefinitions/tcpDump";
@@ -22,12 +25,18 @@ const captureFilePrefix = "vscodenodecap_";
 const captureFileBasePath = `${captureDir}/${captureFilePrefix}`;
 const captureFilePathRegex = `${captureFileBasePath.replace(/\//g, "\\$&")}(.*)\\.cap`; // Matches the part of the filename after the prefix
 
-function getPodName(node: string) {
+function getPodName(node: NodeName) {
     return `debug-${node}`;
 }
 
-function getTcpDumpCommand(capture: string): string {
-    return `${tcpDumpCommandBase} -w ${captureFileBasePath}${capture}.cap`;
+function getTcpDumpCommand(capture: string, filters: CaptureFilters): string {
+    const parts = [
+        tcpDumpCommandBase,
+        filters.interface ? `-i ${filters.interface}` : "",
+        `-w ${captureFileBasePath}${capture}.cap`,
+        filters.pcapFilterString || "",
+    ].filter((part) => !!part);
+    return parts.join(" ");
 }
 
 function getCaptureFromCommand(command: string, commandWithArgs: string): string | null {
@@ -52,6 +61,9 @@ export class TcpDumpPanel extends BasePanel<"tcpDump"> {
             startCaptureResponse: null,
             stopCaptureResponse: null,
             downloadCaptureFileResponse: null,
+            getInterfacesResponse: null,
+            getAllNodesResponse: null,
+            getFilterPodsForNodeResponse: null,
         });
     }
 }
@@ -81,14 +93,17 @@ export class TcpDumpDataProvider implements PanelDataProvider<"tcpDump"> {
             checkNodeState: (args) => this.handleCheckNodeState(args.node, webview),
             startDebugPod: (args) => this.handleStartDebugPod(args.node, webview),
             deleteDebugPod: (args) => this.handleDeleteDebugPod(args.node, webview),
-            startCapture: (args) => this.handleStartCapture(args.node, args.capture, webview),
+            startCapture: (args) => this.handleStartCapture(args.node, args.capture, args.filters, webview),
             stopCapture: (args) => this.handleStopCapture(args.node, args.capture, webview),
             downloadCaptureFile: (args) => this.handleDownloadCaptureFile(args.node, args.capture, webview),
             openFolder: (args) => this.handleOpenFolder(args),
+            getInterfaces: (args) => this.handleGetInterfaces(args.node, webview),
+            getAllNodes: () => this.handleGetAllNodes(webview),
+            getFilterPodsForNode: (args) => this.handleGetFilterPodsForNode(args.node, webview),
         };
     }
 
-    private async handleCheckNodeState(node: string, webview: MessageSink<ToWebViewMsgDef>) {
+    private async handleCheckNodeState(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
         const podNames = await this.getPodNames();
         if (failed(podNames)) {
             webview.postCheckNodeStateResponse({
@@ -168,7 +183,7 @@ export class TcpDumpDataProvider implements PanelDataProvider<"tcpDump"> {
         });
     }
 
-    private async handleStartDebugPod(node: string, webview: MessageSink<ToWebViewMsgDef>) {
+    private async handleStartDebugPod(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
         const createPodYaml = `
 apiVersion: v1
 kind: Pod
@@ -243,7 +258,7 @@ spec:
         });
     }
 
-    private async handleDeleteDebugPod(node: string, webview: MessageSink<ToWebViewMsgDef>) {
+    private async handleDeleteDebugPod(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
         const command = `delete pod -n ${debugPodNamespace} ${getPodName(node)}`;
         const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         if (failed(output)) {
@@ -272,8 +287,13 @@ spec:
         });
     }
 
-    private async handleStartCapture(node: string, capture: string, webview: MessageSink<ToWebViewMsgDef>) {
-        const podCommand = `/bin/sh -c "${getTcpDumpCommand(capture)} 1>/dev/null 2>&1 &"`;
+    private async handleStartCapture(
+        node: NodeName,
+        capture: string,
+        filters: CaptureFilters,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const podCommand = `/bin/sh -c "${getTcpDumpCommand(capture, filters)} 1>/dev/null 2>&1 &"`;
         const output = await getExecOutput(
             this.kubectl,
             this.kubeConfigFilePath,
@@ -288,7 +308,7 @@ spec:
         });
     }
 
-    private async handleStopCapture(node: string, capture: string, webview: MessageSink<ToWebViewMsgDef>) {
+    private async handleStopCapture(node: NodeName, capture: string, webview: MessageSink<ToWebViewMsgDef>) {
         const runningCaptures = await this.getRunningCaptures(node);
         if (failed(runningCaptures)) {
             webview.postStopCaptureResponse({
@@ -361,7 +381,11 @@ spec:
         });
     }
 
-    private async handleDownloadCaptureFile(node: string, captureName: string, webview: MessageSink<ToWebViewMsgDef>) {
+    private async handleDownloadCaptureFile(
+        node: NodeName,
+        captureName: string,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
         const localCaptureUri = await window.showSaveDialog({
             defaultUri: Uri.file(`${captureName}.cap`),
             filters: { "Capture Files": ["cap"] },
@@ -410,25 +434,80 @@ spec:
         commands.executeCommand("revealFileInOS", Uri.file(path));
     }
 
+    private async handleGetInterfaces(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
+        const podCommand = `/bin/sh -c "tcpdump --list-interfaces"`;
+        const output = await getExecOutput(
+            this.kubectl,
+            this.kubeConfigFilePath,
+            debugPodNamespace,
+            getPodName(node),
+            podCommand,
+        );
+        const interfaces = errmap(output, (sr) =>
+            sr.stdout
+                .trim()
+                .split("\n")
+                .map(extractInterfaceName)
+                .filter((i) => !!i),
+        );
+        webview.postGetInterfacesResponse({
+            node,
+            succeeded: interfaces.succeeded,
+            errorMessage: failed(interfaces) ? interfaces.error : null,
+            value: failed(interfaces) ? [] : interfaces.result,
+        });
+    }
+
+    private async handleGetAllNodes(webview: MessageSink<ToWebViewMsgDef>) {
+        const command = `get node --no-headers -o custom-columns=":metadata.name"`;
+        const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
+        const nodenames = errmap(output, (sr) => sr.stdout.trim().split("\n"));
+        webview.postGetAllNodesResponse({
+            succeeded: nodenames.succeeded,
+            errorMessage: failed(nodenames) ? nodenames.error : null,
+            value: failed(nodenames) ? [] : nodenames.result,
+        });
+    }
+
+    private async handleGetFilterPodsForNode(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
+        const command = `get pods --all-namespaces --field-selector spec.nodeName=${node} -o jsonpath="{range .items[*]}{.metadata.name}{\\"\\t\\"}{.status.podIP}{\\"\\t\\"}{{.spec.hostNetwork}}{\\"\\n\\"}{end}"`;
+        const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
+        const pods = errmap(
+            output,
+            (sr) =>
+                sr.stdout
+                    .trim()
+                    .split("\n")
+                    .map(asFilterPod)
+                    .filter((p) => p !== null) as FilterPod[],
+        );
+        webview.postGetFilterPodsForNodeResponse({
+            node,
+            succeeded: pods.succeeded,
+            errorMessage: failed(pods) ? pods.error : null,
+            value: failed(pods) ? [] : pods.result,
+        });
+    }
+
     private async getPodNames(): Promise<Errorable<string[]>> {
         const command = `get pod -n ${debugPodNamespace} --no-headers -o custom-columns=":metadata.name"`;
         const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         return errmap(output, (sr) => sr.stdout.trim().split("\n"));
     }
 
-    private async waitForPodReady(node: string): Promise<Errorable<void>> {
+    private async waitForPodReady(node: NodeName): Promise<Errorable<void>> {
         const command = `wait pod -n ${debugPodNamespace} --for=condition=ready --timeout=300s ${getPodName(node)}`;
         const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         return errmap(output, () => undefined);
     }
 
-    private async waitForPodDeleted(node: string): Promise<Errorable<void>> {
+    private async waitForPodDeleted(node: NodeName): Promise<Errorable<void>> {
         const command = `wait pod -n ${debugPodNamespace} --for=delete --timeout=300s ${getPodName(node)}`;
         const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         return errmap(output, () => undefined);
     }
 
-    private async installDebugTools(node: string): Promise<Errorable<void>> {
+    private async installDebugTools(node: NodeName): Promise<Errorable<void>> {
         const podCommand = `/bin/sh -c "apt-get update && apt-get install -y tcpdump procps"`;
         const output = await getExecOutput(
             this.kubectl,
@@ -440,7 +519,7 @@ spec:
         return errmap(output, () => undefined);
     }
 
-    private async getRunningCaptures(node: string): Promise<Errorable<TcpDumpProcess[]>> {
+    private async getRunningCaptures(node: NodeName): Promise<Errorable<TcpDumpProcess[]>> {
         // List all processes without header columns, including PID, command and args (which contains the command)
         const podCommand = "ps -e -o pid= -o comm= -o args=";
         const output = await getExecOutput(
@@ -466,7 +545,7 @@ spec:
     }
 
     private async getCompletedCaptures(
-        node: string,
+        node: NodeName,
         runningCaptures: string[],
     ): Promise<Errorable<CompletedCapture[]>> {
         // Use 'find' rather than 'ls' (http://mywiki.wooledge.org/ParsingLs)
@@ -538,4 +617,21 @@ function getLocalKubectlCpPath(fileUri: Uri): string {
             : process.cwd();
 
     return relative(workingDirectory, fileUri.fsPath);
+}
+
+function extractInterfaceName(listInterfacesOutputLine: string): string {
+    const match = listInterfacesOutputLine.trim().match(/^\d+\.(\S+)\s.*$/);
+    if (!match) return "";
+    return match && match[1];
+}
+
+function asFilterPod(podOutputLine: string): FilterPod | null {
+    const parts = podOutputLine.trim().split("\t");
+    if (parts.length < 2) return null;
+    const usesHostNetwork = parts.length > 2 && parts[2] === "true";
+    if (usesHostNetwork) return null;
+    return {
+        name: parts[0],
+        ipAddress: parts[1],
+    };
 }

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -470,7 +470,10 @@ spec:
     }
 
     private async handleGetFilterPodsForNode(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {
-        const command = `get pods --all-namespaces --field-selector spec.nodeName=${node} -o jsonpath="{range .items[*]}{.metadata.name}{\\"\\t\\"}{.status.podIP}{\\"\\t\\"}{{.spec.hostNetwork}}{\\"\\n\\"}{end}"`;
+        // From https://kubernetes.io/docs/reference/kubectl/jsonpath/
+        // > On Windows, you must double quote any JSONPath template that contains spaces (not single quote ...).
+        // > This in turn means that you must use a single quote or escaped double quote around any literals in the template
+        const command = `get pods --all-namespaces --field-selector spec.nodeName=${node} -o jsonpath="{range .items[*]}{.metadata.name}{'\\t'}{.status.podIP}{'\\t'}{.spec.hostNetwork}{'\\n'}{end}"`;
         const output = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         const pods = errmap(
             output,

--- a/src/webview-contract/webviewDefinitions/tcpDump.ts
+++ b/src/webview-contract/webviewDefinitions/tcpDump.ts
@@ -6,7 +6,9 @@ export interface InitialState {
 }
 
 export type NodeName = string;
+export type PodName = string;
 export type CaptureName = string;
+export type InterfaceName = string;
 
 export type CompletedCapture = {
     name: CaptureName;
@@ -19,6 +21,15 @@ export type NodeCommand = {
 
 export type NodeCaptureCommand = NodeCommand & {
     capture: CaptureName;
+};
+
+export type StartCaptureCommand = NodeCaptureCommand & {
+    filters: CaptureFilters;
+};
+
+export type CaptureFilters = {
+    interface: InterfaceName | null;
+    pcapFilterString: string | null;
 };
 
 export type CommandResult = {
@@ -48,14 +59,20 @@ export type NodeCaptureDownloadResult = NodeCaptureCommandResult & {
     localCapturePath: string;
 };
 
+export type ValueCommandResult<TCommandResult extends CommandResult, TValue> = TCommandResult & {
+    value: TValue;
+};
+
 export type ToVsCodeMsgDef = {
     checkNodeState: NodeCommand;
     startDebugPod: NodeCommand;
-    startCapture: NodeCaptureCommand;
+    startCapture: StartCaptureCommand;
     stopCapture: NodeCaptureCommand;
     downloadCaptureFile: NodeCaptureCommand;
     deleteDebugPod: NodeCommand;
     openFolder: string;
+    getAllNodes: void;
+    getInterfaces: NodeCommand;
 };
 
 export type ToWebViewMsgDef = {
@@ -65,6 +82,8 @@ export type ToWebViewMsgDef = {
     stopCaptureResponse: NodeCaptureStopResult;
     downloadCaptureFileResponse: NodeCaptureDownloadResult;
     deleteDebugPodResponse: NodeCommandResult;
+    getAllNodesResponse: ValueCommandResult<CommandResult, NodeName[]>;
+    getInterfacesResponse: ValueCommandResult<NodeCommandResult, InterfaceName[]>;
 };
 
 export type TCPDumpDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewDefinitions/tcpDump.ts
+++ b/src/webview-contract/webviewDefinitions/tcpDump.ts
@@ -27,6 +27,11 @@ export type StartCaptureCommand = NodeCaptureCommand & {
     filters: CaptureFilters;
 };
 
+export type FilterPod = {
+    name: PodName;
+    ipAddress: string;
+};
+
 export type CaptureFilters = {
     interface: InterfaceName | null;
     pcapFilterString: string | null;
@@ -72,6 +77,7 @@ export type ToVsCodeMsgDef = {
     deleteDebugPod: NodeCommand;
     openFolder: string;
     getAllNodes: void;
+    getFilterPodsForNode: NodeCommand;
     getInterfaces: NodeCommand;
 };
 
@@ -83,6 +89,7 @@ export type ToWebViewMsgDef = {
     downloadCaptureFileResponse: NodeCaptureDownloadResult;
     deleteDebugPodResponse: NodeCommandResult;
     getAllNodesResponse: ValueCommandResult<CommandResult, NodeName[]>;
+    getFilterPodsForNodeResponse: ValueCommandResult<NodeCommandResult, FilterPod[]>;
     getInterfacesResponse: ValueCommandResult<NodeCommandResult, InterfaceName[]>;
 };
 

--- a/webview-ui/src/TCPDump/CaptureFilters.tsx
+++ b/webview-ui/src/TCPDump/CaptureFilters.tsx
@@ -1,0 +1,56 @@
+import { InterfaceName, NodeName } from "../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { ResourceSelector } from "../components/ResourceSelector";
+import { map as lazyMap } from "../utilities/lazy";
+import { EventHandlers } from "../utilities/state";
+import styles from "./TcpDump.module.css";
+import { EventDef, NodeState, ReferenceData } from "./state";
+
+export interface CaptureFiltersProps {
+    node: NodeName;
+    nodeState: NodeState;
+    referenceData: ReferenceData;
+    eventHandlers: EventHandlers<EventDef>;
+}
+
+export function CaptureFilters(props: CaptureFiltersProps) {
+    const filters = props.nodeState.currentCaptureFilters;
+    return (
+        <div className={styles.content}>
+            <label htmlFor="interface-input" className={styles.label}>
+                Interface
+            </label>
+            <ResourceSelector<InterfaceName>
+                id="interface-input"
+                className={styles.controlDropdown}
+                resources={props.nodeState.captureInterfaces}
+                selectedItem={filters.interface}
+                valueGetter={(i) => i}
+                labelGetter={(i) => i}
+                onSelect={(i) =>
+                    props.eventHandlers.onSetCaptureFilters({
+                        node: props.node,
+                        filters: { ...filters, interface: i },
+                    })
+                }
+            />
+
+            <label htmlFor="source-node-input" className={styles.label}>
+                Source Node
+            </label>
+            <ResourceSelector<NodeName>
+                id="source-node-input"
+                className={styles.controlDropdown}
+                resources={lazyMap(props.referenceData.nodes, (nodes) => nodes.map((n) => n.node))}
+                selectedItem={filters.source.node}
+                valueGetter={(n) => n}
+                labelGetter={(n) => n}
+                onSelect={(n) =>
+                    props.eventHandlers.onSetCaptureFilters({
+                        node: props.node,
+                        filters: { ...filters, source: { ...filters.source, node: n } },
+                    })
+                }
+            />
+        </div>
+    );
+}

--- a/webview-ui/src/TCPDump/TcpDump.module.css
+++ b/webview-ui/src/TCPDump/TcpDump.module.css
@@ -23,6 +23,10 @@
     max-width: 8rem;
 }
 
+.content .fullWidth {
+    grid-column: 1 / 3;
+}
+
 table.capturelist {
     border-collapse: collapse;
     width: 100%;

--- a/webview-ui/src/TCPDump/TcpDump.module.css
+++ b/webview-ui/src/TCPDump/TcpDump.module.css
@@ -5,25 +5,42 @@
     align-items: center;
 }
 
-.content .label {
+.filterContent {
+    margin-left: 1rem;
+    display: grid;
+    grid-template-columns: 8rem 47rem;
+    grid-gap: 1rem;
+    align-items: center;
+}
+
+.content > .label,
+.filterContent > .label {
     grid-column: 1 / 2;
 }
 
-.content .control {
+.content > .control,
+.filterContent > .control {
     grid-column: 2 / 3;
 }
 
-.content .controlDropdown {
+.content > .controlDropdown {
     grid-column: 2 / 3;
     max-width: 30rem;
 }
 
-.content .controlButton {
+.filterContent > .controlDropdown {
+    grid-column: 2 / 3;
+    max-width: 27rem;
+}
+
+.content > .controlButton,
+.filterContent > .controlButton {
     grid-column: 2 / 3;
     max-width: 8rem;
 }
 
-.content .fullWidth {
+.content > .fullWidth,
+.filterContent > .fullWidth {
     grid-column: 1 / 3;
 }
 

--- a/webview-ui/src/TCPDump/TcpDump.module.css
+++ b/webview-ui/src/TCPDump/TcpDump.module.css
@@ -23,6 +23,12 @@
     grid-column: 2 / 3;
 }
 
+.content > .numberControl,
+.filterContent > .numberControl {
+    grid-column: 2 / 3;
+    max-width: 4rem;
+}
+
 .content > .controlDropdown {
     grid-column: 2 / 3;
     max-width: 30rem;

--- a/webview-ui/src/TCPDump/filterScenarios/SpecificPodFilters.tsx
+++ b/webview-ui/src/TCPDump/filterScenarios/SpecificPodFilters.tsx
@@ -1,0 +1,110 @@
+import { EventHandlers } from "../../utilities/state";
+import { EventDef, ReferenceData, SingleEndpointPacketDirection, SpecificPodFilter } from "../state";
+import { ResourceSelector } from "../../components/ResourceSelector";
+import { Lazy, isLoaded, newLoading } from "../../utilities/lazy";
+import styles from "../TcpDump.module.css";
+import { FilterPod, NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { EventHandlerFunc, loadAllNodes, loadFilterPods } from "../state/dataLoading";
+import { FormEvent, useEffect } from "react";
+import { getOrThrow } from "../../utilities/array";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+
+export interface SpecificPodFiltersProps {
+    captureNode: NodeName;
+    filter: SpecificPodFilter;
+    referenceData: ReferenceData;
+    eventHandlers: EventHandlers<EventDef>;
+}
+
+export function SpecificPodFilters(props: SpecificPodFiltersProps) {
+    const updates: EventHandlerFunc[] = [];
+    const { lazyPods } = prepareData(props.referenceData, props.captureNode, updates);
+    useEffect(() => {
+        updates.map((fn) => fn(props.eventHandlers));
+    });
+
+    function handlePodChange(pod: FilterPod | null) {
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "SpecificPod",
+            filters: { ...props.filter, pod },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    function handlePacketDirectionChange(e: Event | FormEvent<HTMLElement>) {
+        const elem = e.target as HTMLInputElement;
+        const packetDirection = elem.value as SingleEndpointPacketDirection;
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "SpecificPod",
+            filters: { ...props.filter, packetDirection },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    const packetDirectionLabels: Record<SingleEndpointPacketDirection, string> = {
+        SentAndReceived: "Sent and received",
+        Sent: "Sent only",
+        Received: "Received only",
+    };
+
+    return (
+        <>
+            <label htmlFor="filter-pod-input" className={styles.label}>
+                Pod
+            </label>
+            <ResourceSelector<FilterPod>
+                id="filter-pod-input"
+                className={styles.controlDropdown}
+                resources={lazyPods}
+                selectedItem={props.filter.pod}
+                valueGetter={(p) => p.name}
+                labelGetter={(p) => p.name}
+                onSelect={handlePodChange}
+            />
+
+            <label htmlFor="packet-direction-input" className={styles.label}>
+                Packet Direction
+            </label>
+            <VSCodeDropdown
+                className={styles.controlDropdown}
+                id="packet-direction-input"
+                value={props.filter.packetDirection}
+                onChange={handlePacketDirectionChange}
+            >
+                {Object.keys(packetDirectionLabels).map((d) => (
+                    <VSCodeOption key={d} value={d}>
+                        {packetDirectionLabels[d as SingleEndpointPacketDirection]}
+                    </VSCodeOption>
+                ))}
+            </VSCodeDropdown>
+        </>
+    );
+}
+
+type LocalData = {
+    lazyPods: Lazy<FilterPod[]>;
+};
+
+function prepareData(referenceData: ReferenceData, captureNode: NodeName, updates: EventHandlerFunc[]): LocalData {
+    const returnValue: LocalData = {
+        lazyPods: newLoading(),
+    };
+
+    if (!isLoaded(referenceData.nodes)) {
+        loadAllNodes(referenceData, updates);
+        return returnValue;
+    }
+
+    const nodesReferenceData = referenceData.nodes.value;
+    const nodeReferenceData = getOrThrow(nodesReferenceData, (n) => n.node === captureNode, `${captureNode} not found`);
+
+    if (!isLoaded(nodeReferenceData.filterPods)) {
+        loadFilterPods(nodeReferenceData, updates);
+        return returnValue;
+    }
+
+    returnValue.lazyPods = nodeReferenceData.filterPods;
+    return returnValue;
+}

--- a/webview-ui/src/TCPDump/filterScenarios/TwoPodsFilters.tsx
+++ b/webview-ui/src/TCPDump/filterScenarios/TwoPodsFilters.tsx
@@ -1,0 +1,199 @@
+import { EventHandlers } from "../../utilities/state";
+import { DualEndpointPacketDirection, EventDef, ReferenceData, TwoPodsFilter } from "../state";
+import { ResourceSelector } from "../../components/ResourceSelector";
+import { Lazy, isLoaded, newLoaded, newLoading } from "../../utilities/lazy";
+import styles from "../TcpDump.module.css";
+import { FilterPod, NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { EventHandlerFunc, loadAllNodes, loadFilterPods } from "../state/dataLoading";
+import { getOrThrow } from "../../utilities/array";
+import { FormEvent, useEffect } from "react";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+
+export interface TwoPodsFiltersProps {
+    captureNode: NodeName;
+    filter: TwoPodsFilter;
+    eventHandlers: EventHandlers<EventDef>;
+    referenceData: ReferenceData;
+}
+
+export function TwoPodsFilters(props: TwoPodsFiltersProps) {
+    const updates: EventHandlerFunc[] = [];
+    const { lazySourceNodes, lazySourcePods, lazyDestNodes, lazyDestPods } = prepareData(
+        props.referenceData,
+        props.filter,
+        updates,
+    );
+
+    useEffect(() => {
+        updates.map((fn) => fn(props.eventHandlers));
+    });
+
+    function handleSourceNodeChange(node: NodeName | null) {
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "TwoPods",
+            filters: { ...props.filter, sourceNode: node, sourcePod: null },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    function handleSourcePodChange(pod: FilterPod | null) {
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "TwoPods",
+            filters: { ...props.filter, sourcePod: pod },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    function handleDestNodeChange(node: NodeName | null) {
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "TwoPods",
+            filters: { ...props.filter, destNode: node, destPod: null },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    function handleDestPodChange(pod: FilterPod | null) {
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "TwoPods",
+            filters: { ...props.filter, destPod: pod },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    function handlePacketDirectionChange(e: Event | FormEvent<HTMLElement>) {
+        const elem = e.target as HTMLInputElement;
+        const packetDirection = elem.value as DualEndpointPacketDirection;
+        props.eventHandlers.onSetCaptureScenarioFilters({
+            node: props.captureNode,
+            scenario: "TwoPods",
+            filters: { ...props.filter, packetDirection },
+        });
+        props.eventHandlers.onRefreshPcapFilterString({ node: props.captureNode });
+    }
+
+    const packetDirectionLabels: Record<DualEndpointPacketDirection, string> = {
+        Bidirectional: "Bidirectional",
+        SourceToDestination: "Source to destination",
+    };
+
+    return (
+        <>
+            <label htmlFor="source-node-input" className={styles.label}>
+                Source Node
+            </label>
+            <ResourceSelector<NodeName>
+                id="source-node-input"
+                className={styles.controlDropdown}
+                resources={lazySourceNodes}
+                selectedItem={props.filter.sourceNode}
+                valueGetter={(n) => n}
+                labelGetter={(n) => n}
+                onSelect={handleSourceNodeChange}
+            />
+
+            <label htmlFor="source-pod-input" className={styles.label}>
+                Source Pod
+            </label>
+            <ResourceSelector<FilterPod>
+                id="source-pod-input"
+                className={styles.controlDropdown}
+                resources={lazySourcePods}
+                selectedItem={props.filter.sourcePod}
+                valueGetter={(p) => p.name}
+                labelGetter={(p) => p.name}
+                onSelect={handleSourcePodChange}
+            />
+
+            <label htmlFor="dest-node-input" className={styles.label}>
+                Destination Node
+            </label>
+            <ResourceSelector<NodeName>
+                id="dest-node-input"
+                className={styles.controlDropdown}
+                resources={lazyDestNodes}
+                selectedItem={props.filter.destNode}
+                valueGetter={(n) => n}
+                labelGetter={(n) => n}
+                onSelect={handleDestNodeChange}
+            />
+
+            <label htmlFor="dest-pod-input" className={styles.label}>
+                Destination Pod
+            </label>
+            <ResourceSelector<FilterPod>
+                id="dest-pod-input"
+                className={styles.controlDropdown}
+                resources={lazyDestPods}
+                selectedItem={props.filter.destPod}
+                valueGetter={(p) => p.name}
+                labelGetter={(p) => p.name}
+                onSelect={handleDestPodChange}
+            />
+
+            <label htmlFor="packet-direction-input" className={styles.label}>
+                Packet Direction
+            </label>
+            <VSCodeDropdown
+                className={styles.controlDropdown}
+                id="packet-direction-input"
+                value={props.filter.packetDirection}
+                onChange={handlePacketDirectionChange}
+            >
+                {Object.keys(packetDirectionLabels).map((d) => (
+                    <VSCodeOption key={d} value={d}>
+                        {packetDirectionLabels[d as DualEndpointPacketDirection]}
+                    </VSCodeOption>
+                ))}
+            </VSCodeDropdown>
+        </>
+    );
+}
+
+type LocalData = {
+    lazySourceNodes: Lazy<NodeName[]>;
+    lazySourcePods: Lazy<FilterPod[]>;
+    lazyDestNodes: Lazy<NodeName[]>;
+    lazyDestPods: Lazy<FilterPod[]>;
+};
+
+function prepareData(referenceData: ReferenceData, filter: TwoPodsFilter, updates: EventHandlerFunc[]): LocalData {
+    const returnValue: LocalData = {
+        lazySourceNodes: newLoading(),
+        lazySourcePods: newLoading(),
+        lazyDestNodes: newLoading(),
+        lazyDestPods: newLoading(),
+    };
+
+    if (!isLoaded(referenceData.nodes)) {
+        loadAllNodes(referenceData, updates);
+        return returnValue;
+    }
+
+    const nodesData = referenceData.nodes.value;
+    returnValue.lazySourceNodes = newLoaded(nodesData.map((d) => d.node));
+    returnValue.lazyDestNodes = newLoaded(nodesData.map((d) => d.node));
+
+    if (filter.sourceNode) {
+        const nodeData = getOrThrow(nodesData, (n) => n.node === filter.sourceNode, `${filter.sourceNode} not found`);
+        if (!isLoaded(nodeData.filterPods)) {
+            loadFilterPods(nodeData, updates);
+        } else {
+            returnValue.lazySourcePods = nodeData.filterPods;
+        }
+    }
+
+    if (filter.destNode) {
+        const nodeData = getOrThrow(nodesData, (n) => n.node === filter.destNode, `${filter.destNode} not found`);
+        if (!isLoaded(nodeData.filterPods)) {
+            loadFilterPods(nodeData, updates);
+        } else {
+            returnValue.lazyDestPods = nodeData.filterPods;
+        }
+    }
+
+    return returnValue;
+}

--- a/webview-ui/src/TCPDump/protocols.ts
+++ b/webview-ui/src/TCPDump/protocols.ts
@@ -1,0 +1,17 @@
+export type TransportLayerProtocol = "TCP" | "UDP" | "ICMP";
+
+export type ApplicationLayerProtocol = "HTTP" | "HTTPS" | "DNS";
+
+export type ProtocolMapping = Record<
+    ApplicationLayerProtocol,
+    {
+        port: number;
+        protocol: TransportLayerProtocol | null;
+    }
+>;
+
+export const protocolMapping: ProtocolMapping = {
+    HTTP: { port: 80, protocol: "TCP" },
+    HTTPS: { port: 443, protocol: "TCP" },
+    DNS: { port: 53, protocol: null }, // TODO: Do we do like NSGs and use "DNS (TCP)" and "DNS (UDP)"?
+};

--- a/webview-ui/src/TCPDump/protocols.ts
+++ b/webview-ui/src/TCPDump/protocols.ts
@@ -1,6 +1,8 @@
-export type TransportLayerProtocol = "TCP" | "UDP" | "ICMP";
+export const transportLayerProtocols = ["TCP", "UDP", "ICMP"];
+export type TransportLayerProtocol = (typeof transportLayerProtocols)[number];
 
-export type ApplicationLayerProtocol = "HTTP" | "HTTPS" | "DNS";
+export const applicationLayerProtocols = ["HTTP", "HTTPS", "DNS"] as const;
+export type ApplicationLayerProtocol = (typeof applicationLayerProtocols)[number];
 
 export type ProtocolMapping = Record<
     ApplicationLayerProtocol,

--- a/webview-ui/src/TCPDump/state.ts
+++ b/webview-ui/src/TCPDump/state.ts
@@ -1,15 +1,16 @@
 import {
     InitialState,
     NodeName,
-    NodeCommandResult,
     CaptureName,
-    NodeCheckResult,
-    NodeCaptureDownloadResult,
-    NodeCaptureStopResult,
+    InterfaceName,
+    PodName,
 } from "../../../src/webview-contract/webviewDefinitions/tcpDump";
-import { replaceItem } from "../utilities/array";
+import { Lazy, newLoading, newNotLoaded } from "../utilities/lazy";
 import { WebviewStateUpdater } from "../utilities/state";
 import { getWebviewMessageContext } from "../utilities/vscode";
+import { ApplicationLayerProtocol, TransportLayerProtocol } from "./protocols";
+import * as CaptureNodeUpdate from "./state/captureNodeUpdate";
+import * as ReferenceDataUpdate from "./state/referenceDataUpdate";
 
 export enum NodeStatus {
     Unknown,
@@ -29,16 +30,38 @@ export enum CaptureStatus {
     Downloaded,
 }
 
-type NodeState = {
+export type FilterPod = {
+    name: PodName;
+    ipAddress: string;
+};
+
+export type EndpointFilter = {
+    node: NodeName | null;
+    pod: FilterPod | null;
+};
+
+export type CaptureFilterSelection = {
+    interface: InterfaceName | null;
+    source: EndpointFilter;
+    destination: EndpointFilter;
+    appLayerProtocol: ApplicationLayerProtocol | null;
+    port: number | null;
+    transportLayerProtocol: TransportLayerProtocol | null;
+    pcapFilterString: string | null;
+};
+
+export type NodeState = {
     status: NodeStatus;
     errorMessage: string | null;
     currentCaptureName: CaptureName | null;
+    currentCaptureFilters: CaptureFilterSelection;
     completedCaptures: NodeCapture[];
+    captureInterfaces: Lazy<InterfaceName[]>;
 };
 
 type NodeStates = { [name: NodeName]: NodeState };
 
-type NodeCapture = {
+export type NodeCapture = {
     name: CaptureName;
     status: CaptureStatus;
     sizeInKB: number;
@@ -48,6 +71,16 @@ type NodeCapture = {
 export type TcpDumpState = InitialState & {
     selectedNode: NodeName | null;
     nodeStates: NodeStates;
+    referenceData: ReferenceData;
+};
+
+export type ReferenceData = {
+    nodes: Lazy<NodeReferenceData[]>;
+};
+
+export type NodeReferenceData = {
+    node: NodeName;
+    filterPods: Lazy<FilterPod[]>;
 };
 
 export type EventDef = {
@@ -58,6 +91,9 @@ export type EventDef = {
     startingNodeCapture: { node: NodeName; capture: CaptureName };
     stoppingNodeCapture: { node: NodeName };
     downloadingNodeCapture: { node: NodeName; capture: CaptureName };
+    setCaptureFilters: { node: NodeName; filters: CaptureFilterSelection };
+    setLoadingNodes: void;
+    setLoadingInterfaces: { node: NodeName };
 };
 
 export const stateUpdater: WebviewStateUpdater<"tcpDump", EventDef, TcpDumpState> = {
@@ -65,193 +101,89 @@ export const stateUpdater: WebviewStateUpdater<"tcpDump", EventDef, TcpDumpState
         ...initialState,
         selectedNode: null,
         nodeStates: {},
+        referenceData: {
+            nodes: newNotLoaded(),
+        },
     }),
     vscodeMessageHandler: {
-        checkNodeStateResponse: (state, args) => ({
+        checkNodeStateResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => CaptureNodeUpdate.updateFromNodeCheck(nodeState, args)),
+        startDebugPodResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromStartPodResult(nodeState, args),
+            ),
+        deleteDebugPodResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromDeletePodResult(nodeState, args),
+            ),
+        startCaptureResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromCaptureStartResult(nodeState, args),
+            ),
+        stopCaptureResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromCaptureStopResult(nodeState, args),
+            ),
+        downloadCaptureFileResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromDownloadResult(nodeState, args),
+            ),
+        getInterfacesResponse: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateCaptureInterfaces(nodeState, args),
+            ),
+        getAllNodesResponse: (state, args) => ({
             ...state,
-            nodeStates: getNodeStatesFromCheck(state.nodeStates, args),
-        }),
-        startDebugPodResponse: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromPodCreation(state.nodeStates, args),
-        }),
-        deleteDebugPodResponse: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromPodDeletion(state.nodeStates, args),
-        }),
-        startCaptureResponse: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromCaptureStartResult(state.nodeStates, args),
-        }),
-        stopCaptureResponse: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromCaptureStopResult(state.nodeStates, args),
-        }),
-        downloadCaptureFileResponse: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromDownloadResult(state.nodeStates, args),
+            referenceData: ReferenceDataUpdate.updateNodes(state.referenceData, args.value),
         }),
     },
     eventHandler: {
-        setSelectedNode: (state, node) => ({
-            ...state,
-            selectedNode: node,
-            nodeStates: ensureNodeStateExists(state.nodeStates, node),
-        }),
-        setCheckingNodeState: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromStatus(state.nodeStates, args.node, NodeStatus.Checking),
-        }),
-        creatingNodeDebugPod: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromStatus(state.nodeStates, args.node, NodeStatus.CreatingDebugPod),
-        }),
-        deletingNodeDebugPod: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromStatus(state.nodeStates, args.node, NodeStatus.DeletingDebugPod),
-        }),
-        startingNodeCapture: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromCaptureStarting(state.nodeStates, args.node, args.capture),
-        }),
-        stoppingNodeCapture: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromStatus(state.nodeStates, args.node, NodeStatus.CaptureStopping),
-        }),
-        downloadingNodeCapture: (state, args) => ({
-            ...state,
-            nodeStates: getNodeStatesFromDownloadStarting(state.nodeStates, args.node, args.capture),
-        }),
+        setSelectedNode: (state, node) => ({ ...ensureNodeStateExists(state, node), selectedNode: node }),
+        setCheckingNodeState: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, status: NodeStatus.Checking })),
+        creatingNodeDebugPod: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, status: NodeStatus.CreatingDebugPod })),
+        deletingNodeDebugPod: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, status: NodeStatus.DeletingDebugPod })),
+        startingNodeCapture: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromCaptureStarting(nodeState, args.capture),
+            ),
+        stoppingNodeCapture: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, status: NodeStatus.CaptureStopping })),
+        downloadingNodeCapture: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) =>
+                CaptureNodeUpdate.updateFromDownloadStarting(nodeState, args.capture),
+            ),
+        setCaptureFilters: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, currentCaptureFilters: args.filters })),
+        setLoadingInterfaces: (state, args) =>
+            updateNodeState(state, args.node, (nodeState) => ({ ...nodeState, captureInterfaces: newLoading() })),
+        setLoadingNodes: (state) => updateReferenceData(state, ReferenceDataUpdate.setNodesLoading),
     },
 };
 
-function ensureNodeStateExists(nodeStates: NodeStates, node: NodeName | null): NodeStates {
-    if (!node) return nodeStates;
-    const defaultNodeState: NodeState = {
-        status: NodeStatus.Unknown,
-        errorMessage: null,
-        currentCaptureName: null,
-        completedCaptures: [],
+function ensureNodeStateExists(state: TcpDumpState, node: NodeName | null): TcpDumpState {
+    if (!node) return state;
+    const nodeStates = { [node]: CaptureNodeUpdate.getInitialNodeState(), ...state.nodeStates };
+    return { ...state, nodeStates };
+}
+
+function updateNodeState(
+    state: TcpDumpState,
+    node: NodeName,
+    updater: (nodeState: NodeState) => NodeState,
+): TcpDumpState {
+    const nodeState = state.nodeStates[node];
+    const nodeStates = { ...state.nodeStates, [node]: updater(nodeState) };
+    return { ...state, nodeStates };
+}
+
+function updateReferenceData(state: TcpDumpState, updater: (data: ReferenceData) => ReferenceData): TcpDumpState {
+    return {
+        ...state,
+        referenceData: updater(state.referenceData),
     };
-    return { [node]: defaultNodeState, ...nodeStates };
-}
-
-function getNodeStatesFromCheck(nodeStates: NodeStates, result: NodeCheckResult): NodeStates {
-    const status = !result.isDebugPodRunning
-        ? NodeStatus.Clean
-        : result.runningCapture === null
-          ? NodeStatus.DebugPodRunning
-          : NodeStatus.CaptureRunning;
-
-    const currentCaptureName = result.runningCapture;
-
-    const completedCaptures = result.completedCaptures.map<NodeCapture>((c) => ({
-        name: c.name,
-        sizeInKB: c.sizeInKB,
-        status: CaptureStatus.Completed,
-        downloadedFilePath: null,
-    }));
-
-    const nodeState: NodeState = { ...nodeStates[result.node], status, currentCaptureName, completedCaptures };
-    return { ...nodeStates, [result.node]: nodeState };
-}
-
-function getNodeStatesFromStatus(nodeStates: NodeStates, node: NodeName, newStatus: NodeStatus): NodeStates {
-    return updateNodeState(nodeStates, node, (state) => ({ ...state, status: newStatus }));
-}
-
-function getNodeStatesFromPodCreation(nodeStates: NodeStates, result: NodeCommandResult): NodeStates {
-    const errorMessage = result.succeeded ? null : result.errorMessage;
-    const status = result.succeeded ? NodeStatus.DebugPodRunning : NodeStatus.Unknown;
-    return updateNodeState(nodeStates, result.node, (state) => ({ ...state, status, errorMessage }));
-}
-
-function getNodeStatesFromPodDeletion(nodeStates: NodeStates, result: NodeCommandResult): NodeStates {
-    const errorMessage = result.succeeded ? null : result.errorMessage;
-    const status = result.succeeded ? NodeStatus.Clean : NodeStatus.Unknown;
-    const currentCaptureName = null;
-    const completedCaptures: NodeCapture[] = [];
-    return updateNodeState(nodeStates, result.node, (state) => ({
-        ...state,
-        status,
-        errorMessage,
-        currentCaptureName,
-        completedCaptures,
-    }));
-}
-
-function getNodeStatesFromCaptureStarting(nodeStates: NodeStates, node: NodeName, capture: CaptureName): NodeStates {
-    return updateNodeState(nodeStates, node, (state) => ({
-        ...state,
-        status: NodeStatus.CaptureStarting,
-        currentCaptureName: capture,
-    }));
-}
-
-function getNodeStatesFromCaptureStartResult(nodeStates: NodeStates, result: NodeCommandResult): NodeStates {
-    const errorMessage = result.succeeded ? null : result.errorMessage;
-    const status = result.succeeded ? NodeStatus.CaptureRunning : NodeStatus.DebugPodRunning;
-    return updateNodeState(nodeStates, result.node, (state) => {
-        const currentCaptureName = result.succeeded ? state.currentCaptureName : null;
-        return { ...state, status, errorMessage, currentCaptureName };
-    });
-}
-
-function getNodeStatesFromCaptureStopResult(nodeStates: NodeStates, result: NodeCaptureStopResult): NodeStates {
-    const errorMessage = result.succeeded ? null : result.errorMessage;
-    const status = result.succeeded ? NodeStatus.DebugPodRunning : NodeStatus.Unknown;
-    return updateNodeState(nodeStates, result.node, (state) => {
-        const newCapture: NodeCapture | null =
-            result.succeeded && result.capture
-                ? {
-                      name: result.capture.name,
-                      sizeInKB: result.capture.sizeInKB,
-                      status: CaptureStatus.Completed,
-                      downloadedFilePath: null,
-                  }
-                : null;
-        const completedCaptures: NodeCapture[] = newCapture
-            ? [...state.completedCaptures, newCapture]
-            : state.completedCaptures;
-        return { ...state, status, errorMessage, completedCaptures };
-    });
-}
-
-function getNodeStatesFromDownloadStarting(
-    nodeStates: NodeStates,
-    node: NodeName,
-    captureName: CaptureName,
-): NodeStates {
-    return updateCapture(nodeStates, node, captureName, (c) => ({ ...c, status: CaptureStatus.Downloading }));
-}
-
-function getNodeStatesFromDownloadResult(nodeStates: NodeStates, result: NodeCaptureDownloadResult): NodeStates {
-    const errorMessage = result.succeeded ? null : result.errorMessage;
-    nodeStates = updateNodeState(nodeStates, result.node, (state) => ({ ...state, errorMessage }));
-
-    const status = result.succeeded ? CaptureStatus.Downloaded : CaptureStatus.Completed;
-    const downloadedFilePath = result.succeeded ? result.localCapturePath : null;
-    nodeStates = updateCapture(nodeStates, result.node, result.captureName, (c) => ({
-        ...c,
-        status,
-        downloadedFilePath,
-    }));
-
-    return nodeStates;
-}
-
-function updateNodeState(nodeStates: NodeStates, node: NodeName, updater: (nodeState: NodeState) => NodeState) {
-    return { ...nodeStates, [node]: updater(nodeStates[node]) };
-}
-
-function updateCapture(
-    nodeStates: NodeStates,
-    node: NodeName,
-    captureName: CaptureName,
-    updater: (capture: NodeCapture) => NodeCapture,
-): NodeStates {
-    const completedCaptures = replaceItem(nodeStates[node].completedCaptures, (c) => c.name === captureName, updater);
-    return updateNodeState(nodeStates, node, (state) => ({ ...state, completedCaptures }));
 }
 
 export const vscode = getWebviewMessageContext<"tcpDump">({
@@ -262,4 +194,6 @@ export const vscode = getWebviewMessageContext<"tcpDump">({
     downloadCaptureFile: null,
     openFolder: null,
     deleteDebugPod: null,
+    getInterfaces: null,
+    getAllNodes: null,
 });

--- a/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
+++ b/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
@@ -1,0 +1,141 @@
+import {
+    CaptureName,
+    InterfaceName,
+    NodeCaptureDownloadResult,
+    NodeCaptureStopResult,
+    NodeCheckResult,
+    NodeCommandResult,
+    ValueCommandResult,
+} from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { replaceItem } from "../../utilities/array";
+import { newLoaded, newNotLoaded } from "../../utilities/lazy";
+import { CaptureStatus, NodeCapture, NodeState, NodeStatus } from "../state";
+
+export function getInitialNodeState(): NodeState {
+    return {
+        status: NodeStatus.Unknown,
+        errorMessage: null,
+        currentCaptureName: null,
+        currentCaptureFilters: {
+            interface: null,
+            source: { node: null, pod: null },
+            destination: { node: null, pod: null },
+            appLayerProtocol: null,
+            port: null,
+            transportLayerProtocol: null,
+            pcapFilterString: null,
+        },
+        completedCaptures: [],
+        captureInterfaces: newNotLoaded(),
+    };
+}
+
+export function updateFromNodeCheck(state: NodeState, result: NodeCheckResult): NodeState {
+    const status = !result.isDebugPodRunning
+        ? NodeStatus.Clean
+        : result.runningCapture === null
+          ? NodeStatus.DebugPodRunning
+          : NodeStatus.CaptureRunning;
+
+    const currentCaptureName = result.runningCapture;
+
+    const completedCaptures = result.completedCaptures.map<NodeCapture>((c) => ({
+        name: c.name,
+        sizeInKB: c.sizeInKB,
+        status: CaptureStatus.Completed,
+        downloadedFilePath: null,
+    }));
+
+    return { ...state, status, currentCaptureName, completedCaptures };
+}
+
+export function updateFromStartPodResult(state: NodeState, result: NodeCommandResult): NodeState {
+    const errorMessage = result.succeeded ? null : result.errorMessage;
+    const status = result.succeeded ? NodeStatus.DebugPodRunning : NodeStatus.Unknown;
+    return { ...state, status, errorMessage };
+}
+
+export function updateFromDeletePodResult(state: NodeState, result: NodeCommandResult): NodeState {
+    const errorMessage = result.succeeded ? null : result.errorMessage;
+    const status = result.succeeded ? NodeStatus.Clean : NodeStatus.Unknown;
+    const currentCaptureName = null;
+    const completedCaptures: NodeCapture[] = [];
+    return {
+        ...state,
+        status,
+        errorMessage,
+        currentCaptureName,
+        completedCaptures,
+    };
+}
+
+export function updateCaptureInterfaces(
+    state: NodeState,
+    result: ValueCommandResult<NodeCommandResult, InterfaceName[]>,
+): NodeState {
+    if (!result.succeeded) {
+        return { ...state, errorMessage: result.errorMessage };
+    }
+
+    return { ...state, captureInterfaces: newLoaded(result.value) };
+}
+
+export function updateFromCaptureStarting(state: NodeState, capture: CaptureName): NodeState {
+    return {
+        ...state,
+        status: NodeStatus.CaptureStarting,
+        currentCaptureName: capture,
+    };
+}
+
+export function updateFromCaptureStartResult(state: NodeState, result: NodeCommandResult): NodeState {
+    const errorMessage = result.succeeded ? null : result.errorMessage;
+    const status = result.succeeded ? NodeStatus.CaptureRunning : NodeStatus.DebugPodRunning;
+    const currentCaptureName = result.succeeded ? state.currentCaptureName : null;
+    return { ...state, status, errorMessage, currentCaptureName };
+}
+
+export function updateFromCaptureStopResult(state: NodeState, result: NodeCaptureStopResult): NodeState {
+    const errorMessage = result.succeeded ? null : result.errorMessage;
+    const status = result.succeeded ? NodeStatus.DebugPodRunning : NodeStatus.Unknown;
+    const newCapture: NodeCapture | null =
+        result.succeeded && result.capture
+            ? {
+                  name: result.capture.name,
+                  sizeInKB: result.capture.sizeInKB,
+                  status: CaptureStatus.Completed,
+                  downloadedFilePath: null,
+              }
+            : null;
+    const completedCaptures: NodeCapture[] = newCapture
+        ? [...state.completedCaptures, newCapture]
+        : state.completedCaptures;
+    return { ...state, status, errorMessage, completedCaptures };
+}
+
+export function updateFromDownloadStarting(state: NodeState, captureName: CaptureName): NodeState {
+    return updateCompletedCapture(state, captureName, (c) => ({ ...c, status: CaptureStatus.Downloading }));
+}
+
+export function updateFromDownloadResult(state: NodeState, result: NodeCaptureDownloadResult): NodeState {
+    const errorMessage = result.succeeded ? null : result.errorMessage;
+    const status = result.succeeded ? CaptureStatus.Downloaded : CaptureStatus.Completed;
+    const downloadedFilePath = result.succeeded ? result.localCapturePath : null;
+    return {
+        ...updateCompletedCapture(state, result.captureName, (c) => ({
+            ...c,
+            status,
+            downloadedFilePath,
+        })),
+        errorMessage,
+    };
+}
+
+function updateCompletedCapture(
+    state: NodeState,
+    captureName: CaptureName,
+    updater: (capture: NodeCapture) => NodeCapture,
+): NodeState {
+    const completedCaptures = replaceItem(state.completedCaptures, (c) => c.name === captureName, updater);
+    return { ...state, completedCaptures };
+}

--- a/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
+++ b/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
@@ -116,13 +116,16 @@ export function updateScenarioFilter(state: NodeState, value: ScenarioFilterValu
 
 export function refreshPcapFilterString(state: NodeState): NodeState {
     // https://www.tcpdump.org/manpages/pcap-filter.7.html
+    // https://docs.netgate.com/pfsense/en/latest/diagnostics/packetcapture/tcpdump.html
     const parts = [];
-    if (state.currentCaptureFilters.port) {
+    if (state.currentCaptureFilters.port && state.currentCaptureFilters.transportLayerProtocol) {
+        const protocol = state.currentCaptureFilters.transportLayerProtocol.toLowerCase();
+        parts.push(`${protocol} port ${state.currentCaptureFilters.port}`);
+    } else if (state.currentCaptureFilters.port) {
         parts.push(`port ${state.currentCaptureFilters.port}`);
-    }
-
-    if (state.currentCaptureFilters.transportLayerProtocol) {
-        parts.push(`ip proto ${state.currentCaptureFilters.transportLayerProtocol.toLowerCase()}`);
+    } else if (state.currentCaptureFilters.transportLayerProtocol) {
+        const protocol = state.currentCaptureFilters.transportLayerProtocol.toLowerCase();
+        parts.push(protocol);
     }
 
     parts.push(...getPcapFilterStringParts(state.currentCaptureFilters));

--- a/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
+++ b/webview-ui/src/TCPDump/state/captureNodeUpdate.ts
@@ -116,8 +116,7 @@ export function updateScenarioFilter(state: NodeState, value: ScenarioFilterValu
 
 export function refreshPcapFilterString(state: NodeState): NodeState {
     // https://www.tcpdump.org/manpages/pcap-filter.7.html
-    const parts = getPcapFilterStringParts(state.currentCaptureFilters);
-
+    const parts = [];
     if (state.currentCaptureFilters.port) {
         parts.push(`port ${state.currentCaptureFilters.port}`);
     }
@@ -125,6 +124,8 @@ export function refreshPcapFilterString(state: NodeState): NodeState {
     if (state.currentCaptureFilters.transportLayerProtocol) {
         parts.push(`ip proto ${state.currentCaptureFilters.transportLayerProtocol.toLowerCase()}`);
     }
+
+    parts.push(...getPcapFilterStringParts(state.currentCaptureFilters));
 
     return {
         ...state,

--- a/webview-ui/src/TCPDump/state/dataLoading.ts
+++ b/webview-ui/src/TCPDump/state/dataLoading.ts
@@ -1,0 +1,27 @@
+import { NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { isNotLoaded } from "../../utilities/lazy";
+import { EventHandlers } from "../../utilities/state";
+import { EventDef, NodeReferenceData, NodeState, ReferenceData, vscode } from "../state";
+
+export type EventHandlerFunc = (eventHandlers: EventHandlers<EventDef>) => void;
+
+export function loadAllNodes(referenceData: ReferenceData, updates: EventHandlerFunc[]): void {
+    if (isNotLoaded(referenceData.nodes)) {
+        vscode.postGetAllNodes();
+        updates.push((e) => e.onSetLoadingNodes());
+    }
+}
+
+export function loadFilterPods(nodeReferenceData: NodeReferenceData, updates: EventHandlerFunc[]): void {
+    if (isNotLoaded(nodeReferenceData.filterPods)) {
+        vscode.postGetFilterPodsForNode({ node: nodeReferenceData.node });
+        updates.push((e) => e.onSetLoadingFilterPods({ node: nodeReferenceData.node }));
+    }
+}
+
+export function loadCaptureInterfaces(nodeState: NodeState, node: NodeName, updates: EventHandlerFunc[]): void {
+    if (isNotLoaded(nodeState.captureInterfaces)) {
+        vscode.postGetInterfaces({ node });
+        updates.push((e) => e.onSetLoadingInterfaces({ node }));
+    }
+}

--- a/webview-ui/src/TCPDump/state/nodeReferenceDataUpdate.ts
+++ b/webview-ui/src/TCPDump/state/nodeReferenceDataUpdate.ts
@@ -1,5 +1,6 @@
+import { FilterPod } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
 import { newLoaded, newLoading } from "../../utilities/lazy";
-import { FilterPod, NodeReferenceData } from "../state";
+import { NodeReferenceData } from "../state";
 
 export function setFilterPodsLoading(data: NodeReferenceData): NodeReferenceData {
     return { ...data, filterPods: newLoading() };

--- a/webview-ui/src/TCPDump/state/nodeReferenceDataUpdate.ts
+++ b/webview-ui/src/TCPDump/state/nodeReferenceDataUpdate.ts
@@ -1,0 +1,13 @@
+import { newLoaded, newLoading } from "../../utilities/lazy";
+import { FilterPod, NodeReferenceData } from "../state";
+
+export function setFilterPodsLoading(data: NodeReferenceData): NodeReferenceData {
+    return { ...data, filterPods: newLoading() };
+}
+
+export function updateFilterPods(data: NodeReferenceData, pods: FilterPod[]): NodeReferenceData {
+    return {
+        ...data,
+        filterPods: newLoaded(pods),
+    };
+}

--- a/webview-ui/src/TCPDump/state/referenceDataUpdate.ts
+++ b/webview-ui/src/TCPDump/state/referenceDataUpdate.ts
@@ -1,7 +1,7 @@
-import { NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { FilterPod, NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
 import { replaceItem, updateValues } from "../../utilities/array";
 import { map as lazyMap, newLoaded, newLoading, newNotLoaded, orDefault } from "../../utilities/lazy";
-import { ReferenceData, NodeReferenceData, FilterPod } from "../state";
+import { ReferenceData, NodeReferenceData } from "../state";
 import * as NodeReferenceDataUpdate from "./nodeReferenceDataUpdate";
 
 export function setNodesLoading(data: ReferenceData): ReferenceData {

--- a/webview-ui/src/TCPDump/state/referenceDataUpdate.ts
+++ b/webview-ui/src/TCPDump/state/referenceDataUpdate.ts
@@ -1,0 +1,46 @@
+import { NodeName } from "../../../../src/webview-contract/webviewDefinitions/tcpDump";
+import { replaceItem, updateValues } from "../../utilities/array";
+import { map as lazyMap, newLoaded, newLoading, newNotLoaded, orDefault } from "../../utilities/lazy";
+import { ReferenceData, NodeReferenceData, FilterPod } from "../state";
+import * as NodeReferenceDataUpdate from "./nodeReferenceDataUpdate";
+
+export function setNodesLoading(data: ReferenceData): ReferenceData {
+    return { ...data, nodes: newLoading() };
+}
+
+export function updateNodes(data: ReferenceData, nodes: NodeName[]): ReferenceData {
+    const existingNodes = orDefault(data.nodes, []);
+    const updatedNodes = updateValues(
+        existingNodes,
+        nodes,
+        (data) => data.node,
+        (node) => ({
+            node,
+            filterPods: newNotLoaded(),
+        }),
+    );
+
+    return {
+        ...data,
+        nodes: newLoaded(updatedNodes),
+    };
+}
+
+export function setFilterPodsLoading(data: ReferenceData, node: NodeName): ReferenceData {
+    return updateNode(data, node, (data) => NodeReferenceDataUpdate.setFilterPodsLoading(data));
+}
+
+export function updateFilterPods(data: ReferenceData, node: NodeName, pods: FilterPod[]): ReferenceData {
+    return updateNode(data, node, (data) => NodeReferenceDataUpdate.updateFilterPods(data, pods));
+}
+
+function updateNode(
+    data: ReferenceData,
+    node: NodeName,
+    updater: (data: NodeReferenceData) => NodeReferenceData,
+): ReferenceData {
+    return {
+        ...data,
+        nodes: lazyMap(data.nodes, (nodes) => replaceItem(nodes, (data) => data.node === node, updater)),
+    };
+}

--- a/webview-ui/src/TCPDump/state/scenarioFiltersUpdate.ts
+++ b/webview-ui/src/TCPDump/state/scenarioFiltersUpdate.ts
@@ -1,0 +1,66 @@
+import {
+    CaptureScenario,
+    CaptureScenarioFilters,
+    ScenarioFilterValue,
+    SpecificPodFilter,
+    TwoPodsFilter,
+} from "../state";
+
+export function updateScenarioFilter(
+    allFilters: CaptureScenarioFilters,
+    value: ScenarioFilterValue,
+): CaptureScenarioFilters {
+    return {
+        ...allFilters,
+        [value.scenario]: value.filters,
+    };
+}
+
+export function getPcapFilterStringParts(scenario: CaptureScenario, filters: CaptureScenarioFilters): string[] {
+    switch (scenario) {
+        case "SpecificPod":
+            return getSpecificPodPcapFilters(filters[scenario]);
+        case "TwoPods":
+            return getTwoPodsPcapFilters(filters[scenario]);
+    }
+}
+
+function getSpecificPodPcapFilters(filter: SpecificPodFilter): string[] {
+    if (!filter.pod) return [];
+    switch (filter.packetDirection) {
+        case "SentAndReceived":
+            return [`host ${filter.pod.ipAddress}`];
+        case "Sent":
+            return [`src ${filter.pod.ipAddress}`];
+        case "Received":
+            return [`dst ${filter.pod.ipAddress}`];
+    }
+}
+
+function getTwoPodsPcapFilters(filter: TwoPodsFilter): string[] {
+    if (!filter.sourcePod && !filter.destPod) return [];
+    const filters = [];
+    if (filter.sourcePod) {
+        switch (filter.packetDirection) {
+            case "SourceToDestination":
+                filters.push(`src ${filter.sourcePod.ipAddress}`);
+                break;
+            case "Bidirectional":
+                filters.push(`host ${filter.sourcePod.ipAddress}`);
+                break;
+        }
+    }
+
+    if (filter.destPod) {
+        switch (filter.packetDirection) {
+            case "SourceToDestination":
+                filters.push(`dst ${filter.destPod.ipAddress}`);
+                break;
+            case "Bidirectional":
+                filters.push(`host ${filter.destPod.ipAddress}`);
+                break;
+        }
+    }
+
+    return filters;
+}

--- a/webview-ui/src/components/ResourceSelector.tsx
+++ b/webview-ui/src/components/ResourceSelector.tsx
@@ -1,0 +1,51 @@
+import { FormEvent } from "react";
+import { Lazy, isLoaded, isLoading, newLoaded } from "../utilities/lazy";
+import { VSCodeDropdown, VSCodeOption, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+
+export interface ResourceSelectorProps<TResource> {
+    resources: Lazy<TResource[]> | TResource[];
+    selectedItem: TResource | null;
+    valueGetter: (resource: TResource) => string;
+    labelGetter: (resource: TResource) => string;
+    id?: string;
+    className?: string;
+    onSelect: (value: TResource | null) => void;
+}
+
+export function ResourceSelector<TResource>(props: ResourceSelectorProps<TResource>) {
+    const resources = asLazy(props.resources);
+
+    function handleChange(e: Event | FormEvent<HTMLElement>) {
+        const elem = e.target as HTMLInputElement;
+        const resource =
+            elem.value && isLoaded(resources)
+                ? resources.value.find((r) => props.valueGetter(r) === elem.value) || null
+                : null;
+        props.onSelect(resource);
+    }
+
+    const selectedValue = props.selectedItem !== null ? props.valueGetter(props.selectedItem) : "";
+    return (
+        <>
+            {isLoading(resources) && <VSCodeProgressRing style={{ height: "1rem" }} />}
+            {isLoaded(resources) && (
+                <VSCodeDropdown className={props.className} id={props.id} value={selectedValue} onChange={handleChange}>
+                    <VSCodeOption value="">Select</VSCodeOption>
+                    {resources.value.map((r) => (
+                        <VSCodeOption key={props.valueGetter(r)} value={props.valueGetter(r)}>
+                            {props.labelGetter(r)}
+                        </VSCodeOption>
+                    ))}
+                </VSCodeDropdown>
+            )}
+        </>
+    );
+}
+
+function asLazy<TResource>(resources: Lazy<TResource[]> | TResource[]): Lazy<TResource[]> {
+    if (resources instanceof Array) {
+        return newLoaded(resources);
+    }
+
+    return resources;
+}

--- a/webview-ui/src/manualTest/tcpDumpTests.tsx
+++ b/webview-ui/src/manualTest/tcpDumpTests.tsx
@@ -32,6 +32,7 @@ const nodeThatFailsToDeleteDebugPod = "node-that-fails-to-delete-debug-pod";
 const nodeThatFailsToStartCapture = "node-that-fails-to-start-capture";
 const nodeThatFailsToStopCapture = "node-that-fails-to-stop-capture";
 const nodeWhereDownloadsFail = "node-where-downloads-fail";
+const windowsNode = "windows-node";
 
 const randomFileSize = () => ~~(Math.random() * 5000);
 
@@ -67,6 +68,8 @@ export function getTCPDumpScenarios() {
             stopCapture: (args) => handleStopCapture(args.node, args.capture),
             downloadCaptureFile: (args) => handleDownloadCaptureFile(args.node, args.capture),
             openFolder: (args) => handleOpenFolder(args),
+            getInterfaces: (args) => handleGetInterfaces(args.node),
+            getAllNodes: handleGetAllNodes,
         };
 
         async function handleCheckNodeState(node: NodeName) {
@@ -161,6 +164,25 @@ export function getTCPDumpScenarios() {
 
         function handleOpenFolder(path: string) {
             alert(`VS Code would launch an OS file system browser here:\n${path}`);
+        }
+
+        async function handleGetInterfaces(node: NodeName) {
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            webview.postGetInterfacesResponse({
+                node,
+                succeeded: true,
+                errorMessage: null,
+                value: ["eth0", "lo", "any", "nflog", "nfqueue"],
+            });
+        }
+
+        async function handleGetAllNodes() {
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            webview.postGetAllNodesResponse({
+                succeeded: true,
+                errorMessage: null,
+                value: [...Object.keys(nodeStates), windowsNode],
+            });
         }
     }
 

--- a/webview-ui/src/utilities/array.ts
+++ b/webview-ui/src/utilities/array.ts
@@ -29,6 +29,15 @@ export function exclude<T>(take: T[], exclude: T[]): T[] {
     return take.filter((a) => !exclude.includes(a));
 }
 
+export function getOrThrow<T>(items: T[], predicate: (item: T) => boolean, messageIfMissing: string): T {
+    const item = items.find(predicate);
+    if (!item) {
+        throw new Error(messageIfMissing);
+    }
+
+    return item;
+}
+
 export type ItemKey = { [key: string]: string } | string;
 
 export function updateValues<TKey extends ItemKey, TItem>(

--- a/webview-ui/src/utilities/array.ts
+++ b/webview-ui/src/utilities/array.ts
@@ -2,7 +2,7 @@ export type Lookup<T> = {
     [key: string]: T;
 };
 
-export function asLookup<T>(items: T[], keyFn: (value: T) => string): Lookup<T> {
+export function asLookup<T>(items: T[], keyFn: (value: T) => ItemKey): Lookup<T> {
     const entries = items.map((val) => [keyFn(val), val]);
     return Object.fromEntries(entries);
 }
@@ -27,4 +27,29 @@ export function intersection<T>(itemsA: T[], itemsB: T[]): T[] {
 
 export function exclude<T>(take: T[], exclude: T[]): T[] {
     return take.filter((a) => !exclude.includes(a));
+}
+
+export type ItemKey = { [key: string]: string } | string;
+
+export function updateValues<TKey extends ItemKey, TItem>(
+    items: TItem[],
+    updatedKeys: TKey[],
+    keyFn: (item: TItem) => TKey,
+    itemFn: (key: TKey) => TItem,
+): TItem[] {
+    const lookup = asLookup(items, keyFn);
+    return updatedKeys.map((key) => {
+        const keyId = getKeyId(key);
+        return keyId in lookup ? lookup[keyId] : itemFn(key);
+    });
+}
+
+function getKeyId(key: ItemKey): string {
+    if (key instanceof Object) {
+        return Object.keys(key)
+            .map((keyPart) => key[keyPart])
+            .join("\0");
+    }
+
+    return key;
 }

--- a/webview-ui/src/utilities/array.ts
+++ b/webview-ui/src/utilities/array.ts
@@ -3,7 +3,7 @@ export type Lookup<T> = {
 };
 
 export function asLookup<T>(items: T[], keyFn: (value: T) => ItemKey): Lookup<T> {
-    const entries = items.map((val) => [keyFn(val), val]);
+    const entries = items.map((val) => [getKeyId(keyFn(val)), val]);
     return Object.fromEntries(entries);
 }
 
@@ -40,6 +40,15 @@ export function getOrThrow<T>(items: T[], predicate: (item: T) => boolean, messa
 
 export type ItemKey = { [key: string]: string } | string;
 
+/**
+ * Creates a new array based on an updated set of 'keys', where each key uniquely identifies
+ * an item in the array.
+ * @param items The existing collection of array items
+ * @param updatedKeys The keys of the updated collection
+ * @param keyFn A function that gets the key of an item
+ * @param itemFn A function that creates a new item from a key
+ * @returns An updated collection of items with the new keys/
+ */
 export function updateValues<TKey extends ItemKey, TItem>(
     items: TItem[],
     updatedKeys: TKey[],


### PR DESCRIPTION
Capture files can become huge very quickly. We need to allow users to filter output so that file sizes are manageable.

This is achieved with a new `Filters` option:
<img width="389" alt="image" src="https://github.com/Azure/vscode-aks-tools/assets/1817696/79ed1405-7120-4a53-abc4-2c63b529a3bb">

Users can filter on network interface, as well as build a [pcap filter string](https://www.tcpdump.org/manpages/pcap-filter.7.html) using protocol/port fields, or editing it manually:
<img width="411" alt="image" src="https://github.com/Azure/vscode-aks-tools/assets/1817696/52aae351-8b51-4b8e-a779-eb003adfd6e3">

The number of options here could grow quite large and become mutually inconsistent, depending on which capture scenarios we want to support in future. For example, collecting outgoing traffic from a _single_ pod requires different filter options from traffic _between_ two known pods. Conceivably we might want to support other scenarios in the future, perhaps involving services or ingresses.

For this reason, we have also added a `Capture Scenario` drop-down. Choosing different values here gives you different additional filter options, and allows us to add future filters in a consistent manner. For now we support "Specific Pod" and "Two Pods":
<img width="388" alt="image" src="https://github.com/Azure/vscode-aks-tools/assets/1817696/e610dd09-6f43-4fbe-8972-fc06aa48a03c">
<img width="385" alt="image" src="https://github.com/Azure/vscode-aks-tools/assets/1817696/0b16d061-80c1-4f35-bf6b-b48bd99551bd">

Note that the `Pcap Filter` string gets updated with the correct IP addresses of the selected pods. `tcpdump` behaviour in response to these filters can be verified from the downloaded capture file:
<img width="588" alt="image" src="https://github.com/Azure/vscode-aks-tools/assets/1817696/7ed1cf4c-f41c-4ccd-a565-a509d149372a">

**Known limitation**: The `Pcap Filter` string allows freeform text because the grammar is too complex for us to validate. If the user enters an invalid filter string there will be an error running the `tcpdump` command. Unfortunately, we run that command in the background (because it's long-running and we need to return control to the user and allow them to stop the capture), meaning we don't catch any non-zero exit code, and the capture appears to be running when it's not. The user will not notice until they try to _stop_ the capture, and there will be an error about being unable to find it. This is solvable, for example we can poll for running `tcpdump` processes and detect if it has exited early, but I'd prefer to make that change in a separate PR.