### PR TITLE
Group typescript-eslint dependencies together for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
   - package-ecosystem: "npm"
     directory: "/webview-ui"
     schedule:
       interval: "weekly"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Should prevent build errors like [this](https://github.com/Azure/vscode-aks-tools/actions/runs/7879702255/job/21501142275?pr=483)