### PR TITLE
Simplify webview dev task problem matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,29 +24,15 @@
             "label": "dev:webview",
             "type": "npm",
             "script": "dev:webview",
-            "problemMatcher": [
-                {
-                    "fileLocation": "absolute",
-                    "background": {
-                        "activeOnStart": true,
-                        "beginsPattern": "^(?:.* page reload |\\[TypeScript\\]).*",
-                        "endsPattern": "^.*\\[TypeScript\\].*"
-                    },
-                    "pattern": [
-                        {
-                            "regexp": "^ (ERROR|WARNING)\\(TypeScript\\)  (.*)",
-                            "severity": 1,
-                            "message": 2
-                        },
-                        {
-                            "regexp": "^ FILE  (.*):(\\d*):(\\d*)$",
-                            "file": 1,
-                            "line": 2,
-                            "column": 3
-                        }
-                    ]
+            "problemMatcher": {
+                "base": "$tsc-watch",
+                "fileLocation": "absolute",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^(?:.* page reload |\\[TypeScript\\]).*",
+                    "endsPattern": "^.*\\[TypeScript\\].*"
                 }
-            ],
+            },
             "isBackground": true,
             "presentation": {
                 "reveal": "never"

--- a/webview-ui/.eslintrc.cjs
+++ b/webview-ui/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaVersion: 2020,
-        project: "./tsconfig.json",
+        project: ["./tsconfig.json", "./tsconfig.node.json"],
         sourceType: "module",
         ecmaFeatures: {
             jsx: true,


### PR DESCRIPTION
Our problem matcher was previously duplicating much of the definition for the [`$tsc-watch` problem matcher](https://github.com/microsoft/vscode/blob/860d67064a9c1ef8ce0c8de35a78bea01033f76c/extensions/typescript-language-features/package.json#L1614-L1632).

This instead re-uses the common problem matcher, but overrides some settings (file location, and begin/end regexes for watching changes that are different because of the way `tsc` is invoked from `vite`).

There was also a linting error in the `vite.config.ts` file referenced in a secondary `tsconfig` file (`tsconfig.node.json`), because eslint was not aware of this second typescript project file. The second change here ensures that `eslint` is aware of both.