### PR TITLE
Refresh subscriptions after adding and deleting clusters

### DIFF
--- a/src/commands/aksCreateCluster/aksCreateCluster.ts
+++ b/src/commands/aksCreateCluster/aksCreateCluster.ts
@@ -34,6 +34,7 @@ export default async function aksCreateCluster(_context: IActionContext, target:
         resourceManagementClient,
         containerServiceClient,
         subscriptionNode.result.subscription,
+        () => vscode.commands.executeCommand("aks.refreshSubscription", target),
     );
 
     panel.show(dataProvider);

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -10,7 +10,7 @@ import { AksClusterTreeNode } from "../../tree/aksClusterTreeItem";
 import * as azcs from "@azure/arm-containerservice";
 import { Errorable, failed, getErrorMessage, succeeded } from "./errorable";
 import { ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
-import { SubscriptionTreeNode } from "../../tree/subscriptionTreeItem";
+import { SubscriptionTreeNode, isSubscriptionTreeNode } from "../../tree/subscriptionTreeItem";
 import { getAksAadAccessToken } from "./authProvider";
 import * as yaml from "js-yaml";
 import * as fs from "fs";
@@ -114,6 +114,10 @@ export function getAksClusterSubscriptionNode(
     commandTarget: unknown,
     cloudExplorer: API<CloudExplorerV1>,
 ): Errorable<SubscriptionTreeNode> {
+    if (isSubscriptionTreeNode(commandTarget)) {
+        return { succeeded: true, result: commandTarget };
+    }
+
     if (!cloudExplorer.available) {
         return { succeeded: false, error: "Cloud explorer is unavailable." };
     }

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -34,6 +34,7 @@ export class CreateClusterDataProvider implements PanelDataProvider<"createClust
         readonly resourceManagementClient: ResourceManagementClient,
         readonly containerServiceClient: ContainerServiceClient,
         readonly subscriptionContext: ISubscriptionContext,
+        readonly refreshTree: () => void,
     ) {}
 
     getTitle(): string {
@@ -141,6 +142,8 @@ export class CreateClusterDataProvider implements PanelDataProvider<"createClust
             this.resourceManagementClient,
             this.subscriptionContext,
         );
+
+        this.refreshTree();
     }
 }
 

--- a/src/tree/subscriptionTreeItem.ts
+++ b/src/tree/subscriptionTreeItem.ts
@@ -20,6 +20,10 @@ export interface SubscriptionTreeNode {
     readonly treeItem: AzExtTreeItem;
 }
 
+export function isSubscriptionTreeNode(node: unknown): node is SubscriptionTreeNode {
+    return node instanceof SubscriptionTreeItemBase;
+}
+
 export function createChildSubscriptionTreeItem(
     parent: AzureAccountTreeItemBase,
     subscription: ISubscriptionContext,


### PR DESCRIPTION
Programmatically refresh the Cloud Explorer treeview after adding and deleting clusters.

This builds on the command to refresh the clusters under a subscription in the treeview (#393), and makes use of the slightly more constrained interface for interacting with TreeView items (#406).