### PR TITLE
Fix for making instance when cluster name is same but RG are different.

### DIFF
--- a/src/tree/aksClusterTreeItem.ts
+++ b/src/tree/aksClusterTreeItem.ts
@@ -35,7 +35,7 @@ class AksClusterTreeItem extends AzExtTreeItem implements AksClusterTreeNode {
         super(parent);
 
         this.iconPath = assetUri("resources/aks-tools.png");
-        this.id = this.resource.name!;
+        this.id = `${this.resource.name!} ${parseResource(this.resource.id!).resourceGroupName!}`;
         this.armId = this.resource.id!;
         this.subscriptionTreeNode = parent;
     }


### PR DESCRIPTION
This Pull Request intend to fix the issue #441 with `AZTreeItem` object which is working within the `azext-utils` given earlier we were supplying `ClusterName` only as the unique identity I think it was filtering that as the duplicated hence the failure during the TreeNode Creation.

Below is the **before** and **after** of this issue after the fix, I played around, and ~~will share the `vsix` for quick play around~~. Here is the link for the `vsix` to test if this fixes the issue for you. (Please rename file after download this `zip` file and then rename to `vsix` and then try to install it manually. 

Here are help how to install:

- [Helpful guidance how to install vsix manually](https://code.visualstudio.com/docs/editor/extension-marketplace#_manage-extensions) OR [guidance 2 how to install manually in vscode](https://stackoverflow.com/questions/42017617/how-to-install-vs-code-extension-manually)

- **Actual VSIX** which fixes the issue (please download and remove *zip from this file before installation steps above) -> [vscode-aks-tools-1.4.0-uniquename-test1.vsix.zip](https://github.com/Azure/vscode-aks-tools/files/14031679/vscode-aks-tools-1.4.0-uniquename-test1.vsix.zip)


Thank you so much all. 

**Before**

![image](https://github.com/Azure/vscode-aks-tools/assets/6233295/5641881b-0202-4df1-8d5c-ce5e53c95f40)


**After**

![image](https://github.com/Azure/vscode-aks-tools/assets/6233295/0b6be89a-8f1a-4a62-8ac5-749b8e007f38)


