### PR TITLE
Improve startup and refresh time for debugging extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
             ],
-            "preLaunchTask": "webpack"
+            "preLaunchTask": "webpack-dev"
         },
         {
             "name": "Extension Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,13 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "webpack-dev",
+            "type": "npm",
+            "script": "webpack-dev",
+            "problemMatcher": "$ts-webpack-watch",
+            "isBackground": true,
+        },
+        {
             "label": "webpack",
             "type": "npm",
             "script": "webpack"

--- a/package.json
+++ b/package.json
@@ -421,7 +421,7 @@
         "build:webview": "cd webview-ui && npm run build",
         "vscode:prepublish": "npm run webpack",
         "webpack": "npm run build:webview && webpack --mode production",
-        "webpack-dev": "webpack --mode development --watch --info-verbosity verbose",
+        "webpack-dev": "webpack --mode development --watch",
         "test-compile": "npm run build:webview && tsc -p ./",
         "watch": "tsc -watch -p ./",
         "test": "npm run test-compile && node ./out/src/tests/runTests.js"


### PR DESCRIPTION
Previously the `Extension` debug profile in `launch.json` ran all the production compilation and packaging steps for the `webview-ui` project and the main extension, _before_ launching a new VS Code window to execute the code being debugged. After making code changes, you would need to stop debugging and run the entire build over again.

This change runs webpack in `watch` mode when launching the `Extension` task, without pre-building the `webview-ui` project. This allows for much faster startup, and also means that the debugging session no longer needs to be stopped and restarted whenever a code change is saved (although the window still needs to be reloaded).

This is a trade-off. The drawback is that it's now the developer's responsibility to ensure the `webview-ui` project gets built (`npm run build:webview`) before/during their debugging session. In most circumstances that will already be the case, since it is still built when running `npm run webpack`, `vsce package`, or when debugging the `webview-ui` project.