### PR TITLE
Adding flag to prevent draft from checking for manifests

### DIFF
--- a/src/panels/draft/DraftDeploymentPanel.ts
+++ b/src/panels/draft/DraftDeploymentPanel.ts
@@ -283,7 +283,7 @@ export class DraftDeploymentDataProvider implements PanelDataProvider<"draftDepl
             .join(" ");
 
         const language = "java"; // So it doesn't attempt to autodetect the language
-        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} --app ${args.applicationName} ${variableArgs} --destination .${path.sep}${args.location}`;
+        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} --app ${args.applicationName} ${variableArgs} --destination .${path.sep}${args.location} --skip-file-detection`;
 
         const execOptions: ShellOptions = {
             workingDir: this.workspaceFolder.uri.fsPath,


### PR DESCRIPTION
Added flag "--skip-file-detection" 

The draft screen was freezing because it detected manifest files in the directory specified or child directories. By adding the "--skip-file-detection" to the draft command, we can remove the check on the draft side and rely on the extension to inform the user that manifest files are present.

Draft deployment screen was freezing as seen  [https://github.com/Azure/vscode-aks-tools/issues/786](here)