### PR TITLE
Release 1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.4.6]
+
+* Ensure initial selection values are populated in Draft.
+* Add draft context menu commands and deprecate starter workflows.
+* PR Size Check with skip tag.
+* Dependabot updates and bumps.
+
+Thanks to @Tatsinnit, @qpetraroia, @hsubramanianaks for contributions, testing and reviews.
+
 ## [1.4.5]
 
 * Fix treeview stuck with only 'select tenant' node.

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -10,7 +10,7 @@ Azure Kubernetes Service (AKS) Extension for Visual Studio Code helps enable AKS
 * [Perform AKS Diagnostics checks on your AKS cluster](./features/aks-diagnostics.md)
 * [Run AKS Periscope within VS Code](./features/aks-periscope.md)
 * [Install Azure Service Operator on your AKS cluster](./features/install-azureserviceoperator.md)
-* [Create GitHub Workflow from your AKS cluster](./features/create-gh-workflow.md)
+* [Create GitHub Workflow from your AKS cluster (deprecated)](./features/create-gh-workflow.md)
 * [Show AKS cluster overview in Azure Portal](./features/show-properties-azureportal-start-stop.md)
 * [Show AKS cluster properties](./features/show-properties-azureportal-start-stop.md)
 * [Create AKS cluster from Azure Portal](./features/show-properties-azureportal-start-stop.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -10,7 +10,7 @@
   - [Perform AKS Diagnostics checks on your AKS cluster](./features/aks-diagnostics.md)
   - [Run AKS Periscope within VS Code](./features/aks-periscope.md)
   - [Install Azure Service Operator on your AKS cluster](./features/install-azureserviceoperator.md)
-  - [Create GitHub Workflow from your AKS cluster](./features/create-gh-workflow.md)
+  - [Create GitHub Workflow from your AKS cluster (deprecated)](./features/create-gh-workflow.md)
   - [Show AKS cluster overview in Azure Portal](./features/show-properties-azureportal-start-stop.md)
   - [Show AKS cluster properties](./features/show-properties-azureportal-start-stop.md)
   - [Create AKS cluster from Azure Portal](./features/show-properties-azureportal-start-stop.md)

--- a/docs/book/src/features/create-gh-workflow.md
+++ b/docs/book/src/features/create-gh-workflow.md
@@ -1,5 +1,9 @@
 # Create GitHub Workflow
 
+## Deprecation note
+
+This command has been superseded by the [Draft Workflow command](./draft-integration.md).
+
 ### Create GitHub Workflow
 
 Right click on your AKS cluster and click on **Create GitHub Workflow** to easily open and create a workflow starter template. This helps in quick generation of the workflow templates with pre populates resource and clustername for:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.5",
+            "version": "1.4.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
I'm proposing to release this before other features, so that we give as much notice as possible for the deprecation of the starter workflow commands.

Changes:
* Ensure initial selection values are populated in Draft.
* Add draft context menu commands and deprecate starter workflows.
* PR Size Check with skip tag.
* Dependabot updates and bumps.