### PR TITLE
Release for version 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [1.4.7]
+
+* Add developer-focused discussion of authentication and Draft work.
+* Recategorize Draft commands as Automated Deployments.
+* UX enhancements for Attach ACR to Cluster.
+* Connect ACR to Cluster implementation.
+* Avoid querying graph APIs for ASO.
+* Add direct node-fetch dependency.
+* Remove deprecated starter workflow commands.
+* Remove starter workflow traces as its removed now. 
+* Dependabot updates and bumps.
+
+Thanks to @peterbom, @ivelisseca, @qpetraroia, @hsubramanianaks for contributions, testing and reviews.
+
 ## [1.4.6]
 
 * Ensure initial selection values are populated in Draft.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.6",
+            "version": "1.4.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is to release 1.4.7.

Please note: It will be nice if we get the #773 merge first and then this.

* Add developer-focused discussion of authentication and Draft work.
* Recategorize Draft commands as Automated Deployments.
* UX enhancements for Attach ACR to Cluster.
* Connect ACR to Cluster implementation.
* Avoid querying graph APIs for ASO.
* Add direct node-fetch dependency.
* Remove deprecated starter workflow commands.
* Remove starter workflow traces as its removed now. 
* Dependabot updates and bumps.

Thanks heaps all. thoughts et. al. cc: @qpetraroia , @hsubramanianaks , @sprab fyi @gambtho

Please do correct the description et. al. Thanks heaps.