### PR TITLE
Connect ACR to Cluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,6 +241,11 @@
                 "title": "Kustomize Workflow (deprecated)"
             },
             {
+                "command": "aks.connectAcrToCluster",
+                "title": "Connect ACR to Cluster",
+                "category": "AKS"
+            },
+            {
                 "command": "aks.draftDockerfile",
                 "title": "Create a Dockerfile",
                 "category": "Draft"
@@ -444,6 +449,10 @@
                 }
             ],
             "aks.draftSubMenu": [
+                {
+                    "command": "aks.connectAcrToCluster",
+                    "group": "navigation"
+                },
                 {
                     "command": "aks.draftDeployment",
                     "group": "navigation"

--- a/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
+++ b/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
@@ -1,0 +1,56 @@
+import { commands, window } from "vscode";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { getReadySessionProvider } from "../../auth/azureAuth";
+import { failed, succeeded } from "../utils/errorable";
+import { InitialSelection } from "../../webview-contract/webviewDefinitions/connectAcrToCluster";
+import { ConnectAcrToClusterDataProvider, ConnectAcrToClusterPanel } from "../../panels/ConnectAcrToClusterPanel";
+import { getExtension } from "../utils/host";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { getAksClusterTreeNode } from "../utils/clusters";
+
+export type ConnectAcrToClusterParams = {
+    initialSelection: InitialSelection;
+};
+
+export function launchConnectAcrToClusterCommand(params: ConnectAcrToClusterParams) {
+    commands.executeCommand("aks.connectAcrToCluster", params);
+}
+
+export async function connectAcrToCluster(_context: IActionContext, target: unknown): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+    const params = getConnectAcrToClusterParams(cloudExplorer, target);
+
+    const extension = getExtension();
+    if (failed(extension)) {
+        window.showErrorMessage(extension.error);
+        return;
+    }
+
+    const sessionProvider = await getReadySessionProvider();
+    if (failed(sessionProvider)) {
+        window.showErrorMessage(sessionProvider.error);
+        return;
+    }
+
+    const panel = new ConnectAcrToClusterPanel(extension.result.extensionUri);
+    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, params?.initialSelection || {});
+    panel.show(dataProvider);
+}
+
+function getConnectAcrToClusterParams(
+    cloudExplorer: k8s.API<k8s.CloudExplorerV1>,
+    params: unknown,
+): ConnectAcrToClusterParams {
+    const clusterNode = getAksClusterTreeNode(params, cloudExplorer);
+    if (succeeded(clusterNode)) {
+        return {
+            initialSelection: {
+                subscriptionId: clusterNode.result.subscriptionId,
+                clusterResourceGroup: clusterNode.result.resourceGroupName,
+                clusterName: clusterNode.result.name,
+            },
+        };
+    }
+
+    return params as ConnectAcrToClusterParams;
+}

--- a/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
+++ b/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
@@ -9,9 +9,13 @@ import * as k8s from "vscode-kubernetes-tools-api";
 import { getAksClusterTreeNode } from "../utils/clusters";
 
 export type ConnectAcrToClusterParams = {
-    initialSelection: InitialSelection;
+    initialSelection?: InitialSelection;
 };
 
+/**
+ * Allows the command to be invoked programmatically, in this case from the message handler
+ * of the 'Draft Workflow' webview.
+ */
 export function launchConnectAcrToClusterCommand(params: ConnectAcrToClusterParams) {
     commands.executeCommand("aks.connectAcrToCluster", params);
 }
@@ -32,8 +36,11 @@ export async function connectAcrToCluster(_context: IActionContext, target: unkn
         return;
     }
 
+    // Explicitly pass empty initialSelection if not defined.
+    const initialSelection = params?.initialSelection || {};
+
     const panel = new ConnectAcrToClusterPanel(extension.result.extensionUri);
-    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, params?.initialSelection || {});
+    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, initialSelection);
     panel.show(dataProvider);
 }
 

--- a/src/commands/utils/arm.ts
+++ b/src/commands/utils/arm.ts
@@ -9,6 +9,7 @@ import { StorageManagementClient } from "@azure/arm-storage";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { ContainerRegistryManagementClient } from "@azure/arm-containerregistry";
 import { ContainerRegistryClient } from "@azure/container-registry";
