### PR TITLE
Fix occasional error message that npm is missing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
             ],
-            "preLaunchTask": "npm: webpack"
+            "preLaunchTask": "webpack"
         },
         {
             "name": "Extension Tests",
@@ -32,7 +32,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/src/tests/**/*.js"
             ],
-            "preLaunchTask": "npm: test-compile"
+            "preLaunchTask": "test-compile"
         },
         {
             "name": "Webview UI",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,16 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "webpack",
+            "type": "npm",
+            "script": "webpack"
+        },
+        {
+            "label": "test-compile",
+            "type": "npm",
+            "script": "test-compile"
+        },
+        {
             "label": "dev:webview",
             "type": "npm",
             "script": "dev:webview",


### PR DESCRIPTION
I have been getting occasional errors launching debug profiles, that I can't reproduce reliably.

The error was `could not find the task "npm: webpack"`. Searching for that error, I found several _similar_ sounding problems, like [this](https://github.com/microsoft/vscode/issues/147193), but in all the examples I could see, the `preLaunchTask` value referred to an entry in `tasks.json`, which appears to be the recommended way to do it.

Creating this PR because making the change myself appeared to fix the issue I was getting, and it seems to be the "right" approach.