### PR TITLE
Fix treeview stuck with only 'select tenant' node

### DIFF
--- a/src/commands/aksAccount/aksAccount.ts
+++ b/src/commands/aksAccount/aksAccount.ts
@@ -17,7 +17,16 @@ export async function selectTenant(): Promise<void> {
     }
 
     if (sessionProvider.availableTenants.length === 1) {
-        window.showInformationMessage(`Only one tenant available (${sessionProvider.availableTenants[0].name}).`);
+        sessionProvider.selectedTenant = sessionProvider.availableTenants[0];
+
+        // If this tenant wasn't previously selected, it was probably because it wasn't immediately
+        // accessible (the user's current token didn't have access to it). Calling getAuthSession
+        // will prompt the user to re-authenticate if necessary.
+        const sessionResult = await sessionProvider.getAuthSession();
+        if (failed(sessionResult)) {
+            window.showErrorMessage(sessionResult.error);
+        }
+
         return;
     }
 

--- a/src/tree/azureAccountTreeItem.ts
+++ b/src/tree/azureAccountTreeItem.ts
@@ -104,8 +104,8 @@ class AzureAccountTreeItem extends AzExtParentTreeItem {
                 ];
         }
 
-        if (this.sessionProvider.selectedTenant === null) {
-            // Signed in, but maybe no tenant selected
+        if (this.sessionProvider.selectedTenant === null && this.sessionProvider.availableTenants.length > 1) {
+            // Signed in, but no tenant selected, AND there is more than one tenant to choose from.
             return [
                 new GenericTreeItem(this, {
                     label: "Select tenant...",
@@ -118,8 +118,9 @@ class AzureAccountTreeItem extends AzExtParentTreeItem {
             ];
         }
 
-        // Check the session is ready and we can get an auth session
-        // (which will be used below for creating a subscription context).
+        // Either we have a selected tenant, or there is only one available tenant and it's not selected
+        // because it requires extra interaction. Calling `getAuthSession` will complete that process.
+        // We will need the returned auth session in any case for creating a subscription context.
         const session = await this.sessionProvider.getAuthSession();
         if (failed(session) || !isReady(this.sessionProvider)) {
             return [


### PR DESCRIPTION
Addresses #680 

This is just to fix the observed behaviour that:
1. The treeview can display a node saying 'select tenant' when in fact there's only one tenant to choose from; and
2. The 'select tenant' command currently doesn't do anything if there is only a single tenant to choose from.

There are some additional changes we can make to the session provider API that should make this kind of defect less likely. I'll address those in a separate issue and PR.