### PR TITLE
Update vscode-azext-utils package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@azure/storage-blob": "^12.17.0",
                 "@microsoft/microsoft-graph-client": "^3.0.7",
                 "@microsoft/vscode-azext-azureutils": "^2.0.2",
-                "@microsoft/vscode-azext-utils": "^2.1.3",
+                "@microsoft/vscode-azext-utils": "^2.1.4",
                 "@vscode/extension-telemetry": "^0.9.1",
                 "cross-fetch": "^4.0.0",
                 "decompress": "^4.2.1",
@@ -981,12 +981,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
-            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.4.tgz",
+            "integrity": "sha512-l9kbmyOtYHljNlelFM8BxPWNAvQeMeZoHHN+CoFBf6O6pzg/nxNt+abSikUnDInwA+BfPPqDpMwXpxw/FBMf0g==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.6.2",
+                "@vscode/extension-telemetry": "^0.9.0",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -997,60 +997,6 @@
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/1ds-core-js": {
-            "version": "3.2.15",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.15.tgz",
-            "integrity": "sha512-w/35jS80jVl+YBbL69BHg6iTHuIkmmnwSuy8LhfBHm8QDTQny2C73GdwUN8c00BqSClM1ldl2w2bQWW1aMJLTg==",
-            "dependencies": {
-                "@microsoft/applicationinsights-core-js": "2.8.16",
-                "@microsoft/applicationinsights-shims": "^2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.7"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/1ds-post-js": {
-            "version": "3.2.15",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.15.tgz",
-            "integrity": "sha512-SZQdaiLpoPelTFC0G1EVZXnuQxzqPdY3F6tcBHfnmQv+h8aJR3HAIiy65xI+p7u9m9LdV+8Mx5buE0s6NfXnQA==",
-            "dependencies": {
-                "@microsoft/1ds-core-js": "3.2.15",
-                "@microsoft/applicationinsights-shims": "^2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.7"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "2.8.16",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.16.tgz",
-            "integrity": "sha512-pO5rR6UuiPymiHFj8XxNXhQgBSTvyHWygf+gdEVDh0xpUXYFO99bZe0Ux0D0HqYqVkJrRfXzL1Ocru6+S0x53Q==",
-            "dependencies": {
-                "@microsoft/applicationinsights-shims": "2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.9"
-            },
-            "peerDependencies": {
-                "tslib": "*"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/applicationinsights-shims": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
-            "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/dynamicproto-js": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
-            "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
-        },
-        "node_modules/@microsoft/vscode-azext-utils/node_modules/@vscode/extension-telemetry": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-            "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
-            "dependencies": {
-                "@microsoft/1ds-core-js": "^3.2.3",
-                "@microsoft/1ds-post-js": "^3.2.3"
-            },
-            "engines": {
-                "vscode": "^1.60.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/escape-string-regexp": {
@@ -7795,12 +7741,12 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.3.tgz",
-            "integrity": "sha512-Qz5MHTupG4vDFmhXDNzjpoISVRtDhELECzuZKcRG90nVlZgdmCZ1uHh/AS4fPEf15UiA+woJ7RRvUpsZRjO/Xw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.4.tgz",
+            "integrity": "sha512-l9kbmyOtYHljNlelFM8BxPWNAvQeMeZoHHN+CoFBf6O6pzg/nxNt+abSikUnDInwA+BfPPqDpMwXpxw/FBMf0g==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.6.2",
+                "@vscode/extension-telemetry": "^0.9.0",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -7810,54 +7756,6 @@
                 "vscode-uri": "^3.0.6"
             },
             "dependencies": {
-                "@microsoft/1ds-core-js": {
-                    "version": "3.2.15",
-                    "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.15.tgz",
-                    "integrity": "sha512-w/35jS80jVl+YBbL69BHg6iTHuIkmmnwSuy8LhfBHm8QDTQny2C73GdwUN8c00BqSClM1ldl2w2bQWW1aMJLTg==",
-                    "requires": {
-                        "@microsoft/applicationinsights-core-js": "2.8.16",
-                        "@microsoft/applicationinsights-shims": "^2.0.2",
-                        "@microsoft/dynamicproto-js": "^1.1.7"
-                    }
-                },
-                "@microsoft/1ds-post-js": {
-                    "version": "3.2.15",
-                    "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.15.tgz",
-                    "integrity": "sha512-SZQdaiLpoPelTFC0G1EVZXnuQxzqPdY3F6tcBHfnmQv+h8aJR3HAIiy65xI+p7u9m9LdV+8Mx5buE0s6NfXnQA==",
-                    "requires": {
-                        "@microsoft/1ds-core-js": "3.2.15",
-                        "@microsoft/applicationinsights-shims": "^2.0.2",
-                        "@microsoft/dynamicproto-js": "^1.1.7"
-                    }
-                },
-                "@microsoft/applicationinsights-core-js": {
-                    "version": "2.8.16",
-                    "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.16.tgz",
-                    "integrity": "sha512-pO5rR6UuiPymiHFj8XxNXhQgBSTvyHWygf+gdEVDh0xpUXYFO99bZe0Ux0D0HqYqVkJrRfXzL1Ocru6+S0x53Q==",
-                    "requires": {
-                        "@microsoft/applicationinsights-shims": "2.0.2",
-                        "@microsoft/dynamicproto-js": "^1.1.9"
-                    }
-                },
-                "@microsoft/applicationinsights-shims": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
-                    "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
-                },
-                "@microsoft/dynamicproto-js": {
-                    "version": "1.1.9",
-                    "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
-                    "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
-                },
-                "@vscode/extension-telemetry": {
-                    "version": "0.6.2",
-                    "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-                    "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
-                    "requires": {
-                        "@microsoft/1ds-core-js": "^3.2.3",
-                        "@microsoft/1ds-post-js": "^3.2.3"
-                    }
-                },
                 "escape-string-regexp": {
                     "version": "2.0.0"
                 },

--- a/package.json
+++ b/package.json
@@ -471,7 +471,7 @@
         "@azure/storage-blob": "^12.17.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/vscode-azext-azureutils": "^2.0.2",
-        "@microsoft/vscode-azext-utils": "^2.1.3",
+        "@microsoft/vscode-azext-utils": "^2.1.4",
         "@vscode/extension-telemetry": "^0.9.1",
         "cross-fetch": "^4.0.0",
         "decompress": "^4.2.1",


### PR DESCRIPTION
We previously had to revert this in #374 because it depended on a newer telemetry library. Now we've updated our telemetry library, we can make this change.