### PR TITLE
Ensure file stream is closed after downloading

### DIFF
--- a/src/commands/utils/download/download.ts
+++ b/src/commands/utils/download/download.ts
@@ -75,6 +75,8 @@ async function download(url: string, outputFilepath: string): Promise<Errorable<
         }
     } catch (e) {
         return { succeeded: false, error: `Error downloading from ${url} to ${outputFilepath}: ${getErrorMessage(e)}` };
+    } finally {
+        fileStream.end();
     }
 
     return { succeeded: true, result: undefined };


### PR DESCRIPTION
I missed calling the `WriteStream.end()` function in #567 - this is added here to ensure the stream is flushed and closed before the file is accessed.