### PR TITLE
Bump draft version to 0.0.36 and fix breaking flag in draft command

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
                 },
                 "aks.drafttool.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.33",
+                    "default": "v0.0.36",
                     "title": "Draft repository release tag",
                     "description": "Release tag for the stable Draft tool release."
                 },

--- a/src/commands/utils/draft.ts
+++ b/src/commands/utils/draft.ts
@@ -56,7 +56,7 @@ async function getDeploymentFiles(
         .join(" ");
 
     const language = "java"; // So it doesn't attempt to autodetect the language
-    const command = `draft create --language ${language} --deployment-only --deploy-type ${deploymentType} --app testapp ${variableArgs} --destination ${destDir} --dry-run --silent`;
+    const command = `draft create --language ${language} --deployment-only --deploy-type ${deploymentType} ${variableArgs} --destination ${destDir} --dry-run --silent`;
 
     const execOptions: ShellOptions = {
         envPaths: [path.dirname(draftBinaryPath)],

--- a/src/panels/draft/DraftDeploymentPanel.ts
+++ b/src/panels/draft/DraftDeploymentPanel.ts
@@ -283,7 +283,7 @@ export class DraftDeploymentDataProvider implements PanelDataProvider<"draftDepl
             .join(" ");
 
         const language = "java"; // So it doesn't attempt to autodetect the language
-        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} --app ${args.applicationName} ${variableArgs} --destination .${path.sep}${args.location}`;
+        const command = `draft create --language ${language} --deployment-only --deploy-type ${args.deploymentSpecType} ${variableArgs} --destination .${path.sep}${args.location}`;
 
         const execOptions: ShellOptions = {
             workingDir: this.workspaceFolder.uri.fsPath,


### PR DESCRIPTION
"--app" flag removed in latest draft version.

Application name will now be retrieved automatically from the ""--variables" arguments which can populated as "${variableArgs}"