+import { AuthorizationManagementClient } from "@azure/arm-authorization";
 
 export function getSubscriptionClient(sessionProvider: ReadyAzureSessionProvider): SubscriptionClient {
     return new SubscriptionClient(getCredential(sessionProvider), { endpoint: getArmEndpoint() });
@@ -54,6 +55,15 @@ export function getAcrClient(
 ): ContainerRegistryClient {
     // Endpoint should be in the form of "https://myregistryname.azurecr.io"
     return new ContainerRegistryClient(`https://${registryLoginServer}`, getCredential(sessionProvider));
+}
+
+export function getAuthorizationManagementClient(
+    sessionProvider: ReadyAzureSessionProvider,
+    subscriptionId: string,
+): AuthorizationManagementClient {
+    return new AuthorizationManagementClient(getCredential(sessionProvider), subscriptionId, {
+        endpoint: getArmEndpoint(),
+    });
 }
 
 function getArmEndpoint(): string {

--- a/src/commands/utils/roleAssignments.ts
+++ b/src/commands/utils/roleAssignments.ts
@@ -40,22 +40,29 @@ export function getPrincipalRoleAssignmentsForCluster(
 }
 
 export function getScopeForAcr(subscriptionId: string, resourceGroup: string, acrName: string): string {
+    // ARM resource ID for ACR
     return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerRegistry/registries/${acrName}`;
 }
 
 export function getScopeForCluster(subscriptionId: string, resourceGroup: string, clusterName: string): string {
+    // ARM resource ID for AKS cluster
     return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${clusterName}`;
 }
+
+// There are several permitted principal types, see: https://learn.microsoft.com/en-us/rest/api/authorization/role-assignments/create?view=rest-authorization-2022-04-01&tabs=HTTP#principaltype
+// For now, 'ServicePrincipal' and 'User' are the ones we're most likely to use here,
+// but we can add more as needed.
+export type PrincipalType = "ServicePrincipal" | "User";
 
 export async function createRoleAssignment(
     client: AuthorizationManagementClient,
     subscriptionId: string,
     principalId: string,
     roleDefinitionName: string,
-    principalType: "ServicePrincipal" | "User",
+    principalType: PrincipalType,
     scope: string,
 ): Promise<Errorable<RoleAssignment>> {
-    const newRoleAssignmentName = uuidv4();
+    const newRoleAssignmentName = createRoleAssignmentName();
     const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
 
     const newRoleAssignment: RoleAssignmentCreateParameters = {
@@ -87,6 +94,7 @@ export async function deleteRoleAssignment(
 
     const roleAssignments = await listAll(client.roleAssignments.listForScope(scope));
     if (failed(roleAssignments)) {
+        // Returning the inner error propagates it up the call chain.
         return roleAssignments;
     }
 
@@ -110,7 +118,9 @@ export async function deleteRoleAssignment(
     }
 }
 
-function uuidv4(): string {
+function createRoleAssignmentName(): string {
+    // https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments#name
+    // "A role assignment's resource name must be a globally unique identifier"
     // https://stackoverflow.com/a/2117523
     return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
         (+c ^ (getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),

--- a/src/commands/utils/roleAssignments.ts
+++ b/src/commands/utils/roleAssignments.ts
@@ -1,0 +1,118 @@
+import {
+    AuthorizationManagementClient,
+    RoleAssignment,
+    RoleAssignmentCreateParameters,
+} from "@azure/arm-authorization";
+import { getRandomValues } from "crypto";
+import { Errorable, failed, getErrorMessage } from "./errorable";
+import { listAll } from "./arm";
+
+export function getPrincipalRoleAssignmentsForAcr(
+    client: AuthorizationManagementClient,
+    principalId: string,
+    acrResourceGroup: string,
+    acrName: string,
+): Promise<Errorable<RoleAssignment[]>> {
+    return listAll(
+        client.roleAssignments.listForResource(acrResourceGroup, "Microsoft.ContainerRegistry", "registries", acrName, {
+            filter: `principalId eq '${principalId}'`,
+        }),
+    );
+}
+
+export function getPrincipalRoleAssignmentsForCluster(
+    client: AuthorizationManagementClient,
+    principalId: string,
+    clusterResourceGroup: string,
+    clusterName: string,
+): Promise<Errorable<RoleAssignment[]>> {
+    return listAll(
+        client.roleAssignments.listForResource(
+            clusterResourceGroup,
+            "Microsoft.ContainerService",
+            "managedClusters",
+            clusterName,
+            {
+                filter: `principalId eq '${principalId}'`,
+            },
+        ),
+    );
+}
+
+export function getScopeForAcr(subscriptionId: string, resourceGroup: string, acrName: string): string {
+    return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerRegistry/registries/${acrName}`;
+}
+
+export function getScopeForCluster(subscriptionId: string, resourceGroup: string, clusterName: string): string {
+    return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${clusterName}`;
+}
+
+export async function createRoleAssignment(
+    client: AuthorizationManagementClient,
+    subscriptionId: string,
+    principalId: string,
+    roleDefinitionName: string,
+    principalType: "ServicePrincipal" | "User",
+    scope: string,
+): Promise<Errorable<RoleAssignment>> {
+    const newRoleAssignmentName = uuidv4();
+    const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
+
+    const newRoleAssignment: RoleAssignmentCreateParameters = {
+        principalId,
+        roleDefinitionId,
+        principalType,
+    };
+
+    try {
+        const roleAssignment: RoleAssignment = await client.roleAssignments.create(
+            scope,
+            newRoleAssignmentName,
+            newRoleAssignment,
+        );
+        return { succeeded: true, result: roleAssignment };
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
+}
+
+export async function deleteRoleAssignment(
+    client: AuthorizationManagementClient,
+    subscriptionId: string,
+    principalId: string,
+    roleDefinitionName: string,
+    scope: string,
+): Promise<Errorable<void>> {
+    const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
+
+    const roleAssignments = await listAll(client.roleAssignments.listForScope(scope));
+    if (failed(roleAssignments)) {
+        return roleAssignments;
+    }
+
+    const roleAssignment = roleAssignments.result.find(
+        (ra) => ra.principalId === principalId && ra.roleDefinitionId === roleDefinitionId,
+    );
+
+    if (!roleAssignment) {
+        return { succeeded: true, result: undefined };
+    }
+
+    if (!roleAssignment.id) {
+        return { succeeded: false, error: "Role assignment has no ID" };
+    }
+
+    try {
+        await client.roleAssignments.deleteById(roleAssignment.id);
+        return { succeeded: true, result: undefined };
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
+}
+
+function uuidv4(): string {
+    // https://stackoverflow.com/a/2117523
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+        (+c ^ (getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),
+    );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { Reporter, reporter } from "./commands/utils/reporter";
 import installAzureServiceOperator from "./commands/azureServiceOperators/installAzureServiceOperator";
 import { AzureResourceNodeContributor } from "./tree/azureResourceNodeContributor";
 import { setAssetContext } from "./assets";
+import { connectAcrToCluster } from "./commands/aksConnectAcrToCluster/connectAcrToCluster";
 import {
     configureStarterWorkflow,
     configureHelmStarterWorkflow,
@@ -86,6 +87,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.configureHelmStarterWorkflow", configureHelmStarterWorkflow);
         registerCommandWithTelemetry("aks.configureKomposeStarterWorkflow", configureKomposeStarterWorkflow);
         registerCommandWithTelemetry("aks.configureKustomizeStarterWorkflow", configureKustomizeStarterWorkflow);
+        registerCommandWithTelemetry("aks.connectAcrToCluster", connectAcrToCluster);
         registerCommandWithTelemetry("aks.draftDockerfile", draftDockerfile);
         registerCommandWithTelemetry("aks.draftDeployment", draftDeployment);
         registerCommandWithTelemetry("aks.draftWorkflow", draftWorkflow);

--- a/src/panels/ConnectAcrToClusterPanel.ts
+++ b/src/panels/ConnectAcrToClusterPanel.ts
@@ -1,0 +1,309 @@
+import { Uri, window } from "vscode";
+import { BasePanel, PanelDataProvider } from "./BasePanel";
+import { MessageHandler, MessageSink } from "../webview-contract/messaging";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
+import { ReadyAzureSessionProvider } from "../auth/types";
+import {
+    AcrKey,
+    ClusterKey,
+    InitialSelection,
+    InitialState,
+    Subscription,
+    SubscriptionKey,
+    ToVsCodeMsgDef,
+    ToWebViewMsgDef,
+    acrPullRoleDefinitionName,
+} from "../webview-contract/webviewDefinitions/connectAcrToCluster";
+import { Errorable, failed, getErrorMessage } from "../commands/utils/errorable";
+import { SelectionType, getSubscriptions } from "../commands/utils/subscriptions";
+import { getResources } from "../commands/utils/azureResources";
+import { getAuthorizationManagementClient } from "../commands/utils/arm";
+import { RoleAssignment } from "@azure/arm-authorization";
+import {
+    createRoleAssignment,
+    deleteRoleAssignment,
+    getPrincipalRoleAssignmentsForAcr,
+    getScopeForAcr,
+} from "../commands/utils/roleAssignments";
+import { getManagedCluster } from "../commands/utils/clusters";
+
+export class ConnectAcrToClusterPanel extends BasePanel<"connectAcrToCluster"> {
+    constructor(extensionUri: Uri) {
+        super(extensionUri, "connectAcrToCluster", {
+            // Reference data responses
+            getSubscriptionsResponse: null,
+            getAcrsResponse: null,
+            getClustersResponse: null,
+
+            // Azure resource role assignment responses
+            getAcrRoleAssignmentResponse: null,
+            createAcrRoleAssignmentResponse: null,
+            deleteAcrRoleAssignmentResponse: null,
+        });
+    }
+}
+
+export class ConnectAcrToClusterDataProvider implements PanelDataProvider<"connectAcrToCluster"> {
+    constructor(
+        readonly sessionProvider: ReadyAzureSessionProvider,
+        readonly initialSelection: InitialSelection,
+    ) {}
+
+    getTitle(): string {
+        return "Connect ACR to Cluster";
+    }
+
+    getInitialState(): InitialState {
+        return {
+            initialSelection: this.initialSelection,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"connectAcrToCluster"> {
+        return {
+            // Reference data requests
+            getSubscriptionsRequest: false,
+            getAcrsRequest: false,
+            getClustersRequest: false,
+
+            // Azure resource role assignment requests
+            getAcrRoleAssignmentRequest: false,
+            createAcrRoleAssignmentRequest: true,
+            deleteAcrRoleAssignmentRequest: true,
+        };
+    }
+
+    getMessageHandler(webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {
+        return {
+            // Reference data requests
+            getSubscriptionsRequest: () => this.handleGetSubscriptionsRequest(webview),
+            getAcrsRequest: (args) => this.handleGetAcrsRequest(args, webview),
+            getClustersRequest: (args) => this.handleGetClustersRequest(args, webview),
+
+            // Azure resource role assignment requests
+            getAcrRoleAssignmentRequest: (args) =>
+                this.handleGetAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+            createAcrRoleAssignmentRequest: (args) =>
+                this.handleCreateAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+            deleteAcrRoleAssignmentRequest: (args) =>
+                this.handleDeleteAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+        };
+    }
+
+    private async handleGetSubscriptionsRequest(webview: MessageSink<ToWebViewMsgDef>) {
+        const azureSubscriptionsResult = await getSubscriptions(this.sessionProvider, SelectionType.AllIfNoFilters);
+        const azureSubscriptions = defaultAndNotify(azureSubscriptionsResult, []);
+
+        const subscriptions: Subscription[] = azureSubscriptions.map((subscription) => ({
+            subscriptionId: subscription.subscriptionId,
+            name: subscription.displayName,
+        }));
+
+        webview.postGetSubscriptionsResponse({ subscriptions });
+    }
+
+    private async handleGetAcrsRequest(key: SubscriptionKey, webview: MessageSink<ToWebViewMsgDef>) {
+        const sourceAcrsResult = await getResources(
+            this.sessionProvider,
+            key.subscriptionId,
+            "Microsoft.ContainerRegistry/registries",
+        );
+        const sourceAcrs = defaultAndNotify(sourceAcrsResult, []);
+
+        const acrs: AcrKey[] = sourceAcrs
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((acr) => ({
+                subscriptionId: key.subscriptionId,
+                resourceGroup: acr.resourceGroup,
+                acrName: acr.name,
+            }));
+
+        webview.postGetAcrsResponse({ key, acrs });
+    }
+
+    private async handleGetClustersRequest(key: SubscriptionKey, webview: MessageSink<ToWebViewMsgDef>) {
+        const sourceClustersResult = await getResources(
+            this.sessionProvider,
+            key.subscriptionId,
+            "Microsoft.ContainerService/managedClusters",
+        );
+        const sourceClusters = defaultAndNotify(sourceClustersResult, []);
+
+        const clusters: ClusterKey[] = sourceClusters
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((acr) => ({
+                subscriptionId: key.subscriptionId,
+                resourceGroup: acr.resourceGroup,
+                clusterName: acr.name,
+            }));
+
+        webview.postGetClustersResponse({ key, clusters });
+    }
+
+    private async handleGetAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postGetAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+
+    private async handleCreateAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const scope = getScopeForAcr(acrKey.subscriptionId, acrKey.resourceGroup, acrKey.acrName);
+
+        const roleAssignment = await createRoleAssignment(
+            client,
+            acrKey.subscriptionId,
+            principalId.result,
+            acrPullRoleDefinitionName,
+            "ServicePrincipal",
+            scope,
+        );
+
+        if (failed(roleAssignment)) {
+            window.showErrorMessage(roleAssignment.error);
+        }
+
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postCreateAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+
+    private async handleDeleteAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const scope = getScopeForAcr(acrKey.subscriptionId, acrKey.resourceGroup, acrKey.acrName);
+        await deleteRoleAssignment(client, acrKey.subscriptionId, principalId.result, acrPullRoleDefinitionName, scope);
+
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postDeleteAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+}
+
+function isAcrPull(roleAssignment: RoleAssignment): boolean {
+    if (!roleAssignment.roleDefinitionId) {
+        return false;
+    }
+
+    const roleDefinitionName = roleAssignment.roleDefinitionId.split("/").pop();
+    return roleDefinitionName === acrPullRoleDefinitionName;
+}
+
+async function getClusterPrincipalId(
+    sessionProvider: ReadyAzureSessionProvider,
+    clusterKey: ClusterKey,
+): Promise<Errorable<string>> {
+    const cluster = await getManagedCluster(
+        sessionProvider,
+        clusterKey.subscriptionId,
+        clusterKey.resourceGroup,
+        clusterKey.clusterName,
+    );
+    if (failed(cluster)) {
+        return cluster;
+    }
+
+    const hasManagedIdentity =
+        cluster.result.identity?.type === "SystemAssigned" || cluster.result.identity?.type === "UserAssigned";
+    if (hasManagedIdentity) {
+        if (
+            cluster.result.identityProfile &&
+            "kubeletidentity" in cluster.result.identityProfile &&
+            cluster.result.identityProfile.kubeletidentity.objectId
+        ) {
+            return {
+                succeeded: true,
+                result: cluster.result.identityProfile.kubeletidentity.objectId,
+            };
+        }
+
+        return {
+            succeeded: false,
+            error: "Cluster has managed identity but no kubelet identity",
+        };
+    }
+
+    const servicePrincipalId = cluster.result.servicePrincipalProfile?.clientId;
+    if (servicePrincipalId) {
+        return {
+            succeeded: true,
+            result: servicePrincipalId,
+        };
+    }
+
+    return {
+        succeeded: false,
+        error: "Cluster has no managed identity or service principal",
+    };
+}
+
+function defaultAndNotify<T>(value: Errorable<T>, defaultValue: T): T {
+    if (failed(value)) {
+        window.showErrorMessage(value.error);
+        return defaultValue;
+    }
+    return value.result;
+}

--- a/src/panels/draft/DraftWorkflowPanel.ts
+++ b/src/panels/draft/DraftWorkflowPanel.ts
@@ -4,6 +4,7 @@ import { BasePanel, PanelDataProvider } from "../BasePanel";
 import {
     ExistingFile,
     InitialState,
+    LaunchConnectAcrToClusterParams,
     PickFilesIdentifier,
     ToVsCodeMsgDef,
     ToWebViewMsgDef,
@@ -31,6 +32,10 @@ import { getAcrRegistry, getRepositories } from "../../commands/utils/acrs";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { getResources } from "../../commands/utils/azureResources";
 import { launchDraftCommand } from "./commandUtils";
+import {
+    ConnectAcrToClusterParams,
+    launchConnectAcrToClusterCommand,
+} from "../../commands/aksConnectAcrToCluster/connectAcrToCluster";
 
 export class DraftWorkflowPanel extends BasePanel<"draftWorkflow"> {
     constructor(extensionUri: Uri) {
@@ -96,6 +101,7 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
             openFileRequest: false,
             launchDraftDockerfile: false,
             launchDraftDeployment: false,
+            launchConnectAcrToCluster: false,
         };
     }
 
@@ -120,6 +126,7 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
                 launchDraftCommand("aks.draftDeployment", {
                     workspaceFolder: this.workspaceFolder,
                 }),
+            launchConnectAcrToCluster: (params) => this.handleLaunchConnectAcrToCluster(params),
         };
     }
 
@@ -314,6 +321,20 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
     private handleOpenFileRequest(relativeFilePath: string) {
         const filePath = path.join(this.workspaceFolder.uri.fsPath, relativeFilePath);
         window.showTextDocument(Uri.file(filePath));
+    }
+
+    private handleLaunchConnectAcrToCluster(params: LaunchConnectAcrToClusterParams) {
+        const commandParams: ConnectAcrToClusterParams = {
+            initialSelection: {
+                subscriptionId: params.initialSubscriptionId || undefined,
+                acrResourceGroup: params.initialAcrResourceGroup || undefined,
+                acrName: params.initialAcrName || undefined,
+                clusterResourceGroup: params.initialClusterResourceGroup || undefined,
+                clusterName: params.initialClusterName || undefined,
+            },
+        };
+
+        launchConnectAcrToClusterCommand(commandParams);
     }
 }
 

--- a/src/webview-contract/webviewDefinitions/connectAcrToCluster.ts
+++ b/src/webview-contract/webviewDefinitions/connectAcrToCluster.ts
@@ -1,0 +1,93 @@
+import { WebviewDefinition } from "../webviewTypes";
+
+export type SubscriptionKey = {
+    subscriptionId: string;
+};
+
+export type Subscription = SubscriptionKey & {
+    name: string;
+};
+
+export type AcrKey = SubscriptionKey & {
+    resourceGroup: string;
+    acrName: string;
+};
+
+export type Acr = AcrKey; // Fully-defined by its key
+
+export type ClusterKey = SubscriptionKey & {
+    resourceGroup: string;
+    clusterName: string;
+};
+
+export type Cluster = ClusterKey; // Fully-defined by its key
+
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+export const acrPullRoleDefinitionName = "7f951dda-4ed3-4680-a7ca-43fe172d538d";
+
+export type InitialSelection = {
+    subscriptionId?: string;
+    acrResourceGroup?: string;
+    acrName?: string;
+    clusterResourceGroup?: string;
+    clusterName?: string;
+};
+
+export interface InitialState {
+    initialSelection: InitialSelection;
+}
+
+export type ToVsCodeMsgDef = {
+    // Reference data requests
+    getSubscriptionsRequest: void;
+    getAcrsRequest: SubscriptionKey;
+    getClustersRequest: SubscriptionKey;
+
+    // Azure resource role assignment requests
+    getAcrRoleAssignmentRequest: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+    };
+    createAcrRoleAssignmentRequest: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+    };
+    deleteAcrRoleAssignmentRequest: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+    };
+};
+
+export type ToWebViewMsgDef = {
+    // Reference data responses
+    getSubscriptionsResponse: {
+        subscriptions: Subscription[];
+    };
+    getAcrsResponse: {
+        key: SubscriptionKey;
+        acrs: Acr[];
+    };
+    getClustersResponse: {
+        key: SubscriptionKey;
+        clusters: Cluster[];
+    };
+
+    // Azure resource role assignment responses
+    getAcrRoleAssignmentResponse: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+        hasAcrPull: boolean;
+    };
+    createAcrRoleAssignmentResponse: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+        hasAcrPull: boolean;
+    };
+    deleteAcrRoleAssignmentResponse: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+        hasAcrPull: boolean;
+    };
+};
+
+export type ConnectAcrToClusterDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewDefinitions/draft/draftWorkflow.ts
+++ b/src/webview-contract/webviewDefinitions/draft/draftWorkflow.ts
@@ -69,6 +69,15 @@ export type ToVsCodeMsgDef = {
     openFileRequest: string;
     launchDraftDockerfile: void;
     launchDraftDeployment: void;
+    launchConnectAcrToCluster: LaunchConnectAcrToClusterParams;
+};
+
+export type LaunchConnectAcrToClusterParams = {
+    initialSubscriptionId: string | null;
+    initialAcrResourceGroup: string | null;
+    initialAcrName: string | null;
+    initialClusterResourceGroup: string | null;
+    initialClusterName: string | null;
 };
 
 export type ToWebViewMsgDef = {

--- a/src/webview-contract/webviewTypes.ts
+++ b/src/webview-contract/webviewTypes.ts
@@ -1,5 +1,6 @@
 import { Message, MessageContext, MessageDefinition, MessageHandler, MessageSink } from "./messaging";
 import { ClusterPropertiesDefinition } from "./webviewDefinitions/clusterProperties";
+import { ConnectAcrToClusterDefinition } from "./webviewDefinitions/connectAcrToCluster";
 import { CreateClusterDefinition } from "./webviewDefinitions/createCluster";
 import { DetectorDefinition } from "./webviewDefinitions/detector";
 import { DraftDeploymentDefinition } from "./webviewDefinitions/draft/draftDeployment";
@@ -33,6 +34,7 @@ export type WebviewDefinition<
 type AllWebviewDefinitions = {
     style: TestStyleViewerDefinition;
     clusterProperties: ClusterPropertiesDefinition;
+    connectAcrToCluster: ConnectAcrToClusterDefinition;
     periscope: PeriscopeDefinition;
     createCluster: CreateClusterDefinition;
     detector: DetectorDefinition;

--- a/webview-ui/src/ConnectAcrToCluster/ConnectAcrToCluster.module.css
+++ b/webview-ui/src/ConnectAcrToCluster/ConnectAcrToCluster.module.css
@@ -1,0 +1,67 @@
+.inputContainer {
+    display: grid;
+    grid-template-columns: 12rem auto;
+    column-gap: 1rem;
+    row-gap: 0.5rem;
+}
+
+.inputContainer .label {
+    grid-column: 1 / 2;
+    margin: 0.2rem 0;
+}
+
+.inputContainer .control {
+    grid-column: 2 / 3;
+    margin: 0.2rem 0;
+    width: 20rem;
+}
+
+.inputContainer .controlSupplement {
+    grid-column: 2 / 3;
+    margin-top: -0.7rem; /* grid row gap + control border */
+    margin-bottom: 0.2rem;
+}
+
+.inputContainer .fullWidth {
+    grid-column: 1 / 3;
+}
+
+.successIndicator {
+    color: var(--vscode-testing-iconPassed);
+}
+
+.errorIndicator {
+    color: var(--vscode-testing-iconFailed);
+}
+
+.actionItemList {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.2rem;
+}
+
+.actionItem {
+    display: grid;
+    grid-template-columns: auto auto;
+    justify-content: stretch;
+}
+
+.actionItem .actionDescription {
+    grid-column: 1 / 2;
+}
+
+.actionItem .actionButtons {
+    grid-column: 2 / 3;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.inlineIcon {
+    vertical-align: middle;
+    margin-left: 0.3rem;
+    margin-right: 0.3rem;
+}

--- a/webview-ui/src/ConnectAcrToCluster/ConnectAcrToCluster.tsx
+++ b/webview-ui/src/ConnectAcrToCluster/ConnectAcrToCluster.tsx
@@ -1,0 +1,280 @@
+import { useEffect } from "react";
+import {
+    Acr,
+    Cluster,
+    InitialState,
+    Subscription,
+} from "../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { Lazy, isLoaded, map as lazyMap } from "../utilities/lazy";
+import { useStateManagement } from "../utilities/state";
+import styles from "./ConnectAcrToCluster.module.css";
+import {
+    EventHandlerFunc,
+    ensureAcrRoleAssignmentLoaded,
+    ensureAcrsLoaded,
+    ensureClustersLoaded,
+    ensureSubscriptionsLoaded,
+} from "./state/dataLoading";
+import { ConnectAcrToClusterState, stateUpdater, vscode } from "./state/state";
+import { distinct } from "../utilities/array";
+import { ResourceSelector } from "../components/ResourceSelector";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { IconDefinition, faCheckCircle, faClock, faSave, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { AcrRoleState } from "./state/stateTypes";
+
+export function ConnectAcrToCluster(initialState: InitialState) {
+    const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
+
+    const updates: EventHandlerFunc[] = [];
+    const {
+        lazySubscriptions,
+        lazyAcrResourceGroups,
+        lazyClusterResourceGroups,
+        lazyAcrs,
+        lazyClusters,
+        lazyAcrRoleState,
+    } = prepareData(state, updates);
+    useEffect(() => {
+        updates.map((fn) => fn(eventHandlers));
+    });
+
+    function getAcrAuthorizationActionItemProps(): ActionItemProps {
+        const createAction = makeFixAction(faSave, "Authorize", null);
+        const deleteAction = makeFixAction(faTrash, "Deauthorize", null);
+        const actionItemProps = makeActionItemProps("ACR Pull", createAction, deleteAction);
+
+        if (state.selectedAcr === null) {
+            actionItemProps.extraInfo = "Please select an ACR.";
+            return actionItemProps;
+        }
+
+        if (state.selectedCluster === null) {
+            actionItemProps.extraInfo = "Please select a cluster.";
+            return actionItemProps;
+        }
+
+        if (!isLoaded(lazyAcrRoleState)) {
+            actionItemProps.extraInfo = "Loading ACR role assignments...";
+            return actionItemProps;
+        }
+
+        const roleState = lazyAcrRoleState.value;
+        const acr = state.selectedAcr;
+        const cluster = state.selectedCluster;
+        const isDone = roleState.hasAcrPull;
+
+        actionItemProps.isDone = isDone;
+        createAction.canPerformAction = !isDone;
+        createAction.action = () => handleCreateAcrRoleAssignment(acr, cluster);
+        deleteAction.canPerformAction = isDone;
+        deleteAction.action = () => handleDeleteAcrRoleAssignment(acr, cluster);
+
+        return actionItemProps;
+    }
+
+    function handleCreateAcrRoleAssignment(acr: Acr, cluster: Cluster) {
+        eventHandlers.onSetAcrRoleAssignmentLoading({ acrKey: acr, clusterKey: cluster });
+        vscode.postCreateAcrRoleAssignmentRequest({
+            acrKey: acr,
+            clusterKey: cluster,
+        });
+    }
+
+    function handleDeleteAcrRoleAssignment(acr: Acr, cluster: Cluster) {
+        eventHandlers.onSetAcrRoleAssignmentLoading({ acrKey: acr, clusterKey: cluster });
+        vscode.postDeleteAcrRoleAssignmentRequest({
+            acrKey: acr,
+            clusterKey: cluster,
+        });
+    }
+
+    return (
+        <>
+            <h2>Connect ACR to Cluster</h2>
+            <fieldset className={styles.inputContainer}>
+                <label htmlFor="subscription-input" className={styles.label}>
+                    Subscription
+                </label>
+                <ResourceSelector<Subscription>
+                    id="subscription-input"
+                    className={styles.control}
+                    resources={lazySubscriptions}
+                    selectedItem={state.selectedSubscription}
+                    valueGetter={(s) => s.subscriptionId}
+                    labelGetter={(s) => s.name}
+                    onSelect={eventHandlers.onSetSelectedSubscription}
+                />
+
+                <label htmlFor="acr-rg-input" className={styles.label}>
+                    ACR Resource Group
+                </label>
+                <ResourceSelector<string>
+                    id="acr-rg-input"
+                    className={styles.control}
+                    resources={lazyAcrResourceGroups}
+                    selectedItem={state.selectedAcrResourceGroup}
+                    valueGetter={(g) => g}
+                    labelGetter={(g) => g}
+                    onSelect={eventHandlers.onSetSelectedAcrResourceGroup}
+                />
+
+                <label htmlFor="acr-input" className={styles.label}>
+                    Container Registry
+                </label>
+                <ResourceSelector<Acr>
+                    id="acr-input"
+                    className={styles.control}
+                    resources={lazyAcrs}
+                    selectedItem={state.selectedAcr}
+                    valueGetter={(acr) => acr.acrName}
+                    labelGetter={(acr) => acr.acrName}
+                    onSelect={eventHandlers.onSetSelectedAcr}
+                />
+
+                <label htmlFor="cluster-rg-input" className={styles.label}>
+                    Cluster Resource Group
+                </label>
+                <ResourceSelector<string>
+                    id="cluster-rg-input"
+                    className={styles.control}
+                    resources={lazyClusterResourceGroups}
+                    selectedItem={state.selectedClusterResourceGroup}
+                    valueGetter={(g) => g}
+                    labelGetter={(g) => g}
+                    onSelect={eventHandlers.onSetSelectedClusterResourceGroup}
+                />
+
+                <label htmlFor="cluster-input" className={styles.label}>
+                    Cluster
+                </label>
+                <ResourceSelector<Cluster>
+                    id="cluster-input"
+                    className={styles.control}
+                    resources={lazyClusters}
+                    selectedItem={state.selectedCluster}
+                    valueGetter={(c) => c.clusterName}
+                    labelGetter={(c) => c.clusterName}
+                    onSelect={eventHandlers.onSetSelectedCluster}
+                />
+
+                <label className={styles.label}>Authorization</label>
+                <div className={`${styles.control} ${styles.actionItemList}`}>
+                    <ActionItem {...getAcrAuthorizationActionItemProps()} />
+                </div>
+            </fieldset>
+        </>
+    );
+}
+
+type LocalData = {
+    lazySubscriptions: Lazy<Subscription[]>;
+    lazyAcrResourceGroups: Lazy<string[]>;
+    lazyClusterResourceGroups: Lazy<string[]>;
+    lazyAcrs: Lazy<Acr[]>;
+    lazyClusters: Lazy<Cluster[]>;
+    lazyAcrRoleState: Lazy<AcrRoleState>;
+};
+
+function prepareData(state: ConnectAcrToClusterState, updates: EventHandlerFunc[]): LocalData {
+    const lazySubscriptions = ensureSubscriptionsLoaded(state.azureReferenceData, updates);
+    const lazySubscriptionAcrs = ensureAcrsLoaded(state.azureReferenceData, state.selectedSubscription, updates);
+    const lazyAcrResourceGroups = lazyMap(lazySubscriptionAcrs, (acrs) => distinct(acrs.map((a) => a.resourceGroup)));
+    const lazySubscriptionClusters = ensureClustersLoaded(
+        state.azureReferenceData,
+        state.selectedSubscription,
+        updates,
+    );
+    const lazyClusterResourceGroups = lazyMap(lazySubscriptionClusters, (clusters) =>
+        distinct(clusters.map((c) => c.resourceGroup)),
+    );
+    const lazyAcrs = lazyMap(lazySubscriptionAcrs, (acrs) =>
+        acrs.filter((a) => a.resourceGroup === state.selectedAcrResourceGroup),
+    );
+    const lazyClusters = lazyMap(lazySubscriptionClusters, (clusters) =>
+        clusters.filter((c) => c.resourceGroup === state.selectedClusterResourceGroup),
+    );
+    const lazyAcrRoleState = ensureAcrRoleAssignmentLoaded(
+        state.azureReferenceData,
+        state.selectedSubscription,
+        state.selectedAcr,
+        state.selectedCluster,
+        updates,
+    );
+
+    return {
+        lazySubscriptions,
+        lazyAcrResourceGroups,
+        lazyClusterResourceGroups,
+        lazyAcrs,
+        lazyClusters,
+        lazyAcrRoleState,
+    };
+}
+
+function makeFixAction(icon: IconDefinition, name: string, action: (() => void) | null): FixAction {
+    return {
+        icon,
+        name,
+        action: action ? action : () => {},
+        canPerformAction: action !== null,
+    };
+}
+
+function makeActionItemProps(description: string, ...actions: FixAction[]): ActionItemProps {
+    return {
+        isDone: false,
+        description,
+        actions,
+        extraInfo: "",
+    };
+}
+
+type ActionItemProps = {
+    isDone: boolean;
+    description: string;
+    actions: FixAction[];
+    extraInfo: string;
+};
+
+type FixAction = {
+    canPerformAction: boolean;
+    icon: IconDefinition;
+    action: () => void;
+    name: string;
+};
+
+function ActionItem(props: ActionItemProps) {
+    return (
+        <div className={styles.actionItem}>
+            <div className={styles.actionDescription}>
+                {props.isDone ? (
+                    <FontAwesomeIcon icon={faCheckCircle} className={styles.successIndicator} />
+                ) : (
+                    <FontAwesomeIcon icon={faClock} />
+                )}{" "}
+                {props.description}{" "}
+                {props.extraInfo && (
+                    <span className={"tooltip-holder"} data-tooltip-text={props.extraInfo}>
+                        <i className={`${styles.inlineIcon} codicon codicon-info`} />
+                    </span>
+                )}
+            </div>
+            <div className={styles.actionButtons}>
+                {props.actions.map((action, i) => (
+                    <VSCodeButton
+                        key={i}
+                        appearance="secondary"
+                        onClick={action.action}
+                        disabled={!action.canPerformAction}
+                        title={action.name}
+                    >
+                        <span className={styles.inlineIcon}>
+                            <FontAwesomeIcon icon={action.icon} />
+                        </span>
+                    </VSCodeButton>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/dataLoading.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/dataLoading.ts
@@ -123,11 +123,7 @@ function getAcrReferenceData(
     acr: Acr | null,
 ): AcrReferenceData | null {
     const subscriptionData = getSubscriptionReferenceData(referenceData, subscription);
-    if (subscriptionData === null || !isLoaded(subscriptionData.acrs)) {
-        return null;
-    }
-
-    if (subscription === null || acr === null) {
+    if (subscriptionData === null || !isLoaded(subscriptionData.acrs) || subscription === null || acr === null) {
         return null;
     }
 

--- a/webview-ui/src/ConnectAcrToCluster/state/dataLoading.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/dataLoading.ts
@@ -1,0 +1,139 @@
+import {
+    Acr,
+    AcrKey,
+    Cluster,
+    ClusterKey,
+    Subscription,
+} from "../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { getOrThrow } from "../../utilities/array";
+import { Lazy, isLoaded, isNotLoaded, map as lazyMap, newNotLoaded } from "../../utilities/lazy";
+import { EventHandlers } from "../../utilities/state";
+import {
+    AcrReferenceData,
+    AcrRoleState,
+    AzureReferenceData,
+    SubscriptionReferenceData,
+    createClusterId,
+} from "../state/stateTypes";
+import { EventDef, vscode } from "./state";
+
+export type EventHandlerFunc = (eventHandlers: EventHandlers<EventDef>) => void;
+
+export function ensureSubscriptionsLoaded(
+    referenceData: AzureReferenceData,
+    updates: EventHandlerFunc[],
+): Lazy<Subscription[]> {
+    if (isNotLoaded(referenceData.subscriptions)) {
+        vscode.postGetSubscriptionsRequest();
+        updates.push((e) => e.onSetSubscriptionsLoading());
+    }
+
+    return lazyMap(referenceData.subscriptions, (data) => data.map((s) => s.subscription));
+}
+
+export function ensureAcrsLoaded(
+    referenceData: AzureReferenceData,
+    subscription: Subscription | null,
+    updates: EventHandlerFunc[],
+): Lazy<Acr[]> {
+    const subscriptionData = getSubscriptionReferenceData(referenceData, subscription);
+    if (subscriptionData === null) {
+        return newNotLoaded();
+    }
+
+    if (isNotLoaded(subscriptionData.acrs)) {
+        const key = { subscriptionId: subscriptionData.subscription.subscriptionId };
+        vscode.postGetAcrsRequest(key);
+        updates.push((e) => e.onSetAcrsLoading(key));
+    }
+
+    return lazyMap(subscriptionData.acrs, (data) => data.map((a) => a.acr));
+}
+
+export function ensureClustersLoaded(
+    referenceData: AzureReferenceData,
+    subscription: Subscription | null,
+    updates: EventHandlerFunc[],
+): Lazy<Cluster[]> {
+    const subscriptionData = getSubscriptionReferenceData(referenceData, subscription);
+    if (subscriptionData === null) {
+        return newNotLoaded();
+    }
+
+    if (isNotLoaded(subscriptionData.clusters)) {
+        const key = { subscriptionId: subscriptionData.subscription.subscriptionId };
+        vscode.postGetClustersRequest(key);
+        updates.push((e) => e.onSetClustersLoading(key));
+    }
+
+    return subscriptionData.clusters;
+}
+
+export function ensureAcrRoleAssignmentLoaded(
+    referenceData: AzureReferenceData,
+    subscription: Subscription | null,
+    acrKey: AcrKey | null,
+    clusterKey: ClusterKey | null,
+    updates: EventHandlerFunc[],
+): Lazy<AcrRoleState> {
+    const acrData = getAcrReferenceData(referenceData, subscription, acrKey);
+    if (acrData === null) {
+        return newNotLoaded();
+    }
+
+    if (clusterKey === null) {
+        return newNotLoaded();
+    }
+
+    const assignedRoleDefinitions: Lazy<AcrRoleState> =
+        acrData.assignedRoleDefinitions[createClusterId(clusterKey)] || newNotLoaded();
+
+    if (isNotLoaded(assignedRoleDefinitions)) {
+        const acrKey: AcrKey = {
+            subscriptionId: acrData.acr.subscriptionId,
+            resourceGroup: acrData.acr.resourceGroup,
+            acrName: acrData.acr.acrName,
+        };
+
+        vscode.postGetAcrRoleAssignmentRequest({ acrKey, clusterKey });
+        updates.push((e) => e.onSetAcrRoleAssignmentLoading({ acrKey, clusterKey }));
+    }
+
+    return assignedRoleDefinitions;
+}
+
+function getSubscriptionReferenceData(
+    referenceData: AzureReferenceData,
+    subscription: Subscription | null,
+): SubscriptionReferenceData | null {
+    if (!isLoaded(referenceData.subscriptions) || subscription === null) {
+        return null;
+    }
+
+    return getOrThrow(
+        referenceData.subscriptions.value,
+        (s) => s.subscription.subscriptionId === subscription.subscriptionId,
+        `${subscription.subscriptionId} (${subscription.name}) not found`,
+    );
+}
+
+function getAcrReferenceData(
+    referenceData: AzureReferenceData,
+    subscription: Subscription | null,
+    acr: Acr | null,
+): AcrReferenceData | null {
+    const subscriptionData = getSubscriptionReferenceData(referenceData, subscription);
+    if (subscriptionData === null || !isLoaded(subscriptionData.acrs)) {
+        return null;
+    }
+
+    if (subscription === null || acr === null) {
+        return null;
+    }
+
+    return getOrThrow(
+        subscriptionData.acrs.value,
+        (data) => data.acr.resourceGroup === acr.resourceGroup && data.acr.acrName === acr.acrName,
+        `${acr.acrName} not found`,
+    );
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/state.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/state.ts
@@ -1,0 +1,232 @@
+import {
+    Acr,
+    AcrKey,
+    Cluster,
+    ClusterKey,
+    InitialSelection,
+    Subscription,
+    SubscriptionKey,
+} from "../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { newNotLoaded } from "../../utilities/lazy";
+import { WebviewStateUpdater } from "../../utilities/state";
+import { AzureReferenceData } from "./stateTypes";
+import * as AzureReferenceDataUpdate from "./update/azureReferenceDataUpdate";
+import { getWebviewMessageContext } from "../../utilities/vscode";
+
+export type EventDef = {
+    // Reference data loading
+    setSubscriptionsLoading: void;
+    setAcrsLoading: SubscriptionKey;
+    setClustersLoading: SubscriptionKey;
+    setAcrRoleAssignmentLoading: {
+        acrKey: AcrKey;
+        clusterKey: ClusterKey;
+    };
+
+    // Azure resource selections
+    setSelectedSubscription: Subscription | null;
+    setSelectedAcrResourceGroup: string | null;
+    setSelectedClusterResourceGroup: string | null;
+    setSelectedAcr: Acr | null;
+    setSelectedCluster: Cluster | null;
+};
+
+export type ConnectAcrToClusterState = {
+    // Reference data
+    azureReferenceData: AzureReferenceData;
+
+    // Properties waiting to be automatically selected when data is available
+    pendingSelection: InitialSelection;
+
+    // Azure resource selections
+    selectedSubscription: Subscription | null;
+    selectedAcrResourceGroup: string | null;
+    selectedClusterResourceGroup: string | null;
+    selectedAcr: Acr | null;
+    selectedCluster: Cluster | null;
+};
+
+export const stateUpdater: WebviewStateUpdater<"connectAcrToCluster", EventDef, ConnectAcrToClusterState> = {
+    createState: (initialState) => ({
+        // Reference data
+        azureReferenceData: {
+            subscriptions: newNotLoaded(),
+        },
+
+        // Pending selections
+        pendingSelection: {
+            ...initialState.initialSelection,
+        },
+
+        // Selected items
+        selectedSubscription: null,
+        selectedAcrResourceGroup: null,
+        selectedClusterResourceGroup: null,
+        selectedAcr: null,
+        selectedCluster: null,
+    }),
+    vscodeMessageHandler: {
+        // Reference data responses
+        getSubscriptionsResponse: (state, args) => ({
+            ...state,
+            selectedSubscription: getSelectedValue(
+                args.subscriptions,
+                (s) => s.subscriptionId === state.pendingSelection.subscriptionId,
+            ),
+            selectedAcrResourceGroup: null,
+            selectedClusterResourceGroup: null,
+            selectedAcr: null,
+            selectedCluster: null,
+            azureReferenceData: AzureReferenceDataUpdate.updateSubscriptions(
+                state.azureReferenceData,
+                args.subscriptions,
+            ),
+        }),
+        getAcrsResponse: (state, args) => ({
+            ...state,
+            selectedAcrResourceGroup: getSelectedValue(
+                args.acrs.map((acr) => acr.resourceGroup),
+                (rg) => rg === state.pendingSelection.acrResourceGroup,
+            ),
+            selectedAcr: getSelectedValue(
+                args.acrs,
+                (acr) =>
+                    acr.resourceGroup === state.pendingSelection.acrResourceGroup &&
+                    acr.acrName === state.pendingSelection.acrName,
+            ),
+            azureReferenceData: AzureReferenceDataUpdate.updateAcrs(
+                state.azureReferenceData,
+                args.key.subscriptionId,
+                args.acrs,
+            ),
+        }),
+        getClustersResponse: (state, args) => ({
+            ...state,
+            selectedClusterResourceGroup: getSelectedValue(
+                args.clusters.map((c) => c.resourceGroup),
+                (rg) => rg === state.pendingSelection.clusterResourceGroup,
+            ),
+            selectedCluster: getSelectedValue(
+                args.clusters,
+                (c) =>
+                    c.resourceGroup === state.pendingSelection.clusterResourceGroup &&
+                    c.clusterName === state.pendingSelection.clusterName,
+            ),
+            azureReferenceData: AzureReferenceDataUpdate.updateClusters(
+                state.azureReferenceData,
+                args.key.subscriptionId,
+                args.clusters,
+            ),
+        }),
+
+        // Azure resource role assignment responses
+        getAcrRoleAssignmentResponse: (state, args) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.updateAcrRoleAssignment(
+                state.azureReferenceData,
+                args.acrKey,
+                args.clusterKey,
+                args.hasAcrPull,
+            ),
+        }),
+        createAcrRoleAssignmentResponse: (state, args) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.updateAcrRoleAssignment(
+                state.azureReferenceData,
+                args.acrKey,
+                args.clusterKey,
+                args.hasAcrPull,
+            ),
+        }),
+        deleteAcrRoleAssignmentResponse: (state, args) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.updateAcrRoleAssignment(
+                state.azureReferenceData,
+                args.acrKey,
+                args.clusterKey,
+                args.hasAcrPull,
+            ),
+        }),
+    },
+    eventHandler: {
+        // Reference data loading
+        setSubscriptionsLoading: (state) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.setSubscriptionsLoading(state.azureReferenceData),
+        }),
+        setAcrsLoading: (state, key) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.setAcrsLoading(state.azureReferenceData, key.subscriptionId),
+        }),
+        setClustersLoading: (state, key) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.setClustersLoading(
+                state.azureReferenceData,
+                key.subscriptionId,
+            ),
+        }),
+        setAcrRoleAssignmentLoading: (state, msg) => ({
+            ...state,
+            azureReferenceData: AzureReferenceDataUpdate.setAcrRoleAssignmentLoading(
+                state.azureReferenceData,
+                msg.acrKey,
+                msg.clusterKey,
+            ),
+        }),
+
+        // Azure resource selections
+        setSelectedSubscription: (state, sub) => ({
+            ...state,
+            pendingSelection: { ...state.pendingSelection, subscriptionId: undefined },
+            selectedSubscription: sub,
+            selectedAcrResourceGroup: null,
+            selectedAcr: null,
+            selectedClusterResourceGroup: null,
+            selectedCluster: null,
+        }),
+        setSelectedAcrResourceGroup: (state, rg) => ({
+            ...state,
+            pendingSelection: { ...state.pendingSelection, acrResourceGroup: undefined },
+            selectedAcrResourceGroup: rg,
+            selectedAcr: null,
+        }),
+        setSelectedClusterResourceGroup: (state, rg) => ({
+            ...state,
+            pendingSelection: { ...state.pendingSelection, clusterResourceGroup: undefined },
+            selectedClusterResourceGroup: rg,
+            selectedCluster: null,
+        }),
+        setSelectedAcr: (state, acr) => ({
+            ...state,
+            pendingSelection: { ...state.pendingSelection, acrName: undefined },
+            selectedAcr: acr,
+        }),
+        setSelectedCluster: (state, cluster) => ({
+            ...state,
+            pendingSelection: { ...state.pendingSelection, clusterName: undefined },
+            selectedCluster: cluster,
+        }),
+    },
+};
+
+export const vscode = getWebviewMessageContext<"connectAcrToCluster">({
+    getSubscriptionsRequest: null,
+    getAcrsRequest: null,
+    getClustersRequest: null,
+    getAcrRoleAssignmentRequest: null,
+    createAcrRoleAssignmentRequest: null,
+    deleteAcrRoleAssignmentRequest: null,
+});
+
+function getSelectedValue<TItem>(items: TItem[], matchesInitialValue: (item: TItem) => boolean): TItem | null {
+    if (items.length === 1) {
+        return items[0];
+    }
+
+    const initialItem = items.find(matchesInitialValue);
+    if (initialItem) {
+        return initialItem;
+    }
+
+    return null;
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/stateTypes.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/stateTypes.ts
@@ -1,0 +1,32 @@
+import {
+    Acr,
+    Cluster,
+    ClusterKey,
+    Subscription,
+} from "../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { Lazy } from "../../utilities/lazy";
+
+export type AzureReferenceData = {
+    subscriptions: Lazy<SubscriptionReferenceData[]>;
+};
+
+export type SubscriptionReferenceData = {
+    subscription: Subscription;
+    acrs: Lazy<AcrReferenceData[]>;
+    clusters: Lazy<Cluster[]>;
+};
+
+export type AcrReferenceData = {
+    acr: Acr;
+    assignedRoleDefinitions: {
+        [clusterId: string]: Lazy<AcrRoleState>;
+    };
+};
+
+export type AcrRoleState = {
+    hasAcrPull: boolean;
+};
+
+export function createClusterId(clusterKey: ClusterKey): string {
+    return `${clusterKey.resourceGroup}/${clusterKey.clusterName}`;
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/update/acrDataUpdate.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/update/acrDataUpdate.ts
@@ -1,0 +1,27 @@
+import { ClusterKey } from "../../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { newLoaded, newLoading } from "../../../utilities/lazy";
+import { AcrReferenceData, createClusterId } from "../stateTypes";
+
+export function setRoleAssignmentLoading(data: AcrReferenceData, clusterKey: ClusterKey): AcrReferenceData {
+    return {
+        ...data,
+        assignedRoleDefinitions: {
+            ...data.assignedRoleDefinitions,
+            [createClusterId(clusterKey)]: newLoading(),
+        },
+    };
+}
+
+export function updateRoleAssignments(
+    data: AcrReferenceData,
+    clusterKey: ClusterKey,
+    hasAcrPull: boolean,
+): AcrReferenceData {
+    return {
+        ...data,
+        assignedRoleDefinitions: {
+            ...data.assignedRoleDefinitions,
+            [createClusterId(clusterKey)]: newLoaded({ hasAcrPull }),
+        },
+    };
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/update/azureReferenceDataUpdate.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/update/azureReferenceDataUpdate.ts
@@ -1,0 +1,86 @@
+import {
+    AcrKey,
+    ClusterKey,
+    Subscription,
+} from "../../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { replaceItem, updateValues } from "../../../utilities/array";
+import { map as lazyMap, newLoaded, newLoading, newNotLoaded, orDefault } from "../../../utilities/lazy";
+import { AzureReferenceData, SubscriptionReferenceData } from "../stateTypes";
+import * as SubscriptionDataUpdate from "./subscriptionDataUpdate";
+
+export function setSubscriptionsLoading(data: AzureReferenceData): AzureReferenceData {
+    return { ...data, subscriptions: newLoading() };
+}
+
+export function updateSubscriptions(data: AzureReferenceData, subscriptions: Subscription[]): AzureReferenceData {
+    const existingSubs = orDefault(data.subscriptions, []);
+    const updatedSubs = updateValues(
+        existingSubs,
+        subscriptions,
+        (sub, subData) => sub.subscriptionId === subData.subscription.subscriptionId,
+        (subscription) => ({
+            subscription,
+            acrs: newNotLoaded(),
+            clusters: newNotLoaded(),
+        }),
+    );
+
+    return {
+        ...data,
+        subscriptions: newLoaded(updatedSubs),
+    };
+}
+
+export function setAcrsLoading(data: AzureReferenceData, subscriptionId: string): AzureReferenceData {
+    return updateSubscription(data, subscriptionId, (sub) => ({ ...sub, acrs: newLoading() }));
+}
+
+export function updateAcrs(data: AzureReferenceData, subscriptionId: string, acrKeys: AcrKey[]): AzureReferenceData {
+    return updateSubscription(data, subscriptionId, (sub) => SubscriptionDataUpdate.updateAcrs(sub, acrKeys));
+}
+
+export function setClustersLoading(data: AzureReferenceData, subscriptionId: string): AzureReferenceData {
+    return updateSubscription(data, subscriptionId, (sub) => ({ ...sub, clusters: newLoading() }));
+}
+
+export function updateClusters(
+    data: AzureReferenceData,
+    subscriptionId: string,
+    clusterKeys: ClusterKey[],
+): AzureReferenceData {
+    return updateSubscription(data, subscriptionId, (sub) => ({ ...sub, clusters: newLoaded(clusterKeys) }));
+}
+
+export function setAcrRoleAssignmentLoading(
+    data: AzureReferenceData,
+    acrKey: AcrKey,
+    clusterKey: ClusterKey,
+): AzureReferenceData {
+    return updateSubscription(data, acrKey.subscriptionId, (sub) =>
+        SubscriptionDataUpdate.setAcrRoleAssignmentLoading(sub, acrKey, clusterKey),
+    );
+}
+
+export function updateAcrRoleAssignment(
+    data: AzureReferenceData,
+    acrKey: AcrKey,
+    clusterKey: ClusterKey,
+    hasAcrPull: boolean,
+): AzureReferenceData {
+    return updateSubscription(data, acrKey.subscriptionId, (sub) =>
+        SubscriptionDataUpdate.updateAcrRoleAssignment(sub, acrKey, clusterKey, hasAcrPull),
+    );
+}
+
+function updateSubscription(
+    data: AzureReferenceData,
+    subscriptionId: string,
+    updater: (data: SubscriptionReferenceData) => SubscriptionReferenceData,
+): AzureReferenceData {
+    return {
+        ...data,
+        subscriptions: lazyMap(data.subscriptions, (subs) =>
+            replaceItem(subs, (subData) => subData.subscription.subscriptionId === subscriptionId, updater),
+        ),
+    };
+}

--- a/webview-ui/src/ConnectAcrToCluster/state/update/subscriptionDataUpdate.ts
+++ b/webview-ui/src/ConnectAcrToCluster/state/update/subscriptionDataUpdate.ts
@@ -1,0 +1,58 @@
+import { AcrKey, ClusterKey } from "../../../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { replaceItem, updateValues } from "../../../utilities/array";
+import { map as lazyMap, newLoaded, orDefault } from "../../../utilities/lazy";
+import { AcrReferenceData, SubscriptionReferenceData } from "../stateTypes";
+import * as AcrDataUpdate from "./acrDataUpdate";
+
+export function updateAcrs(data: SubscriptionReferenceData, newKeys: AcrKey[]): SubscriptionReferenceData {
+    const existingAcrs = orDefault(data.acrs, []);
+    const updatedAcrs = updateValues(
+        existingAcrs,
+        newKeys,
+        (acr, acrData) => acr.resourceGroup === acrData.acr.resourceGroup && acr.acrName === acrData.acr.acrName,
+        (acr) => ({
+            acr,
+            assignedRoleDefinitions: {},
+        }),
+    );
+
+    return {
+        ...data,
+        acrs: newLoaded(updatedAcrs),
+    };
+}
+
+export function setAcrRoleAssignmentLoading(
+    data: SubscriptionReferenceData,
+    acrKey: AcrKey,
+    clusterKey: ClusterKey,
+): SubscriptionReferenceData {
+    return updateAcr(data, acrKey, (acr) => AcrDataUpdate.setRoleAssignmentLoading(acr, clusterKey));
+}
+
+export function updateAcrRoleAssignment(
+    data: SubscriptionReferenceData,
+    acrKey: AcrKey,
+    clusterKey: ClusterKey,
+    hasAcrPull: boolean,
+): SubscriptionReferenceData {
+    return updateAcr(data, acrKey, (acr) => AcrDataUpdate.updateRoleAssignments(acr, clusterKey, hasAcrPull));
+}
+
+function updateAcr(
+    data: SubscriptionReferenceData,
+    acrKey: AcrKey,
+    updater: (data: AcrReferenceData) => AcrReferenceData,
+): SubscriptionReferenceData {
+    return {
+        ...data,
+        acrs: lazyMap(data.acrs, (acrs) =>
+            replaceItem(
+                acrs,
+                (acrData) =>
+                    acrData.acr.resourceGroup === acrKey.resourceGroup && acrData.acr.acrName === acrKey.acrName,
+                updater,
+            ),
+        ),
+    };
+}

--- a/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
+++ b/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
@@ -1,5 +1,9 @@
 import { FormEvent, useEffect } from "react";
-import { CreateParams, InitialState } from "../../../../src/webview-contract/webviewDefinitions/draft/draftWorkflow";
+import {
+    CreateParams,
+    InitialState,
+    LaunchConnectAcrToClusterParams,
+} from "../../../../src/webview-contract/webviewDefinitions/draft/draftWorkflow";
 import {
     DeploymentSpecType,
     GitHubRepo,
@@ -287,6 +291,19 @@ export function DraftWorkflow(initialState: InitialState) {
             ...state.helmParamsState.selectedOverrides,
             { key: unset(), value: unset() },
         ]);
+    }
+
+    function handleLaunchConnectAcrToClusterClick(e: React.MouseEvent) {
+        e.preventDefault();
+        const params: LaunchConnectAcrToClusterParams = {
+            initialSubscriptionId: orDefault(state.selectedSubscription, null)?.id || null,
+            initialAcrResourceGroup: orDefault(state.selectedAcrResourceGroup, null) || null,
+            initialAcrName: orDefault(state.selectedAcr, null) || null,
+            initialClusterResourceGroup: orDefault(state.selectedClusterResourceGroup, null) || null,
+            initialClusterName: orDefault(state.selectedCluster, null) || null,
+        };
+
+        vscode.postLaunchConnectAcrToCluster(params);
     }
 
     function validate(): Maybe<CreateParams> {
@@ -867,7 +884,7 @@ export function DraftWorkflow(initialState: InitialState) {
                                 <ul>
                                     <li>
                                         The ACR {isValueSet(state.selectedAcr) ? `(${state.selectedAcr.value})` : ""}{" "}
-                                        <VSCodeLink href="https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?tabs=azure-cli#configure-acr-integration-for-an-existing-aks-cluster">
+                                        <VSCodeLink href="#" onClick={handleLaunchConnectAcrToClusterClick}>
                                             is attached
                                         </VSCodeLink>{" "}
                                         to the cluster{" "}

--- a/webview-ui/src/Draft/DraftWorkflow/state.ts
+++ b/webview-ui/src/Draft/DraftWorkflow/state.ts
@@ -374,6 +374,7 @@ export const vscode = getWebviewMessageContext<"draftWorkflow">({
     openFileRequest: null,
     launchDraftDockerfile: null,
     launchDraftDeployment: null,
+    launchConnectAcrToCluster: null,
 });
 
 function updatePickedFile(

--- a/webview-ui/src/main.tsx
+++ b/webview-ui/src/main.tsx
@@ -14,6 +14,7 @@ import { AzureServiceOperator } from "./AzureServiceOperator/AzureServiceOperato
 import { ClusterProperties } from "./ClusterProperties/ClusterProperties";
 import { TcpDump } from "./TCPDump/TcpDump";
 import { RetinaCapture } from "./RetinaCapture/RetinaCapture";
+import { ConnectAcrToCluster } from "./ConnectAcrToCluster/ConnectAcrToCluster";
 import { DraftDeployment, DraftDockerfile, DraftWorkflow } from "./Draft";
 
 // There are two modes of launching this application:
@@ -46,6 +47,7 @@ function getVsCodeContent(): JSX.Element {
     const rendererLookup: Record<ContentId, () => JSX.Element> = {
         createCluster: () => <CreateCluster {...getInitialState()} />,
         style: () => <TestStyleViewer {...getInitialState()} />,
+        connectAcrToCluster: () => <ConnectAcrToCluster {...getInitialState()} />,
         clusterProperties: () => <ClusterProperties {...getInitialState()} />,
         periscope: () => <Periscope {...getInitialState()} />,
         detector: () => <Detector {...getInitialState()} />,

--- a/webview-ui/src/manualTest/connectAcrToClusterTests.tsx
+++ b/webview-ui/src/manualTest/connectAcrToClusterTests.tsx
@@ -1,0 +1,214 @@
+import { MessageHandler, MessageSink } from "../../../src/webview-contract/messaging";
+import {
+    Acr,
+    AcrKey,
+    Cluster,
+    ClusterKey,
+    InitialSelection,
+    Subscription,
+    SubscriptionKey,
+    ToVsCodeMsgDef,
+    ToWebViewMsgDef,
+} from "../../../src/webview-contract/webviewDefinitions/connectAcrToCluster";
+import { ConnectAcrToCluster } from "../ConnectAcrToCluster/ConnectAcrToCluster";
+import { stateUpdater } from "../ConnectAcrToCluster/state/state";
+import { Scenario } from "../utilities/manualTest";
+import { delay } from "../utilities/time";
+
+type ReferenceData = {
+    subscriptions: SubscriptionData[];
+};
+
+type SubscriptionData = {
+    subscription: Subscription;
+    resourceGroups: ResourceGroupData[];
+};
+
+type ResourceGroupData = {
+    group: string;
+    acrs: AcrData[];
+    clusterNames: string[];
+};
+
+type AcrData = {
+    name: string;
+    acrPull: {
+        [clusterId: string]: boolean;
+    };
+};
+
+function getReferenceData(): ReferenceData {
+    return {
+        subscriptions: Array.from({ length: 2 }, (_, i) => createSubscriptionData(i + 1)),
+    };
+}
+
+function createSubscriptionData(subNumber: number): SubscriptionData {
+    return {
+        subscription: {
+            subscriptionId: `5b516719-${String(subNumber).padStart(4, "0")}-0000-0000-000000000000`,
+            name: `Test Sub ${subNumber}`,
+        },
+        resourceGroups: Array.from({ length: 2 }, (_, i) => createResourceGroupData(i + 1)),
+    };
+}
+
+function createResourceGroupData(groupNumber: number): ResourceGroupData {
+    return {
+        group: `rg${groupNumber}`,
+        clusterNames: Array.from({ length: 2 }, (_, i) => createClusterName(groupNumber, i + 1)),
+        acrs: Array.from({ length: 2 }, (_, i) => createAcrData(groupNumber, i + 1)),
+    };
+}
+
+function createClusterName(groupNumber: number, clusterNumber: number): string {
+    return `rg${groupNumber}_cluster${clusterNumber}`;
+}
+
+function createAcrData(groupNumber: number, acrNumber: number): AcrData {
+    return {
+        name: `rg${groupNumber}acr${acrNumber}`,
+        acrPull: {},
+    };
+}
+
+function createUnpopulatedInitialSelection(): InitialSelection {
+    return {};
+}
+
+function createPopulatedInitialSelection(referenceData: ReferenceData): InitialSelection {
+    return {
+        subscriptionId: referenceData.subscriptions[0].subscription.subscriptionId,
+        acrResourceGroup: referenceData.subscriptions[0].resourceGroups[0].group,
+        acrName: referenceData.subscriptions[0].resourceGroups[0].acrs[0].name,
+        clusterResourceGroup: referenceData.subscriptions[0].resourceGroups[1].group,
+        clusterName: referenceData.subscriptions[0].resourceGroups[1].clusterNames[0],
+    };
+}
+
+export function getConnectAcrToClusterScenarios() {
+    function getMessageHandler(
+        webview: MessageSink<ToWebViewMsgDef>,
+        referenceData: ReferenceData,
+    ): MessageHandler<ToVsCodeMsgDef> {
+        return {
+            getSubscriptionsRequest: handleGetSubscriptionsRequest,
+            getAcrsRequest: handleGetAcrsRequest,
+            getClustersRequest: handleGetClustersRequest,
+            getAcrRoleAssignmentRequest: (args) => handleGetAcrRoleAssignmentRequest(args.acrKey, args.clusterKey),
+            createAcrRoleAssignmentRequest: (args) =>
+                handleCreateAcrRoleAssignmentRequest(args.acrKey, args.clusterKey),
+            deleteAcrRoleAssignmentRequest: (args) =>
+                handleDeleteAcrRoleAssignmentRequest(args.acrKey, args.clusterKey),
+        };
+
+        async function handleGetSubscriptionsRequest() {
+            await delay(2000);
+            const subscriptions = referenceData.subscriptions.map((d) => d.subscription);
+            webview.postGetSubscriptionsResponse({ subscriptions });
+        }
+
+        async function handleGetAcrsRequest(key: SubscriptionKey) {
+            await delay(2000);
+            const subData = referenceData.subscriptions.find(
+                (d) => d.subscription.subscriptionId === key.subscriptionId,
+            );
+            const acrs: Acr[] =
+                subData?.resourceGroups?.flatMap((g) =>
+                    g.acrs.map((acr) => ({
+                        ...key,
+                        resourceGroup: g.group,
+                        acrName: acr.name,
+                    })),
+                ) || [];
+
+            webview.postGetAcrsResponse({ key, acrs });
+        }
+
+        async function handleGetClustersRequest(key: SubscriptionKey) {
+            await delay(2000);
+            const subData = referenceData.subscriptions.find(
+                (d) => d.subscription.subscriptionId === key.subscriptionId,
+            );
+            const clusters: Cluster[] =
+                subData?.resourceGroups?.flatMap((g) =>
+                    g.clusterNames.map((clusterName) => ({
+                        ...key,
+                        resourceGroup: g.group,
+                        clusterName,
+                    })),
+                ) || [];
+
+            webview.postGetClustersResponse({ key, clusters });
+        }
+
+        async function handleGetAcrRoleAssignmentRequest(acrKey: AcrKey, clusterKey: ClusterKey) {
+            await delay(2000);
+            const subData = referenceData.subscriptions.find(
+                (d) => d.subscription.subscriptionId === acrKey.subscriptionId,
+            );
+            const groupData = subData?.resourceGroups.find((g) => g.group === acrKey.resourceGroup);
+            const acrData = groupData?.acrs.find((a) => a.name === acrKey.acrName);
+            const hasAcrPull = acrData?.acrPull[`${clusterKey.resourceGroup}/${clusterKey.clusterName}`] || false;
+            webview.postGetAcrRoleAssignmentResponse({ acrKey, clusterKey, hasAcrPull });
+        }
+
+        async function handleCreateAcrRoleAssignmentRequest(acrKey: AcrKey, clusterKey: ClusterKey) {
+            await delay(2000);
+            const subData = referenceData.subscriptions.find(
+                (d) => d.subscription.subscriptionId === acrKey.subscriptionId,
+            );
+            const groupData = subData?.resourceGroups.find((g) => g.group === acrKey.resourceGroup);
+            const acrData = groupData?.acrs.find((a) => a.name === acrKey.acrName);
+            if (acrData === undefined) {
+                return;
+            }
+
+            acrData.acrPull[`${clusterKey.resourceGroup}/${clusterKey.clusterName}`] = true;
+
+            webview.postCreateAcrRoleAssignmentResponse({
+                acrKey,
+                clusterKey,
+                hasAcrPull: true,
+            });
+        }
+
+        async function handleDeleteAcrRoleAssignmentRequest(acrKey: AcrKey, clusterKey: ClusterKey) {
+            await delay(2000);
+            const subData = referenceData.subscriptions.find(
+                (d) => d.subscription.subscriptionId === acrKey.subscriptionId,
+            );
+            const groupData = subData?.resourceGroups.find((g) => g.group === acrKey.resourceGroup);
+            const acrData = groupData?.acrs.find((a) => a.name === acrKey.acrName);
+            if (acrData === undefined) {
+                return;
+            }
+
+            acrData.acrPull[`${clusterKey.resourceGroup}/${clusterKey.clusterName}`] = false;
+
+            webview.postDeleteAcrRoleAssignmentResponse({
+                acrKey,
+                clusterKey,
+                hasAcrPull: false,
+            });
+        }
+    }
+
+    function createScenario(name: string, getInitialSelection: (refData: ReferenceData) => InitialSelection) {
+        const referenceData = getReferenceData();
+        const initialSelection = getInitialSelection(referenceData);
+        const initialState = { initialSelection };
+        return Scenario.create(
+            "connectAcrToCluster",
+            name,
+            () => <ConnectAcrToCluster {...initialState} />,
+            (webview) => getMessageHandler(webview, referenceData),
+            stateUpdater.vscodeMessageHandler,
+        );
+    }
+
+    return [
+        createScenario("blank", createUnpopulatedInitialSelection),
+        createScenario("populated", createPopulatedInitialSelection),
+    ];
+}

--- a/webview-ui/src/manualTest/draft/draftWorkflowTests.tsx
+++ b/webview-ui/src/manualTest/draft/draftWorkflowTests.tsx
@@ -95,6 +95,10 @@ export function getDraftWorkflowScenarios() {
                 alert(`Launching Draft Workflow command with initial selection:\n${JSON.stringify(args, null, 2)}`),
             launchDraftDeployment: (args) =>
                 alert(`Launching Draft Deployment command with initial selection:\n${JSON.stringify(args, null, 2)}`),
+            launchConnectAcrToCluster: (args) =>
+                alert(
+                    `Launching Connect ACR to Cluster command with initial selection:\n${JSON.stringify(args, null, 2)}`,
+                ),
         };
 
         async function handlePickFilesRequest(params: PickFilesRequestParams<PickFilesIdentifier>) {

--- a/webview-ui/src/manualTest/main.tsx
+++ b/webview-ui/src/manualTest/main.tsx
@@ -9,6 +9,7 @@ import { getCreateClusterScenarios } from "./createClusterTests";
 import { getPeriscopeScenarios } from "./periscopeTests";
 import { getDetectorScenarios } from "./detectorTests";
 import { getDraftDeploymentScenarios, getDraftDockerfileScenarios, getDraftWorkflowScenarios } from "./draft";
+import { getConnectAcrToClusterScenarios } from "./connectAcrToClusterTests";
 import { getInspektorGadgetScenarios } from "./inspektorGadgetTests";
 import { getKubectlScenarios } from "./kubectlTests";
 import { ContentId } from "../../../src/webview-contract/webviewTypes";
@@ -34,6 +35,7 @@ const root = createRoot(rootElem!);
 const contentTestScenarios: Record<ContentId, Scenario[]> = {
     style: getTestStyleViewerScenarios(),
     clusterProperties: getClusterPropertiesScenarios(),
+    connectAcrToCluster: getConnectAcrToClusterScenarios(),
     createCluster: getCreateClusterScenarios(),
     periscope: getPeriscopeScenarios(),
     detector: getDetectorScenarios(),


### PR DESCRIPTION
Addresses #694.

This provides functionality that's equivalent to the Azure CLI's `az aks update --attach-acr` and `az aks update --detach-acr` commands.

It can be launched from the command palette, from the cluster context menu, or from the Draft Workflow webview (after creating the draft).

![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/d79ef195-4075-4beb-b8a7-36d073a02605)
![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/00ee1e6e-29b5-42fe-99b0-d8ab6a1c2385)
![image](https://github.com/Azure/vscode-aks-tools/assets/1817696/88a3f6eb-3531-4093-b33f-df78ac04d080)
