### PR TITLE
Connect ACR to Cluster implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,6 +241,11 @@
                 "title": "Kustomize Workflow (deprecated)"
             },
             {
+                "command": "aks.connectAcrToCluster",
+                "title": "Connect ACR to Cluster",
+                "category": "AKS"
+            },
+            {
                 "command": "aks.draftDockerfile",
                 "title": "Create a Dockerfile",
                 "category": "Draft"
@@ -444,6 +449,10 @@
                 }
             ],
             "aks.draftSubMenu": [
+                {
+                    "command": "aks.connectAcrToCluster",
+                    "group": "navigation"
+                },
                 {
                     "command": "aks.draftDeployment",
                     "group": "navigation"

--- a/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
+++ b/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
@@ -1,0 +1,56 @@
+import { commands, window } from "vscode";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { getReadySessionProvider } from "../../auth/azureAuth";
+import { failed, succeeded } from "../utils/errorable";
+import { InitialSelection } from "../../webview-contract/webviewDefinitions/connectAcrToCluster";
+import { ConnectAcrToClusterDataProvider, ConnectAcrToClusterPanel } from "../../panels/ConnectAcrToClusterPanel";
+import { getExtension } from "../utils/host";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { getAksClusterTreeNode } from "../utils/clusters";
+
+export type ConnectAcrToClusterParams = {
+    initialSelection: InitialSelection;
+};
+
+export function launchConnectAcrToClusterCommand(params: ConnectAcrToClusterParams) {
+    commands.executeCommand("aks.connectAcrToCluster", params);
+}
+
+export async function connectAcrToCluster(_context: IActionContext, target: unknown): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+    const params = getConnectAcrToClusterParams(cloudExplorer, target);
+
+    const extension = getExtension();
+    if (failed(extension)) {
+        window.showErrorMessage(extension.error);
+        return;
+    }
+
+    const sessionProvider = await getReadySessionProvider();
+    if (failed(sessionProvider)) {
+        window.showErrorMessage(sessionProvider.error);
+        return;
+    }
+
+    const panel = new ConnectAcrToClusterPanel(extension.result.extensionUri);
+    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, params?.initialSelection || {});
+    panel.show(dataProvider);
+}
+
+function getConnectAcrToClusterParams(
+    cloudExplorer: k8s.API<k8s.CloudExplorerV1>,
+    params: unknown,
+): ConnectAcrToClusterParams {
+    const clusterNode = getAksClusterTreeNode(params, cloudExplorer);
+    if (succeeded(clusterNode)) {
+        return {
+            initialSelection: {
+                subscriptionId: clusterNode.result.subscriptionId,
+                clusterResourceGroup: clusterNode.result.resourceGroupName,
+                clusterName: clusterNode.result.name,
+            },
+        };
+    }
+
+    return params as ConnectAcrToClusterParams;
+}

--- a/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
+++ b/src/commands/aksConnectAcrToCluster/connectAcrToCluster.ts
@@ -9,9 +9,13 @@ import * as k8s from "vscode-kubernetes-tools-api";
 import { getAksClusterTreeNode } from "../utils/clusters";
 
 export type ConnectAcrToClusterParams = {
-    initialSelection: InitialSelection;
+    initialSelection?: InitialSelection;
 };
 
+/**
+ * Allows the command to be invoked programmatically, in this case from the message handler
+ * of the 'Draft Workflow' webview.
+ */
 export function launchConnectAcrToClusterCommand(params: ConnectAcrToClusterParams) {
     commands.executeCommand("aks.connectAcrToCluster", params);
 }
@@ -32,8 +36,11 @@ export async function connectAcrToCluster(_context: IActionContext, target: unkn
         return;
     }
 
+    // Explicitly pass empty initialSelection if not defined.
+    const initialSelection = params?.initialSelection || {};
+
     const panel = new ConnectAcrToClusterPanel(extension.result.extensionUri);
-    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, params?.initialSelection || {});
+    const dataProvider = new ConnectAcrToClusterDataProvider(sessionProvider.result, initialSelection);
     panel.show(dataProvider);
 }
 

