### PR TITLE
Support telemetry for commands from webviews

### DIFF
--- a/src/panels/AzureServiceOperatorPanel.ts
+++ b/src/panels/AzureServiceOperatorPanel.ts
@@ -17,6 +17,7 @@ import { NonZeroExitCodeBehaviour, invokeKubectlCommand } from "../commands/util
 import path from "path";
 import * as fs from "fs/promises";
 import { createTempFile } from "../commands/utils/tempfile";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class AzureServiceOperatorPanel extends BasePanel<"aso"> {
     constructor(extensionUri: vscode.Uri) {
@@ -47,6 +48,17 @@ export class AzureServiceOperatorDataProvider implements PanelDataProvider<"aso"
     getInitialState(): InitialState {
         return {
             clusterName: this.clusterName,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"aso"> {
+        return {
+            checkSPRequest: true,
+            installCertManagerRequest: true,
+            waitForCertManagerRequest: false,
+            installOperatorRequest: true,
+            installOperatorSettingsRequest: true,
+            waitForControllerManagerRequest: false,
         };
     }
 

--- a/src/panels/BasePanel.ts
+++ b/src/panels/BasePanel.ts
@@ -172,9 +172,9 @@ function getTelemetryData<TContent extends ContentId>(
     if (getTelemetryData === false) return null;
 
     // The `command` value we emit will combine the webview identifier (contentId), e.g. `createCluster`
-    // with the command in the message, e.g. `createClusterRequest`.
-    const data = { command: `${contentId}.${message.command}` };
-    if (getTelemetryData === true) return data;
-
-    return { ...data, ...getTelemetryData(message.parameters) };
+    // with either:
+    // - the command in the message, e.g. `createClusterRequest`
+    // - the return value of `getTelemetryData`
+    const commandValue = getTelemetryData === true ? message.command : getTelemetryData(message.parameters);
+    return { command: `${contentId}.${commandValue}` };
 }

--- a/src/panels/ClusterPropertiesPanel.ts
+++ b/src/panels/ClusterPropertiesPanel.ts
@@ -11,6 +11,7 @@ import {
 } from "../webview-contract/webviewDefinitions/clusterProperties";
 import { ContainerServiceClient, ManagedCluster, ManagedClusterAgentPoolProfile } from "@azure/arm-containerservice";
 import { getManagedCluster } from "../commands/utils/clusters";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class ClusterPropertiesPanel extends BasePanel<"clusterProperties"> {
     constructor(extensionUri: Uri) {
@@ -35,6 +36,17 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
     getInitialState(): InitialState {
         return {
             clusterName: this.clusterName,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"clusterProperties"> {
+        return {
+            getPropertiesRequest: false,
+            stopClusterRequest: true,
+            startClusterRequest: true,
+            abortAgentPoolOperation: true,
+            abortClusterOperation: true,
+            reconcileClusterRequest: true,
         };
     }
 

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -17,6 +17,7 @@ import {
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { ClusterDeploymentBuilder, ClusterSpec } from "./utilities/ClusterSpecCreationBuilder";
 import { getPortalResourceUrl } from "../commands/utils/env";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class CreateClusterPanel extends BasePanel<"createCluster"> {
     constructor(extensionUri: Uri) {
@@ -43,6 +44,14 @@ export class CreateClusterDataProvider implements PanelDataProvider<"createClust
         return {
             subscriptionId: this.subscriptionContext.subscriptionId,
             subscriptionName: this.subscriptionContext.subscriptionDisplayName,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"createCluster"> {
+        return {
+            getResourceGroupsRequest: false,
+            getLocationsRequest: false,
+            createClusterRequest: true,
         };
     }
 

--- a/src/panels/DetectorPanel.ts
+++ b/src/panels/DetectorPanel.ts
@@ -9,6 +9,7 @@ import {
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { getPortalUrl } from "../commands/utils/detectors";
 import { Environment } from "@azure/ms-rest-azure-env";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class DetectorPanel extends BasePanel<"detector"> {
     constructor(extensionUri: Uri) {
@@ -43,6 +44,10 @@ export class DetectorDataProvider implements PanelDataProvider<"detector"> {
             portalDetectorUrl: this.detectorPortalUrl,
             detectors: this.detectors,
         };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"detector"> {
+        return {};
     }
 
     getMessageHandler(): MessageHandler<ToVsCodeMsgDef> {

--- a/src/panels/InspektorGadgetPanel.ts
+++ b/src/panels/InspektorGadgetPanel.ts
@@ -46,14 +46,10 @@ export class InspektorGadgetDataProvider implements PanelDataProvider<"gadget"> 
             getVersionRequest: false,
             deployRequest: true,
             undeployRequest: true,
-            runStreamingTraceRequest: (args) => ({
-                category: args.arguments.gadgetCategory,
-                resource: args.arguments.gadgetResource,
-            }),
-            runBlockingTraceRequest: (args) => ({
-                category: args.arguments.gadgetCategory,
-                resource: args.arguments.gadgetResource,
-            }),
+            runStreamingTraceRequest: (args) =>
+                `streamTrace_${args.arguments.gadgetCategory}_${args.arguments.gadgetResource}`,
+            runBlockingTraceRequest: (args) =>
+                `runTrace_${args.arguments.gadgetCategory}_${args.arguments.gadgetResource}`,
             stopStreamingTraceRequest: true,
             getNodesRequest: false,
             getNamespacesRequest: false,

--- a/src/panels/InspektorGadgetPanel.ts
+++ b/src/panels/InspektorGadgetPanel.ts
@@ -11,6 +11,7 @@ import {
     ToWebViewMsgDef,
     TraceOutputItem,
 } from "../webview-contract/webviewDefinitions/inspektorGadget";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class InspektorGadgetPanel extends BasePanel<"gadget"> {
     constructor(extensionUri: vscode.Uri) {
@@ -38,6 +39,27 @@ export class InspektorGadgetDataProvider implements PanelDataProvider<"gadget"> 
 
     getInitialState(): InitialState {
         return {};
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"gadget"> {
+        return {
+            getVersionRequest: false,
+            deployRequest: true,
+            undeployRequest: true,
+            runStreamingTraceRequest: (args) => ({
+                category: args.arguments.gadgetCategory,
+                resource: args.arguments.gadgetResource,
+            }),
+            runBlockingTraceRequest: (args) => ({
+                category: args.arguments.gadgetCategory,
+                resource: args.arguments.gadgetResource,
+            }),
+            stopStreamingTraceRequest: true,
+            getNodesRequest: false,
+            getNamespacesRequest: false,
+            getPodsRequest: false,
+            getContainersRequest: false,
+        };
     }
 
     getMessageHandler(webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -11,6 +11,7 @@ import {
     ToWebViewMsgDef,
 } from "../webview-contract/webviewDefinitions/kubectl";
 import { addKubectlCustomCommand, deleteKubectlCustomCommand } from "../commands/utils/config";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class KubectlPanel extends BasePanel<"kubectl"> {
     constructor(extensionUri: Uri) {
@@ -36,6 +37,14 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         return {
             clusterName: this.clusterName,
             customCommands: this.customCommands,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"kubectl"> {
+        return {
+            runCommandRequest: true,
+            addCustomCommandRequest: true,
+            deleteCustomCommandRequest: true,
         };
     }
 

--- a/src/panels/PeriscopePanel.ts
+++ b/src/panels/PeriscopePanel.ts
@@ -14,6 +14,7 @@ import {
 } from "../webview-contract/webviewDefinitions/periscope";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { URL } from "url";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 export class PeriscopePanel extends BasePanel<"periscope"> {
     constructor(extensionUri: Uri) {
@@ -81,6 +82,13 @@ export class PeriscopeDataProvider implements PanelDataProvider<"periscope"> {
             kustomizeConfig: this.deploymentParameters?.kustomizeConfig || null,
             blobContainerUrl: containerUrl,
             shareableSas: shareableSas,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"periscope"> {
+        return {
+            nodeLogsRequest: false,
+            uploadStatusRequest: false,
         };
     }
 

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -17,6 +17,7 @@ import {
     ToWebViewMsgDef,
 } from "../webview-contract/webviewDefinitions/tcpDump";
 import { withOptionalTempFile } from "../commands/utils/tempfile";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 
 const debugPodNamespace = "default";
 const tcpDumpCommandBase = "tcpdump --snapshot-length=0 -vvv";
@@ -85,6 +86,21 @@ export class TcpDumpDataProvider implements PanelDataProvider<"tcpDump"> {
         return {
             clusterName: this.clusterName,
             allNodes: this.linuxNodesList,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"tcpDump"> {
+        return {
+            checkNodeState: false,
+            startDebugPod: true,
+            deleteDebugPod: true,
+            startCapture: true,
+            stopCapture: true,
+            downloadCaptureFile: true,
+            openFolder: true,
+            getInterfaces: false,
+            getAllNodes: false,
+            getFilterPodsForNode: false,
         };
     }
 

--- a/src/tests/suite/webview.test.ts
+++ b/src/tests/suite/webview.test.ts
@@ -5,6 +5,7 @@ import { BasePanel, PanelDataProvider } from "../../panels/BasePanel";
 import { getExtensionPath } from "../../commands/utils/host";
 import { map as errmap, Succeeded, succeeded } from "../../commands/utils/errorable";
 import { expect } from "chai";
+import { TelemetryDefinition } from "../../webview-contract/webviewTypes";
 
 const extensionPathResult = getExtensionPath();
 const extensionUriResult = errmap(extensionPathResult, (p) => vscode.Uri.file(p));
@@ -50,6 +51,13 @@ class StyleTestDataProvider implements PanelDataProvider<"style"> {
 
     getInitialState(): InitialState {
         return { isVSCode: true };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"style"> {
+        return {
+            reportCssRules: false,
+            reportCssVars: false,
+        };
     }
 
     getMessageHandler(): MessageHandler<ToVsCodeMsgDef> {

--- a/src/webview-contract/messaging.ts
+++ b/src/webview-contract/messaging.ts
@@ -71,6 +71,8 @@ export type Message<TMsgDef extends MessageDefinition> = {
     };
 }[Command<TMsgDef>];
 
+export type MessageParameters<TMsgDef extends MessageDefinition, TCommand extends Command<TMsgDef>> = TMsgDef[TCommand];
+
 /**
  * The handler type for all the messages defined in `TMsgDef`.
  */

--- a/src/webview-contract/messaging.ts
+++ b/src/webview-contract/messaging.ts
@@ -71,8 +71,6 @@ export type Message<TMsgDef extends MessageDefinition> = {
     };
 }[Command<TMsgDef>];
 
-export type MessageParameters<TMsgDef extends MessageDefinition, TCommand extends Command<TMsgDef>> = TMsgDef[TCommand];
-
 /**
  * The handler type for all the messages defined in `TMsgDef`.
  */

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -69,10 +69,9 @@ export type WebviewMessageContext<T extends ContentId> = MessageContext<ToVsCode
  * Possible values are:
  * - false: No telemetry will be emitted
  * - true: A telemetry event will be emitted containing the property "command" with value "<webview>.<messagetype>"
- * - (args) => {properties}: A telemetry event will be emitted containing:
- *                           - the property "command" with value "<webview>.<messagetype>"
- *                           - all other properties defined in the function.
+ * - (args) => string: A telemetry event will be emitted containing the property "command" with value "<webview>.<returnValue>"
+ *                     where `returnValue` is the command name returned from the specified function.
  */
 export type TelemetryDefinition<T extends ContentId> = {
-    [P in keyof ToVsCodeMsgDef<T>]: ((args: ToVsCodeMsgDef<T>[P]) => { [key: string]: string }) | boolean;
+    [P in keyof ToVsCodeMsgDef<T>]: ((args: ToVsCodeMsgDef<T>[P]) => string) | boolean;
 };

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -63,3 +63,7 @@ export type ToWebviewMessage<T extends ContentId> = Message<ToWebviewMsgDef<T>>;
 
 export type VsCodeMessageContext<T extends ContentId> = MessageContext<ToWebviewMsgDef<T>, ToVsCodeMsgDef<T>>;
 export type WebviewMessageContext<T extends ContentId> = MessageContext<ToVsCodeMsgDef<T>, ToWebviewMsgDef<T>>;
+
+export type TelemetryDefinition<T extends ContentId> = {
+    [P in keyof ToVsCodeMsgDef<T>]: ((args: ToVsCodeMsgDef<T>[P]) => { [key: string]: string }) | boolean;
+};

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -64,6 +64,15 @@ export type ToWebviewMessage<T extends ContentId> = Message<ToWebviewMsgDef<T>>;
 export type VsCodeMessageContext<T extends ContentId> = MessageContext<ToWebviewMsgDef<T>, ToVsCodeMsgDef<T>>;
 export type WebviewMessageContext<T extends ContentId> = MessageContext<ToVsCodeMsgDef<T>, ToWebviewMsgDef<T>>;
 
+/**
+ * A type for definining what telemetry (if any) will be emitted for each message passed from a webview to VS Code.
+ * Possible values are:
+ * - false: No telemetry will be emitted
+ * - true: A telemetry event will be emitted containing the property "command" with value "<webview>.<messagetype>"
+ * - (args) => {properties}: A telemetry event will be emitted containing:
+ *                           - the property "command" with value "<webview>.<messagetype>"
+ *                           - all other properties defined in the function.
+ */
 export type TelemetryDefinition<T extends ContentId> = {
     [P in keyof ToVsCodeMsgDef<T>]: ((args: ToVsCodeMsgDef<T>[P]) => { [key: string]: string }) | boolean;
 };


### PR DESCRIPTION
Addresses #376 

~~We need further discussion about how best to structure the properties that we emit: @Tatsinnit, @qpetraroia, @hsubramanianaks so opening this as draft for now.~~

Some background:
- Commands from webviews are invoked by sending a message from the webview to VS Code.
- These messages are well-known and explicitly defined for each webview. For example, the `createCluster` webview uses three messages:
  - `getResourceGroupsRequest`
  - `getLocationsRequest`
  - `createClusterRequest`
- We probably **don't** want to emit telemetry for all of these events. In the above case we'd probably want an event for `createClusterRequest` only.
- We have some messages where the name itself is probably not sufficiently granular, and we'd need to extract some content from the message in order for the telemetry to be useful. This is the case for Inspektor Gadget commands, in which all we can tell from the message name is whether it was a 'streaming' or 'blocking' command. What we actually care about is the _category_ (e.g. `trace`, `snapshot`, `top`, etc.) and the _resource_ (`dns`, `tcp`, etc.).
- The changes here will allow us to define ~~which properties will be emitted~~ _custom command names_ for each message. See comment in `webviewTypes.ts`:
```
 * Possible values are:
 * - false: No telemetry will be emitted
 * - true: A telemetry event will be emitted containing the property "command" with value "<webview>.<messagetype>"
 * - (args) => string: A telemetry event will be emitted containing the property "command" with value "<webview>.<returnValue>"
 *                     where `returnValue` is the command name returned from the specified function.
```
- So, a `trace dns` Inspektor Gadget command will result in an event like:
```
EventName: "vscode-aks-tools/command"
Properties: {
   command: "gadget.streamTrace_trace_dns",
   ...commonProperties
}
```

**Earlier discussion below**:

I think the main thing that warrants further discussion is the structure of the properties. Do we want different property names that are specific to certain messages, or do we want a well-known property name, like `commandDetail`, which would squash all relevant properties into a single string, e.g. `commandDetail: "trace dns"`?

There are trade-offs here between maintenance and ease of querying, and I don't think the answer is obvious.

**EDIT**: Another option here is to _only_ allow the telemetry definition to override the `command` value, returning just a string, not an object. E.g. for the IG scenario, the definition could be something like:
```typescript
    startStreamingTraceRequest: (args) => `runCommand_${args.category}_${args.resource}`,
```
And the event would look like:
```
EventName: "vscode-aks-tools/command"
Properties: {
   command: "gadget.runCommand_trace_dns"
}
```
This would also save us doing _any_ GDPR classification.