### PR TITLE
Update types vscode version with engine.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "@types/semver": "^7.5.6",
                 "@types/sinon": "^17.0.3",
                 "@types/tmp": "^0.2.6",
-                "@types/vscode": "^1.82.0",
+                "@types/vscode": "^1.86.0",
                 "@typescript-eslint/eslint-plugin": "^6.20.0",
                 "@typescript-eslint/parser": "^6.20.0",
                 "@vscode/test-electron": "^2.3.9",
@@ -63,7 +63,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.82.0"
+                "vscode": "^1.86.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1370,9 +1370,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.84.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.1.tgz",
-            "integrity": "sha512-DB10vBRLEPA/us7p3gQilU2Tq5HDu6JWTyCpD9qtb7MKWIvJS5In9HU3YgVGCXf/miwHJiY62aXwjtUSMpT8HA==",
+            "version": "1.86.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
+            "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
             "dev": true
         },
         "node_modules/@types/yargs": {
@@ -8180,9 +8180,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.84.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.1.tgz",
-            "integrity": "sha512-DB10vBRLEPA/us7p3gQilU2Tq5HDu6JWTyCpD9qtb7MKWIvJS5In9HU3YgVGCXf/miwHJiY62aXwjtUSMpT8HA==",
+            "version": "1.86.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
+            "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
             "dev": true
         },
         "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",
     "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.86.0"
     },
     "capabilities": {
         "untrustedWorkspaces": {
@@ -466,7 +466,7 @@
         "@types/semver": "^7.5.6",
         "@types/sinon": "^17.0.3",
         "@types/tmp": "^0.2.6",
-        "@types/vscode": "^1.82.0",
+        "@types/vscode": "^1.86.0",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
         "@vscode/test-electron": "^2.3.9",


### PR DESCRIPTION
This PR takes care of the intent being PR #480 , and as you can see builds are all green with this change in the PR because `vscode engine` needed upgrade as well. 🙏☕️

kind fyi and cc to @peterbom, @hsubramanianaks Thanks heaps.