### PR TITLE
Add draft context menu commands and deprecate starter workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
             },
             {
                 "command": "aks.configureStarterWorkflow",
-                "title": "Starter Workflow"
+                "title": "Starter Workflow (deprecated)"
             },
             {
                 "command": "aks.aksCRUDDiagnostics",
@@ -230,15 +230,15 @@
             },
             {
                 "command": "aks.configureHelmStarterWorkflow",
-                "title": "Helm Workflow"
+                "title": "Helm Workflow (deprecated)"
             },
             {
                 "command": "aks.configureKomposeStarterWorkflow",
-                "title": "Kompose Workflow"
+                "title": "Kompose Workflow (deprecated)"
             },
             {
                 "command": "aks.configureKustomizeStarterWorkflow",
-                "title": "Kustomize Workflow"
+                "title": "Kustomize Workflow (deprecated)"
             },
             {
                 "command": "aks.draftDockerfile",
@@ -323,6 +323,16 @@
                     "when": "workspaceFolderCount >= 1"
                 }
             ],
+            "explorer/context": [
+                {
+                    "command": "aks.draftDockerfile",
+                    "when": "explorerResourceIsFolder"
+                },
+                {
+                    "command": "aks.draftDeployment",
+                    "when": "explorerResourceIsFolder"
+                }
+            ],
             "view/item/context": [
                 {
                     "command": "aks.selectSubscriptions",
@@ -362,6 +372,11 @@
                 {
                     "command": "aks.installAzureServiceOperator",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i || view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster$/i"
+                },
+                {
+                    "submenu": "aks.draftSubMenu",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && workspaceFolderCount >= 1",
+                    "group": "9@1"
                 },
                 {
                     "submenu": "aks.ghWorkflowSubMenu",
@@ -428,6 +443,16 @@
                     "group": "navigation"
                 }
             ],
+            "aks.draftSubMenu": [
+                {
+                    "command": "aks.draftDeployment",
+                    "group": "navigation"
+                },
+                {
+                    "command": "aks.draftWorkflow",
+                    "group": "navigation"
+                }
+            ],
             "aks.ghWorkflowSubMenu": [
                 {
                     "command": "aks.configureHelmStarterWorkflow",
@@ -481,8 +506,12 @@
                 "label": "Run AKS Diagnostics"
             },
             {
+                "id": "aks.draftSubMenu",
+                "label": "Draft"
+            },
+            {
                 "id": "aks.ghWorkflowSubMenu",
-                "label": "Create GitHub Workflow"
+                "label": "Create GitHub Workflow (deprecated)"
             },
             {
                 "id": "aks.managedClusterOperationSubMenu",

--- a/src/commands/draft/types.ts
+++ b/src/commands/draft/types.ts
@@ -5,6 +5,7 @@ import { InitialSelection as WorkflowInitialSelection } from "../../webview-cont
 export type DraftCommandParamsTypes = {
     "aks.draftDockerfile": {
         workspaceFolder?: WorkspaceFolder;
+        initialLocation?: string;
     };
     "aks.draftDeployment": {
         workspaceFolder?: WorkspaceFolder;

--- a/src/panels/draft/DraftDockerfilePanel.ts
+++ b/src/panels/draft/DraftDockerfilePanel.ts
@@ -31,6 +31,7 @@ export class DraftDockerfileDataProvider implements PanelDataProvider<"draftDock
     constructor(
         readonly workspaceFolder: WorkspaceFolder,
         readonly draftBinaryPath: string,
+        readonly initialLocation: string,
     ) {
         this.draftDirectory = path.dirname(draftBinaryPath);
     }
@@ -46,9 +47,9 @@ export class DraftDockerfileDataProvider implements PanelDataProvider<"draftDock
                 fullPath: this.workspaceFolder.uri.fsPath,
                 pathSeparator: path.sep,
             },
-            location: "",
+            location: this.initialLocation,
             supportedLanguages: getSupportedLanguages(),
-            existingFiles: getExistingFiles(this.workspaceFolder, ""),
+            existingFiles: getExistingFiles(this.workspaceFolder, this.initialLocation),
         };
     }
 


### PR DESCRIPTION
This adds context menu items for the Draft commands, both in the file system explorer and the cloud explorer tree views:

![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/0fef978d-a7d9-4405-8caf-21d7af0bde3a)
![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/6a668af5-a9da-44d8-a6b1-2b4047044621)

It also marks the starter workflow commands as deprecated:
![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/c94ce529-7794-4824-a74b-f37dc8f94cd7)