--- a/src/commands/utils/arm.ts
+++ b/src/commands/utils/arm.ts
@@ -9,6 +9,7 @@ import { StorageManagementClient } from "@azure/arm-storage";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { ContainerRegistryManagementClient } from "@azure/arm-containerregistry";
 import { ContainerRegistryClient } from "@azure/container-registry";
+import { AuthorizationManagementClient } from "@azure/arm-authorization";
 
 export function getSubscriptionClient(sessionProvider: ReadyAzureSessionProvider): SubscriptionClient {
     return new SubscriptionClient(getCredential(sessionProvider), { endpoint: getArmEndpoint() });
@@ -54,6 +55,15 @@ export function getAcrClient(
 ): ContainerRegistryClient {
     // Endpoint should be in the form of "https://myregistryname.azurecr.io"
     return new ContainerRegistryClient(`https://${registryLoginServer}`, getCredential(sessionProvider));
+}
+
+export function getAuthorizationManagementClient(
+    sessionProvider: ReadyAzureSessionProvider,
+    subscriptionId: string,
+): AuthorizationManagementClient {
+    return new AuthorizationManagementClient(getCredential(sessionProvider), subscriptionId, {
+        endpoint: getArmEndpoint(),
+    });
 }
 
 function getArmEndpoint(): string {

--- a/src/commands/utils/roleAssignments.ts
+++ b/src/commands/utils/roleAssignments.ts
@@ -40,22 +40,29 @@ export function getPrincipalRoleAssignmentsForCluster(
 }
 
 export function getScopeForAcr(subscriptionId: string, resourceGroup: string, acrName: string): string {
+    // ARM resource ID for ACR
     return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerRegistry/registries/${acrName}`;
 }
 
 export function getScopeForCluster(subscriptionId: string, resourceGroup: string, clusterName: string): string {
+    // ARM resource ID for AKS cluster
     return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${clusterName}`;
 }
+
+// There are several permitted principal types, see: https://learn.microsoft.com/en-us/rest/api/authorization/role-assignments/create?view=rest-authorization-2022-04-01&tabs=HTTP#principaltype
+// For now, 'ServicePrincipal' and 'User' are the ones we're most likely to use here,
+// but we can add more as needed.
+export type PrincipalType = "ServicePrincipal" | "User";
 
 export async function createRoleAssignment(
     client: AuthorizationManagementClient,
     subscriptionId: string,
     principalId: string,
     roleDefinitionName: string,
-    principalType: "ServicePrincipal" | "User",
+    principalType: PrincipalType,
     scope: string,
 ): Promise<Errorable<RoleAssignment>> {
-    const newRoleAssignmentName = uuidv4();
+    const newRoleAssignmentName = createRoleAssignmentName();
     const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
 
     const newRoleAssignment: RoleAssignmentCreateParameters = {
@@ -87,6 +94,7 @@ export async function deleteRoleAssignment(
 
     const roleAssignments = await listAll(client.roleAssignments.listForScope(scope));
     if (failed(roleAssignments)) {
+        // Returning the inner error propagates it up the call chain.
         return roleAssignments;
     }
 
@@ -110,7 +118,9 @@ export async function deleteRoleAssignment(
     }
 }
 
-function uuidv4(): string {
+function createRoleAssignmentName(): string {
+    // https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments#name
+    // "A role assignment's resource name must be a globally unique identifier"
     // https://stackoverflow.com/a/2117523
     return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
         (+c ^ (getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),

--- a/src/commands/utils/roleAssignments.ts
+++ b/src/commands/utils/roleAssignments.ts
@@ -1,0 +1,118 @@
+import {
+    AuthorizationManagementClient,
+    RoleAssignment,
+    RoleAssignmentCreateParameters,
+} from "@azure/arm-authorization";
+import { getRandomValues } from "crypto";
+import { Errorable, failed, getErrorMessage } from "./errorable";
+import { listAll } from "./arm";
+
+export function getPrincipalRoleAssignmentsForAcr(
+    client: AuthorizationManagementClient,
+    principalId: string,
+    acrResourceGroup: string,
+    acrName: string,
+): Promise<Errorable<RoleAssignment[]>> {
+    return listAll(
+        client.roleAssignments.listForResource(acrResourceGroup, "Microsoft.ContainerRegistry", "registries", acrName, {
+            filter: `principalId eq '${principalId}'`,
+        }),
+    );
+}
+
+export function getPrincipalRoleAssignmentsForCluster(
+    client: AuthorizationManagementClient,
+    principalId: string,
+    clusterResourceGroup: string,
+    clusterName: string,
+): Promise<Errorable<RoleAssignment[]>> {
+    return listAll(
+        client.roleAssignments.listForResource(
+            clusterResourceGroup,
+            "Microsoft.ContainerService",
+            "managedClusters",
+            clusterName,
+            {
+                filter: `principalId eq '${principalId}'`,
+            },
+        ),
+    );
+}
+
+export function getScopeForAcr(subscriptionId: string, resourceGroup: string, acrName: string): string {
+    return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerRegistry/registries/${acrName}`;
+}
+
+export function getScopeForCluster(subscriptionId: string, resourceGroup: string, clusterName: string): string {
+    return `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${clusterName}`;
+}
+
+export async function createRoleAssignment(
+    client: AuthorizationManagementClient,
+    subscriptionId: string,
+    principalId: string,
+    roleDefinitionName: string,
+    principalType: "ServicePrincipal" | "User",
+    scope: string,
+): Promise<Errorable<RoleAssignment>> {
+    const newRoleAssignmentName = uuidv4();
+    const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
+
+    const newRoleAssignment: RoleAssignmentCreateParameters = {
+        principalId,
+        roleDefinitionId,
+        principalType,
+    };
+
+    try {
+        const roleAssignment: RoleAssignment = await client.roleAssignments.create(
+            scope,
+            newRoleAssignmentName,
+            newRoleAssignment,
+        );
+        return { succeeded: true, result: roleAssignment };
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
+}
+
+export async function deleteRoleAssignment(
+    client: AuthorizationManagementClient,
+    subscriptionId: string,
+    principalId: string,
+    roleDefinitionName: string,
+    scope: string,
+): Promise<Errorable<void>> {
+    const roleDefinitionId = `/subscriptions/${subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roleDefinitionName}`;
+
+    const roleAssignments = await listAll(client.roleAssignments.listForScope(scope));
+    if (failed(roleAssignments)) {
+        return roleAssignments;
+    }
+
+    const roleAssignment = roleAssignments.result.find(
+        (ra) => ra.principalId === principalId && ra.roleDefinitionId === roleDefinitionId,
+    );
+
+    if (!roleAssignment) {
+        return { succeeded: true, result: undefined };
+    }
+
+    if (!roleAssignment.id) {
+        return { succeeded: false, error: "Role assignment has no ID" };
+    }
+
+    try {
+        await client.roleAssignments.deleteById(roleAssignment.id);
+        return { succeeded: true, result: undefined };
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
+}
+
+function uuidv4(): string {
+    // https://stackoverflow.com/a/2117523
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+        (+c ^ (getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),
+    );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { Reporter, reporter } from "./commands/utils/reporter";
 import installAzureServiceOperator from "./commands/azureServiceOperators/installAzureServiceOperator";
 import { AzureResourceNodeContributor } from "./tree/azureResourceNodeContributor";
 import { setAssetContext } from "./assets";
+import { connectAcrToCluster } from "./commands/aksConnectAcrToCluster/connectAcrToCluster";
 import {
     configureStarterWorkflow,
     configureHelmStarterWorkflow,
@@ -86,6 +87,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.configureHelmStarterWorkflow", configureHelmStarterWorkflow);
         registerCommandWithTelemetry("aks.configureKomposeStarterWorkflow", configureKomposeStarterWorkflow);
         registerCommandWithTelemetry("aks.configureKustomizeStarterWorkflow", configureKustomizeStarterWorkflow);
+        registerCommandWithTelemetry("aks.connectAcrToCluster", connectAcrToCluster);
         registerCommandWithTelemetry("aks.draftDockerfile", draftDockerfile);
         registerCommandWithTelemetry("aks.draftDeployment", draftDeployment);
         registerCommandWithTelemetry("aks.draftWorkflow", draftWorkflow);

--- a/src/panels/ConnectAcrToClusterPanel.ts
+++ b/src/panels/ConnectAcrToClusterPanel.ts
@@ -1,0 +1,309 @@
+import { Uri, window } from "vscode";
+import { BasePanel, PanelDataProvider } from "./BasePanel";
+import { MessageHandler, MessageSink } from "../webview-contract/messaging";
+import { TelemetryDefinition } from "../webview-contract/webviewTypes";
+import { ReadyAzureSessionProvider } from "../auth/types";
+import {
+    AcrKey,
+    ClusterKey,
+    InitialSelection,
+    InitialState,
+    Subscription,
+    SubscriptionKey,
+    ToVsCodeMsgDef,
+    ToWebViewMsgDef,
+    acrPullRoleDefinitionName,
+} from "../webview-contract/webviewDefinitions/connectAcrToCluster";
+import { Errorable, failed, getErrorMessage } from "../commands/utils/errorable";
+import { SelectionType, getSubscriptions } from "../commands/utils/subscriptions";
+import { getResources } from "../commands/utils/azureResources";
+import { getAuthorizationManagementClient } from "../commands/utils/arm";
+import { RoleAssignment } from "@azure/arm-authorization";
+import {
+    createRoleAssignment,
+    deleteRoleAssignment,
+    getPrincipalRoleAssignmentsForAcr,
+    getScopeForAcr,
+} from "../commands/utils/roleAssignments";
+import { getManagedCluster } from "../commands/utils/clusters";
+
+export class ConnectAcrToClusterPanel extends BasePanel<"connectAcrToCluster"> {
+    constructor(extensionUri: Uri) {
+        super(extensionUri, "connectAcrToCluster", {
+            // Reference data responses
+            getSubscriptionsResponse: null,
+            getAcrsResponse: null,
+            getClustersResponse: null,
+
+            // Azure resource role assignment responses
+            getAcrRoleAssignmentResponse: null,
+            createAcrRoleAssignmentResponse: null,
+            deleteAcrRoleAssignmentResponse: null,
+        });
+    }
+}
+
+export class ConnectAcrToClusterDataProvider implements PanelDataProvider<"connectAcrToCluster"> {
+    constructor(
+        readonly sessionProvider: ReadyAzureSessionProvider,
+        readonly initialSelection: InitialSelection,
+    ) {}
+
+    getTitle(): string {
+        return "Connect ACR to Cluster";
+    }
+
+    getInitialState(): InitialState {
+        return {
+            initialSelection: this.initialSelection,
+        };
+    }
+
+    getTelemetryDefinition(): TelemetryDefinition<"connectAcrToCluster"> {
+        return {
+            // Reference data requests
+            getSubscriptionsRequest: false,
+            getAcrsRequest: false,
+            getClustersRequest: false,
+
+            // Azure resource role assignment requests
+            getAcrRoleAssignmentRequest: false,
+            createAcrRoleAssignmentRequest: true,
+            deleteAcrRoleAssignmentRequest: true,
+        };
+    }
+
+    getMessageHandler(webview: MessageSink<ToWebViewMsgDef>): MessageHandler<ToVsCodeMsgDef> {
+        return {
+            // Reference data requests
+            getSubscriptionsRequest: () => this.handleGetSubscriptionsRequest(webview),
+            getAcrsRequest: (args) => this.handleGetAcrsRequest(args, webview),
+            getClustersRequest: (args) => this.handleGetClustersRequest(args, webview),
+
+            // Azure resource role assignment requests
+            getAcrRoleAssignmentRequest: (args) =>
+                this.handleGetAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+            createAcrRoleAssignmentRequest: (args) =>
+                this.handleCreateAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+            deleteAcrRoleAssignmentRequest: (args) =>
+                this.handleDeleteAcrRoleAssignmentRequest(args.acrKey, args.clusterKey, webview),
+        };
+    }
+
+    private async handleGetSubscriptionsRequest(webview: MessageSink<ToWebViewMsgDef>) {
+        const azureSubscriptionsResult = await getSubscriptions(this.sessionProvider, SelectionType.AllIfNoFilters);
+        const azureSubscriptions = defaultAndNotify(azureSubscriptionsResult, []);
+
+        const subscriptions: Subscription[] = azureSubscriptions.map((subscription) => ({
+            subscriptionId: subscription.subscriptionId,
+            name: subscription.displayName,
+        }));
+
+        webview.postGetSubscriptionsResponse({ subscriptions });
+    }
+
+    private async handleGetAcrsRequest(key: SubscriptionKey, webview: MessageSink<ToWebViewMsgDef>) {
+        const sourceAcrsResult = await getResources(
+            this.sessionProvider,
+            key.subscriptionId,
+            "Microsoft.ContainerRegistry/registries",
+        );
+        const sourceAcrs = defaultAndNotify(sourceAcrsResult, []);
+
+        const acrs: AcrKey[] = sourceAcrs
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((acr) => ({
+                subscriptionId: key.subscriptionId,
+                resourceGroup: acr.resourceGroup,
+                acrName: acr.name,
+            }));
+
+        webview.postGetAcrsResponse({ key, acrs });
+    }
+
+    private async handleGetClustersRequest(key: SubscriptionKey, webview: MessageSink<ToWebViewMsgDef>) {
+        const sourceClustersResult = await getResources(
+            this.sessionProvider,
+            key.subscriptionId,
+            "Microsoft.ContainerService/managedClusters",
+        );
+        const sourceClusters = defaultAndNotify(sourceClustersResult, []);
+
+        const clusters: ClusterKey[] = sourceClusters
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((acr) => ({
+                subscriptionId: key.subscriptionId,
+                resourceGroup: acr.resourceGroup,
+                clusterName: acr.name,
+            }));
+
+        webview.postGetClustersResponse({ key, clusters });
+    }
+
+    private async handleGetAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postGetAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+
+    private async handleCreateAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const scope = getScopeForAcr(acrKey.subscriptionId, acrKey.resourceGroup, acrKey.acrName);
+
+        const roleAssignment = await createRoleAssignment(
+            client,
+            acrKey.subscriptionId,
+            principalId.result,
+            acrPullRoleDefinitionName,
+            "ServicePrincipal",
+            scope,
+        );
+
+        if (failed(roleAssignment)) {
+            window.showErrorMessage(roleAssignment.error);
+        }
+
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postCreateAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+
+    private async handleDeleteAcrRoleAssignmentRequest(
+        acrKey: AcrKey,
+        clusterKey: ClusterKey,
+        webview: MessageSink<ToWebViewMsgDef>,
+    ) {
+        const principalId = await getClusterPrincipalId(this.sessionProvider, clusterKey);
+        if (failed(principalId)) {
+            window.showErrorMessage(getErrorMessage(principalId));
+            return;
+        }
+
+        const client = getAuthorizationManagementClient(this.sessionProvider, acrKey.subscriptionId);
+        const scope = getScopeForAcr(acrKey.subscriptionId, acrKey.resourceGroup, acrKey.acrName);
+        await deleteRoleAssignment(client, acrKey.subscriptionId, principalId.result, acrPullRoleDefinitionName, scope);
+
+        const roleAssignmentsResult = await getPrincipalRoleAssignmentsForAcr(
+            client,
+            principalId.result,
+            acrKey.resourceGroup,
+            acrKey.acrName,
+        );
+
+        const roleAssignments = defaultAndNotify(roleAssignmentsResult, []);
+        const hasAcrPull = roleAssignments.some(isAcrPull);
+        webview.postDeleteAcrRoleAssignmentResponse({
+            acrKey,
+            clusterKey,
+            hasAcrPull,
+        });
+    }
+}
+
+function isAcrPull(roleAssignment: RoleAssignment): boolean {
+    if (!roleAssignment.roleDefinitionId) {
+        return false;
+    }
+
+    const roleDefinitionName = roleAssignment.roleDefinitionId.split("/").pop();
+    return roleDefinitionName === acrPullRoleDefinitionName;
+}
+
+async function getClusterPrincipalId(
+    sessionProvider: ReadyAzureSessionProvider,
+    clusterKey: ClusterKey,
+): Promise<Errorable<string>> {
+    const cluster = await getManagedCluster(
+        sessionProvider,
+        clusterKey.subscriptionId,
+        clusterKey.resourceGroup,
+        clusterKey.clusterName,
+    );
+    if (failed(cluster)) {
+        return cluster;
+    }
+
+    const hasManagedIdentity =
+        cluster.result.identity?.type === "SystemAssigned" || cluster.result.identity?.type === "UserAssigned";
+    if (hasManagedIdentity) {
+        if (
+            cluster.result.identityProfile &&
+            "kubeletidentity" in cluster.result.identityProfile &&
+            cluster.result.identityProfile.kubeletidentity.objectId
+        ) {
+            return {
+                succeeded: true,
+                result: cluster.result.identityProfile.kubeletidentity.objectId,
+            };
+        }
+
+        return {
+            succeeded: false,
+            error: "Cluster has managed identity but no kubelet identity",
+        };
+    }
+
+    const servicePrincipalId = cluster.result.servicePrincipalProfile?.clientId;
+    if (servicePrincipalId) {
+        return {
+            succeeded: true,
+            result: servicePrincipalId,
+        };
+    }
+
+    return {
+        succeeded: false,
+        error: "Cluster has no managed identity or service principal",
+    };
+}
+
+function defaultAndNotify<T>(value: Errorable<T>, defaultValue: T): T {
+    if (failed(value)) {
+        window.showErrorMessage(value.error);
+        return defaultValue;
+    }
+    return value.result;
+}

--- a/src/panels/draft/DraftWorkflowPanel.ts
+++ b/src/panels/draft/DraftWorkflowPanel.ts
@@ -4,6 +4,7 @@ import { BasePanel, PanelDataProvider } from "../BasePanel";
 import {
     ExistingFile,
     InitialState,
+    LaunchConnectAcrToClusterParams,
     PickFilesIdentifier,
     ToVsCodeMsgDef,
     ToWebViewMsgDef,
@@ -31,6 +32,10 @@ import { getAcrRegistry, getRepositories } from "../../commands/utils/acrs";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { getResources } from "../../commands/utils/azureResources";
 import { launchDraftCommand } from "./commandUtils";
+import {
+    ConnectAcrToClusterParams,
+    launchConnectAcrToClusterCommand,
+} from "../../commands/aksConnectAcrToCluster/connectAcrToCluster";
 
 export class DraftWorkflowPanel extends BasePanel<"draftWorkflow"> {
     constructor(extensionUri: Uri) {
@@ -96,6 +101,7 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
             openFileRequest: false,
             launchDraftDockerfile: false,
             launchDraftDeployment: false,
+            launchConnectAcrToCluster: false,
         };
     }
 
@@ -120,6 +126,7 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
                 launchDraftCommand("aks.draftDeployment", {
                     workspaceFolder: this.workspaceFolder,
                 }),
+            launchConnectAcrToCluster: (params) => this.handleLaunchConnectAcrToCluster(params),
         };
     }
 
@@ -314,6 +321,20 @@ export class DraftWorkflowDataProvider implements PanelDataProvider<"draftWorkfl
     private handleOpenFileRequest(relativeFilePath: string) {
         const filePath = path.join(this.workspaceFolder.uri.fsPath, relativeFilePath);
         window.showTextDocument(Uri.file(filePath));
+    }
+
+    private handleLaunchConnectAcrToCluster(params: LaunchConnectAcrToClusterParams) {
+        const commandParams: ConnectAcrToClusterParams = {
+            initialSelection: {
+                subscriptionId: params.initialSubscriptionId || undefined,
+                acrResourceGroup: params.initialAcrResourceGroup || undefined,
+                acrName: params.initialAcrName || undefined,
+                clusterResourceGroup: params.initialClusterResourceGroup || undefined,
+                clusterName: params.initialClusterName || undefined,
+            },
+        };
+
+        launchConnectAcrToClusterCommand(commandParams);
     }
 }
 

--- a/src/webview-contract/webviewDefinitions/draft/draftWorkflow.ts
+++ b/src/webview-contract/webviewDefinitions/draft/draftWorkflow.ts
@@ -69,6 +69,15 @@ export type ToVsCodeMsgDef = {
     openFileRequest: string;
     launchDraftDockerfile: void;
     launchDraftDeployment: void;
+    launchConnectAcrToCluster: LaunchConnectAcrToClusterParams;
+};
+
+export type LaunchConnectAcrToClusterParams = {
+    initialSubscriptionId: string | null;
+    initialAcrResourceGroup: string | null;
+    initialAcrName: string | null;
+    initialClusterResourceGroup: string | null;
+    initialClusterName: string | null;
 };
 
 export type ToWebViewMsgDef = {

--- a/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
+++ b/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
@@ -1,5 +1,9 @@
 import { FormEvent, useEffect } from "react";
-import { CreateParams, InitialState } from "../../../../src/webview-contract/webviewDefinitions/draft/draftWorkflow";
+import {
+    CreateParams,
+    InitialState,
+    LaunchConnectAcrToClusterParams,
+} from "../../../../src/webview-contract/webviewDefinitions/draft/draftWorkflow";
 import {
     DeploymentSpecType,
     GitHubRepo,
@@ -287,6 +291,19 @@ export function DraftWorkflow(initialState: InitialState) {
             ...state.helmParamsState.selectedOverrides,
             { key: unset(), value: unset() },
         ]);
+    }
+
+    function handleLaunchConnectAcrToClusterClick(e: React.MouseEvent) {
+        e.preventDefault();
+        const params: LaunchConnectAcrToClusterParams = {
+            initialSubscriptionId: orDefault(state.selectedSubscription, null)?.id || null,
+            initialAcrResourceGroup: orDefault(state.selectedAcrResourceGroup, null) || null,
+            initialAcrName: orDefault(state.selectedAcr, null) || null,
+            initialClusterResourceGroup: orDefault(state.selectedClusterResourceGroup, null) || null,
+            initialClusterName: orDefault(state.selectedCluster, null) || null,
+        };
+
+        vscode.postLaunchConnectAcrToCluster(params);
     }
 
     function validate(): Maybe<CreateParams> {
@@ -867,7 +884,7 @@ export function DraftWorkflow(initialState: InitialState) {
                                 <ul>
                                     <li>
                                         The ACR {isValueSet(state.selectedAcr) ? `(${state.selectedAcr.value})` : ""}{" "}
-                                        <VSCodeLink href="https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?tabs=azure-cli#configure-acr-integration-for-an-existing-aks-cluster">
+                                        <VSCodeLink href="#" onClick={handleLaunchConnectAcrToClusterClick}>
                                             is attached
                                         </VSCodeLink>{" "}
                                         to the cluster{" "}

--- a/webview-ui/src/Draft/DraftWorkflow/state.ts
+++ b/webview-ui/src/Draft/DraftWorkflow/state.ts
@@ -374,6 +374,7 @@ export const vscode = getWebviewMessageContext<"draftWorkflow">({
     openFileRequest: null,
     launchDraftDockerfile: null,
     launchDraftDeployment: null,
+    launchConnectAcrToCluster: null,
 });
 
 function updatePickedFile(

--- a/webview-ui/src/manualTest/draft/draftWorkflowTests.tsx
+++ b/webview-ui/src/manualTest/draft/draftWorkflowTests.tsx
@@ -95,6 +95,10 @@ export function getDraftWorkflowScenarios() {
                 alert(`Launching Draft Workflow command with initial selection:\n${JSON.stringify(args, null, 2)}`),
             launchDraftDeployment: (args) =>
                 alert(`Launching Draft Deployment command with initial selection:\n${JSON.stringify(args, null, 2)}`),
+            launchConnectAcrToCluster: (args) =>
+                alert(
+                    `Launching Connect ACR to Cluster command with initial selection:\n${JSON.stringify(args, null, 2)}`,
+                ),
         };
 
         async function handlePickFilesRequest(params: PickFilesRequestParams<PickFilesIdentifier>) {


### PR DESCRIPTION
This completes #694.

The [original PR](#709) for this has already been partially reviewed, but was split into two parts: #720 and this.

The changes here are for the VS Code implementation (launching the webview, handling the messages from it, and calling the Azure APIs to make the appropriate role assignment changes).