### PR TITLE
Publish release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.4.1]
+
+* Fix for making instance when cluster name is same but RG are different.
+* Changes in correlation with new GH Action Permission Changes.
+* Add badge for codeql and chai test fix.
+* Add codeql analysis for repo.
+* Add bestpractices progress and other badges.
+* Dependabot updates.
+
+Thank you so much @sprab for continued effort for testing changes for unique name fix and testing other feature, thanks @hsubramanianaks, @peterbom for reviews, collaboration. Thank you everyone who indirectly helped in building in any ideas for this release!
+
 ## [1.4.0]
 
 * Run Eraser Tool on AKS Cluster.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
Publishing version `1.4.1`, in this release we with add few key updates as described below. Thanks heaps @sprab for through testing in certain instances and cc: @sprab @peterbom and, @qpetraroia, @hsubramanianaks, ❤️🙏🎊🥷 fyi - @gambtho

Following fixes/feature/package updates will be going out with this release:

* Fix for making instance when cluster name is same but RG are different.
* Changes in correlation with new GH Action Permission Changes.
* Add badge for codeql and chai test fix.
* Add codeql analysis for repo.
* Add bestpractices progress and other badges.
* Dependabot updates.

Thanks heaps, for testing here is the vsix, (Please remove zip and the install in case anyone tests from here.)

[vscode-aks-tools-1.4.1-test copy.vsix.zip](https://github.com/Azure/vscode-aks-tools/files/14047595/vscode-aks-tools-1.4.1-test.copy.vsix.zip)
