### PR TITLE
Draft Version Update & Manifest file check removal by draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
                 },
                 "aks.drafttool.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.33",
+                    "default": "v0.0.36",
                     "title": "Draft repository release tag",
                     "description": "Release tag for the stable Draft tool release."
                 },

--- a/src/commands/utils/draft.ts
+++ b/src/commands/utils/draft.ts
@@ -56,7 +56,7 @@ async function getDeploymentFiles(
         .join(" ");
 
     const language = "java"; // So it doesn't attempt to autodetect the language
-    const command = `draft create --language ${language} --deployment-only --deploy-type ${deploymentType} --app testapp ${variableArgs} --destination ${destDir} --dry-run --silent`;
+    const command = `draft create --language ${language} --deployment-only --deploy-type ${deploymentType} ${variableArgs} --destination ${destDir} --dry-run --silent`;
 
     const execOptions: ShellOptions = {
         envPaths: [path.dirname(draftBinaryPath)],

--- a/src/panels/draft/DraftDeploymentPanel.ts
+++ b/src/panels/draft/DraftDeploymentPanel.ts
@@ -283,7 +283,7 @@ export class DraftDeploymentDataProvider implements PanelDataProvider<"draftDepl
             .join(" ");
 
         const language = "java"; // So it doesn't attempt to autodetect the language
-        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} --app ${args.applicationName} ${variableArgs} --destination .${path.sep}${args.location}`;
+        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} ${variableArgs} --destination .${path.sep}${args.location} --skip-file-detection`;
 
         const execOptions: ShellOptions = {
             workingDir: this.workspaceFolder.uri.fsPath,


### PR DESCRIPTION
Draft version update [https://github.com/Azure/draft/releases/tag/v0.0.36](https://github.com/Azure/draft/releases/tag/v0.0.36) was released.

Latest draft update requires us to remove the "--app" flag utilized in the draft commands by the extension. The app name is now automatically populated from the "--variable" arguments.

As well the draft deployment screen was freezing as seen in [https://github.com/Azure/vscode-aks-tools/issues/786](here) . This was because draft detected that there were manifest files in the directory specified or child directories.  By adding the "--skip-file-detection" to the draft command, we can remove the check on the draft side and rely on the extension to inform the user that manifest files are present.

![image](https://github.com/user-attachments/assets/c3eae378-6ed4-44eb-9188-d5e44627f138)

