### PR TITLE
Make TreeItem implementation classes private

### DIFF
--- a/src/commands/aksClusterProperties/aksClusterProperties.ts
+++ b/src/commands/aksClusterProperties/aksClusterProperties.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterTreeItem, getContainerClient } from "../utils/clusters";
+import { getAksClusterTreeNode, getContainerClient } from "../utils/clusters";
 import { getExtension } from "../utils/host";
 import { failed } from "../utils/errorable";
 import { ClusterPropertiesDataProvider, ClusterPropertiesPanel } from "../../panels/ClusterPropertiesPanel";
@@ -9,9 +9,9 @@ import { ClusterPropertiesDataProvider, ClusterPropertiesPanel } from "../../pan
 export default async function aksClusterProperties(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
@@ -21,11 +21,11 @@ export default async function aksClusterProperties(_context: IActionContext, tar
         return;
     }
 
-    const client = getContainerClient(cluster.result);
+    const client = getContainerClient(clusterNode.result);
     const dataProvider = new ClusterPropertiesDataProvider(
         client,
-        cluster.result.resourceGroupName,
-        cluster.result.name,
+        clusterNode.result.resourceGroupName,
+        clusterNode.result.name,
     );
     const panel = new ClusterPropertiesPanel(extension.result.extensionUri);
 

--- a/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
+++ b/src/commands/aksCreateClusterNavToAzurePortal/aksCreateClusterNavToAzurePortal.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterSubscriptionItem } from "../utils/clusters";
+import { getAksClusterSubscriptionNode } from "../utils/clusters";
 import { failed } from "../utils/errorable";
 
 export default async function aksCreateClusterNavToAzurePortal(
@@ -10,9 +10,9 @@ export default async function aksCreateClusterNavToAzurePortal(
 ): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterSubscriptionItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
+    if (failed(subscriptionNode)) {
+        vscode.window.showErrorMessage(subscriptionNode.error);
         return;
     }
 

--- a/src/commands/aksDeleteCluster/aksDeleteCluster.ts
+++ b/src/commands/aksDeleteCluster/aksDeleteCluster.ts
@@ -1,20 +1,20 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { deleteCluster, getAksClusterTreeItem } from "../utils/clusters";
+import { deleteCluster, getAksClusterTreeNode } from "../utils/clusters";
 import { failed, succeeded } from "../utils/errorable";
 import { longRunning } from "../utils/host";
 
 export default async function aksDeleteCluster(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
-    const clusterName = cluster.result.name;
+    const clusterName = clusterNode.result.name;
 
     const answer = await vscode.window.showInformationMessage(
         `Do you want to delete cluster ${clusterName}?`,
@@ -24,7 +24,7 @@ export default async function aksDeleteCluster(_context: IActionContext, target:
 
     if (answer === "Yes") {
         const result = await longRunning(`Deleting cluster ${clusterName}.`, async () => {
-            return await deleteCluster(cluster.result, clusterName);
+            return await deleteCluster(clusterNode.result, clusterName);
         });
 
         if (failed(result)) {

--- a/src/commands/aksNavToPortal/aksNavToPortal.ts
+++ b/src/commands/aksNavToPortal/aksNavToPortal.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterTreeItem } from "../utils/clusters";
+import { getAksClusterTreeNode } from "../utils/clusters";
 import { getExtensionPath } from "../utils/host";
 import { failed } from "../utils/errorable";
 import { getPortalResourceUrl } from "../utils/env";
@@ -9,9 +9,9 @@ import { getPortalResourceUrl } from "../utils/env";
 export default async function aksNavToPortal(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
@@ -22,6 +22,6 @@ export default async function aksNavToPortal(_context: IActionContext, target: u
     }
 
     // armid is in the format: /subscriptions/<sub_id>/resourceGroups/<resource_group>/providers/<container_service>/managedClusters/<aks_clustername>
-    const resourceUrl = getPortalResourceUrl(cluster.result.subscription.environment, cluster.result.armId);
+    const resourceUrl = getPortalResourceUrl(clusterNode.result.subscription.environment, clusterNode.result.armId);
     vscode.env.openExternal(vscode.Uri.parse(resourceUrl));
 }

--- a/src/commands/aksReconcileCluster/aksReconcileCluster.ts
+++ b/src/commands/aksReconcileCluster/aksReconcileCluster.ts
@@ -1,20 +1,20 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { reconcileUsingUpdateInCluster, getAksClusterTreeItem } from "../utils/clusters";
+import { reconcileUsingUpdateInCluster, getAksClusterTreeNode } from "../utils/clusters";
 import { failed, succeeded } from "../utils/errorable";
 import { longRunning } from "../utils/host";
 
 export default async function aksReconcileCluster(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
-    const clusterName = cluster.result.name;
+    const clusterName = clusterNode.result.name;
 
     const answer = await vscode.window.showInformationMessage(
         `Do you want to reconcile/update operation on cluster ${clusterName}?`,
@@ -24,7 +24,7 @@ export default async function aksReconcileCluster(_context: IActionContext, targ
 
     if (answer === "Yes") {
         const result = await longRunning(`Reconciling/update last cluster operation in ${clusterName}.`, async () => {
-            return await reconcileUsingUpdateInCluster(cluster.result, clusterName);
+            return await reconcileUsingUpdateInCluster(clusterNode.result);
         });
 
         if (failed(result)) {

--- a/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
+++ b/src/commands/aksRotateClusterCert/aksRotateClusterCert.ts
@@ -1,20 +1,20 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterTreeItem, rotateClusterCert } from "../utils/clusters";
+import { getAksClusterTreeNode, rotateClusterCert } from "../utils/clusters";
 import { failed, succeeded } from "../utils/errorable";
 import { longRunning } from "../utils/host";
 
 export default async function aksRotateClusterCert(_context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
-    const clusterName = cluster.result.name;
+    const clusterName = clusterNode.result.name;
 
     const answer = await vscode.window.showInformationMessage(
         `Do you want to rotate cluster ${clusterName} certificate?`,
@@ -28,7 +28,7 @@ export default async function aksRotateClusterCert(_context: IActionContext, tar
 
     if (answer === "Yes") {
         const result = await longRunning(`Rotating cluster certificate for ${clusterName}.`, async () =>
-            rotateClusterCert(cluster.result, clusterName),
+            rotateClusterCert(clusterNode.result),
         );
 
         if (failed(result)) {

--- a/src/commands/aksStarterWorkflow/configureStarterWorkflow.ts
+++ b/src/commands/aksStarterWorkflow/configureStarterWorkflow.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterTreeItem } from "../utils/clusters";
+import { getAksClusterTreeNode } from "../utils/clusters";
 import { getWorkflowYaml, substituteClusterInWorkflowYaml } from "../utils/configureWorkflowHelper";
 import { failed } from "../utils/errorable";
 
@@ -24,9 +24,9 @@ export function configureKustomizeStarterWorkflow(_context: IActionContext, targ
 async function configureNamedStarterWorkflow(target: unknown, workflowName: string) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
-    const cluster = getAksClusterTreeItem(target, cloudExplorer);
-    if (failed(cluster)) {
-        vscode.window.showErrorMessage(cluster.error);
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
         return;
     }
 
@@ -39,8 +39,8 @@ async function configureNamedStarterWorkflow(target: unknown, workflowName: stri
 
     const substitutedYaml = substituteClusterInWorkflowYaml(
         starterWorkflowYaml.result,
-        cluster.result.armId.split("/")[4],
-        cluster.result.name,
+        clusterNode.result.resourceGroupName,
+        clusterNode.result.name,
     );
 
     // Display it to the end-user in their vscode editor.

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -8,7 +8,7 @@ import { MonitorClient, DiagnosticSettingsResourceCollection } from "@azure/arm-
 import * as path from "path";
 import * as fs from "fs";
 import * as semver from "semver";
-import AksClusterTreeItem from "../../../tree/aksClusterTreeItem";
+import { AksClusterTreeNode } from "../../../tree/aksClusterTreeItem";
 import * as tmpfile from "../../utils/tempfile";
 import { combine, Errorable, failed } from "../../utils/errorable";
 import { invokeKubectlCommand } from "../../utils/kubectl";
@@ -20,15 +20,15 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 import { dirSync } from "tmp";
 
 export async function getClusterDiagnosticSettings(
-    cluster: AksClusterTreeItem,
+    clusterNode: AksClusterTreeNode,
 ): Promise<DiagnosticSettingsResourceCollection | undefined> {
     try {
         // Get daignostic setting via diagnostic monitor
         const diagnosticMonitor = new MonitorClient(
-            cluster.subscription.credentials,
-            cluster.subscription.subscriptionId,
+            clusterNode.subscription.credentials,
+            clusterNode.subscription.subscriptionId,
         );
-        const diagnosticSettings = await diagnosticMonitor.diagnosticSettings.list(cluster.id!);
+        const diagnosticSettings = await diagnosticMonitor.diagnosticSettings.list(clusterNode.armId);
 
         return diagnosticSettings;
     } catch (e) {
@@ -82,7 +82,7 @@ export async function chooseStorageAccount(
 
 export async function getStorageInfo(
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    cluster: AksClusterTreeItem,
+    clusterNode: AksClusterTreeNode,
     diagnosticStorageAccountId: string,
     clusterKubeConfig: string,
 ): Promise<Errorable<PeriscopeStorage>> {
@@ -98,8 +98,8 @@ export async function getStorageInfo(
 
         // Get keys from storage client.
         const storageClient = new StorageManagementClient(
-            cluster.subscription.credentials,
-            cluster.subscription.subscriptionId,
+            clusterNode.subscription.credentials,
+            clusterNode.subscription.subscriptionId,
         );
         const storageAccKeyList = await storageClient.storageAccounts.listKeys(resourceGroupName, accountName);
         if (storageAccKeyList.keys === undefined) {

--- a/src/commands/refreshSubscriptions.ts
+++ b/src/commands/refreshSubscriptions.ts
@@ -1,18 +1,17 @@
 import * as k8s from "vscode-kubernetes-tools-api";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { getAksClusterSubscriptionItem } from "./utils/clusters";
+import { getAksClusterSubscriptionNode } from "./utils/clusters";
 import { failed } from "./utils/errorable";
 
 export default async function refreshSubscription(context: IActionContext, target: unknown): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
     if (cloudExplorer.available) {
-        const subscriptionItem = getAksClusterSubscriptionItem(target, cloudExplorer);
-        if (failed(subscriptionItem)) {
+        const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
+        if (failed(subscriptionNode)) {
             return;
         }
 
-        const subscriptionNode = subscriptionItem.result;
-        subscriptionNode.treeDataProvider.refresh(context, subscriptionNode.treeItem);
+        subscriptionNode.result.treeDataProvider.refresh(context, subscriptionNode.result.treeItem);
     }
 }

--- a/src/commands/utils/azureAccount.ts
+++ b/src/commands/utils/azureAccount.ts
@@ -199,7 +199,6 @@ async function getSubscriptionAccess(
     subscription: Subscription,
     spInfo: ServicePrincipalInfo,
 ): Promise<Errorable<SubscriptionAccessResult>> {
-
     if (!subscription.subscriptionId) {
         return { succeeded: true, result: { subscription, hasRoleAssignment: false } };
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
-import AksClusterTreeItem from "./tree/aksClusterTreeItem";
-import AzureAccountTreeItem from "./tree/azureAccountTreeItem";
+import { AksClusterTreeNode } from "./tree/aksClusterTreeItem";
+import { createAzureAccountTreeItem } from "./tree/azureAccountTreeItem";
 import {
     createAzExtOutputChannel,
     AzExtTreeDataProvider,
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await registerAzureServiceNodes(context);
 
-        const azureAccountTreeItem = new AzureAccountTreeItem();
+        const azureAccountTreeItem = createAzureAccountTreeItem();
         context.subscriptions.push(azureAccountTreeItem);
         const treeDataProvider = new AzExtTreeDataProvider(azureAccountTreeItem, "azureAks.loadMore");
 
@@ -130,17 +130,17 @@ export async function registerAzureServiceNodes(context: vscode.ExtensionContext
     clusterExplorer.api.registerNodeContributor(azureResourceNodeContributor);
 }
 
-async function getClusterKubeconfig(target: AksClusterTreeItem): Promise<string | undefined> {
-    const properties = await longRunning(`Getting properties for cluster ${target.name}.`, () =>
-        getClusterProperties(target),
+async function getClusterKubeconfig(treeNode: AksClusterTreeNode): Promise<string | undefined> {
+    const properties = await longRunning(`Getting properties for cluster ${treeNode.name}.`, () =>
+        getClusterProperties(treeNode),
     );
     if (failed(properties)) {
         vscode.window.showErrorMessage(properties.error);
         return undefined;
     }
 
-    const kubeconfig = await longRunning(`Retrieving kubeconfig for cluster ${target.name}.`, () =>
-        getKubeconfigYaml(target, properties.result),
+    const kubeconfig = await longRunning(`Retrieving kubeconfig for cluster ${treeNode.name}.`, () =>
+        getKubeconfigYaml(treeNode, properties.result),
     );
     if (failed(kubeconfig)) {
         vscode.window.showErrorMessage(kubeconfig.error);

--- a/src/tree/azureAccountTreeItem.ts
+++ b/src/tree/azureAccountTreeItem.ts
@@ -1,11 +1,15 @@
 import { ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { AzureAccountTreeItemBase, SubscriptionTreeItemBase } from "@microsoft/vscode-azext-azureutils";
-import SubscriptionTreeItem from "./subscriptionTreeItem";
+import { createChildSubscriptionTreeItem } from "./subscriptionTreeItem";
 import * as k8s from "vscode-kubernetes-tools-api";
 
-export default class AzureAccountTreeItem extends AzureAccountTreeItemBase {
-    public createSubscriptionTreeItem(root: ISubscriptionContext): SubscriptionTreeItemBase {
-        return new SubscriptionTreeItem(this, root);
+export function createAzureAccountTreeItem(): AzureAccountTreeItemBase {
+    return new AzureAccountTreeItem();
+}
+
+class AzureAccountTreeItem extends AzureAccountTreeItemBase {
+    public createSubscriptionTreeItem(subscription: ISubscriptionContext): SubscriptionTreeItemBase {
+        return createChildSubscriptionTreeItem(this, subscription);
     }
 
     public async refreshImpl?(): Promise<void> {


### PR DESCRIPTION
We have three "tree item" implementation classes: `AzureAccountTreeItem`, `SubscriptionTreeItem` and `AksClusterTreeItem`.

These classes contain properties and functions that are specific to the VS Code treeview UI, including implementations for refreshing and loading child items that [the documentation says should not be called directly](https://github.com/Microsoft/vscode-azuretools/blob/main/utils/README.md#azure-extension-tree-data-provider). For this reason we should only be referring to these during the initial building of the Cloud Explorer treeview. For code invoked from commands we can instead use the corresponding interfaces: `SubscriptionTreeNode` and `AksClusterTreeNode`.

These changes made the `TreeItem` classes private (not `export`ed), and fixes consuming code to use the interfaces instead (along with corresponding variable/function naming updates). It also allowed for some simplification, e.g. being able to refer to the resource group directly instead of parsing it out of the ARM ID.