### PR TITLE
AzureSessionProvider changes

### DIFF
--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -17,13 +17,18 @@ export type Tenant = {
     id: string;
 };
 
+export type GetAuthSessionOptions = {
+    applicationClientId?: string;
+    scopes?: string[];
+};
+
 export type AzureSessionProvider = {
     signIn(): Promise<void>;
     signInStatus: SignInStatus;
     availableTenants: Tenant[];
     selectedTenant: Tenant | null;
     signInStatusChangeEvent: Event<SignInStatus>;
-    getAuthSession(): Promise<Errorable<AzureAuthenticationSession>>;
+    getAuthSession(options?: GetAuthSessionOptions): Promise<Errorable<AzureAuthenticationSession>>;
     dispose(): void;
 };
 


### PR DESCRIPTION
Minimal changes for #682:
- add options for getting session
- don't require active token for selected tenant

This helps prevent issues like #680 from arising in the future. It also makes the `AzureSessionProvider` interface more resistant to breakages by adding an `Options` parameter for session retrieval options that might grow in the future (e.g. to enable specifying extra graph API scopes or application client IDs).

Design decisions:
1. We will make no immediate attempt to adhere to the structure proposed [here](https://github.com/microsoft/vscode-azuretools/pull/1722).
2. There is no implicit extra meaning to the `selectedTenant` property that assumes the user would be able to silently obtain a token for that tenant.

~~Opening as a draft since those decisions are debatable.~~

EDIT: I discussed this further with @alexweininger (who authored the [Azure authentication extension](https://github.com/microsoft/vscode-azuretools/tree/main/auth)). Some notes:
- There are likely to be [further changes to the VS Code API](https://github.com/microsoft/vscode/issues/152399#issuecomment-2145828468) to better support the handling of multiple accounts and scopes. We agreed it's not worth making significant changes here until that API is finalized.
- Our `AzureSessionProvider` interface currently manages two separate concerns which should probably be distinct:
  1. Authentication state (by account/tenant)
  2. Tenant (and implicitly account) selection (i.e. what account/tenant the user is currently accessing).
  Longer term it would probably make sense to explicitly separate these out. But again, we should wait for further developments in the VS Code API first.