### PR TITLE
Handle new archive structure for IG in windows

### DIFF
--- a/src/commands/utils/helper/kubectlGadgetDownload.ts
+++ b/src/commands/utils/helper/kubectlGadgetDownload.ts
@@ -22,7 +22,7 @@ export async function getKubectlGadgetBinaryPath(): Promise<Errorable<string>> {
 
     const archiveFilename = getArchiveFilename(releaseTag);
     const downloadUrl = `https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${releaseTag}/${archiveFilename}`;
-    const pathToBinaryInArchive = getPathToBinaryInArchive();
+    const pathToBinaryInArchive = getBinaryFilename();
 
     // The plugin requires an '.exe' extension on Windows, but it doesn't have that in the archive
     // so we can't simply extract it from the path within the archive.
@@ -48,10 +48,6 @@ function getArchiveFilename(releaseTag: string) {
     }
 
     return `kubectl-gadget-${operatingSystem}-${architecture}-${releaseTag}.tar.gz`;
-}
-
-function getPathToBinaryInArchive() {
-    return "kubectl-gadget";
 }
 
 function getBinaryFilename() {


### PR DESCRIPTION
In the newer version of Inspektor Gadget which we're downloading, the archive file that gets downloaded contains a binary with a .exe extension on Windows (previously in v0.19.0 it had no extension). This caused the download/extract functionality to break.

This update recognises the newer archive structure.