### PR TITLE
Update/pr size workflow with skip tag for necessary need.

### DIFF
--- a/.github/workflows/restrict-pr-size.yml
+++ b/.github/workflows/restrict-pr-size.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  MAX_LINE_CHANGED: 1200 # Maximum number of lines changed allowed
+  MAX_LINE_CHANGED: 2 # Maximum number of lines changed allowed
   TARGET_BRANCH: main
 
 permissions:

--- a/.github/workflows/restrict-pr-size.yml
+++ b/.github/workflows/restrict-pr-size.yml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   build:
-    if: ${{ !contains(github.event.head_commit.message, '[skip pr-size]') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -43,7 +42,9 @@ jobs:
             echo $size
         shell: bash
       - run: |
-          if [[ $size -gt ${{ env.MAX_LINE_CHANGED }} ]]
+          COMMITMSG=$(git log --format=%B -n 1 ${{github.event.after}})
+          echo "${COMMITMSG}"
+          if [[ $size -gt ${{ env.MAX_LINE_CHANGED }} && "${COMMITMSG}" != *"[skip pr-size]"* ]]
           then
           echo "Warning - total lines changed is greater than" ${{ env.MAX_LINE_CHANGED }}.
           echo "Please consider breaking this PR down."

--- a/.github/workflows/restrict-pr-size.yml
+++ b/.github/workflows/restrict-pr-size.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  MAX_LINE_CHANGED: 2 # Maximum number of lines changed allowed
+  MAX_LINE_CHANGED: 1200 # Maximum number of lines changed allowed
   TARGET_BRANCH: main
 
 permissions:
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ !contains(github.event.head_commit.message, '[skip pr-size]') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
This is moving forward PR, the size gate for PR for the repo is to regulate the bigger size PR for reasons mentioned here https://github.com/Azure/vscode-aks-tools/pull/708#issue-2326602863 

* This PR enable a special case: What this PR enables in the `commit` tag called `[skip pr-size]` which needs to be explicitly mentioned in the PR which will help in skipping the run for this pull request. 
* This will be for instances where PR cannot be broken at-all!! (Although it will be great to have a sanity check for the original writers to keep this in mind)

This is well tested against one of my repo for my fork.

Thanks heaps ☕️🙏❤️