### PR TITLE
Escaping special regex chars

### DIFF
--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -28,7 +28,7 @@ const captureFileBasePathEscaped = escapeRegExp(captureFileBasePath);
 const captureFilePathRegex = `${captureFileBasePathEscaped}(.*)\\.cap`; // Matches the part of the filename after the prefix
 
 // Escape all regex meta characters to ensure sanitation and '/' for later use in regex pattern
-function escapeRegExp(input: string): string {
+export function escapeRegExp(input: string): string {
     return input.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&"); //Escapes by adding '\' to every matched string $&
 }
 //Reference for regex syntax chars: https://262.ecma-international.org/13.0/index.html#prod-SyntaxCharacter
@@ -59,20 +59,6 @@ function getCaptureFromFilePath(filePath: string): string | null {
     if (!fileMatch) return null;
     return fileMatch && fileMatch[1];
 }
-
-// Test function to verify escaping
-function testEscapeRegExp() {
-    const testString = "/tmp/vscodenodecap_*+?^${}()|[]\\";
-    const expectedEscapedString = "\\/tmp\\/vscodenodecap_\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\";
-
-    const actualEscapedString = escapeRegExp(testString);
-    console.assert(
-        actualEscapedString === expectedEscapedString,
-        `Expected ${expectedEscapedString}, but got ${actualEscapedString}`,
-    );
-}
-
-testEscapeRegExp();
 
 export class TcpDumpPanel extends BasePanel<"tcpDump"> {
     constructor(extensionUri: Uri) {

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -24,7 +24,14 @@ const tcpDumpCommandBase = "tcpdump --snapshot-length=0 -vvv";
 const captureDir = "/tmp";
 const captureFilePrefix = "vscodenodecap_";
 const captureFileBasePath = `${captureDir}/${captureFilePrefix}`;
-const captureFilePathRegex = `${captureFileBasePath.replace(/\//g, "\\$&")}(.*)\\.cap`; // Matches the part of the filename after the prefix
+const captureFileBasePathEscaped = escapeRegExp(captureFileBasePath);
+const captureFilePathRegex = `${captureFileBasePathEscaped}(.*)\\.cap`; // Matches the part of the filename after the prefix
+
+// Escape all regex meta characters to ensure sanitation and '/' for later use in regex pattern
+function escapeRegExp(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&"); //Escapes by adding '\' to every matched string $&
+}
+//Reference for regex syntax chars: https://262.ecma-international.org/13.0/index.html#prod-SyntaxCharacter
 
 function getPodName(node: NodeName) {
     return `debug-${node}`;
@@ -52,6 +59,20 @@ function getCaptureFromFilePath(filePath: string): string | null {
     if (!fileMatch) return null;
     return fileMatch && fileMatch[1];
 }
+
+// Test function to verify escaping
+function testEscapeRegExp() {
+    const testString = "/tmp/vscodenodecap_*+?^${}()|[]\\";
+    const expectedEscapedString = "\\/tmp\\/vscodenodecap_\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\";
+
+    const actualEscapedString = escapeRegExp(testString);
+    console.assert(
+        actualEscapedString === expectedEscapedString,
+        `Expected ${expectedEscapedString}, but got ${actualEscapedString}`,
+    );
+}
+
+testEscapeRegExp();
 
 export class TcpDumpPanel extends BasePanel<"tcpDump"> {
     constructor(extensionUri: Uri) {

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -29,9 +29,11 @@ const captureFilePathRegex = `${captureFileBasePathEscaped}(.*)\\.cap`; // Match
 
 // Escape all regex meta characters to ensure sanitation and '/' for later use in regex pattern
 export function escapeRegExp(input: string): string {
-    return input.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&"); //Escapes by adding '\' to every matched string $&
-}
-//Reference for regex syntax chars: https://262.ecma-international.org/13.0/index.html#prod-SyntaxCharacter
+    return input.replace(/(\\)?([.*+?^${}()|[\]\\/])/g, (match, backslash, char) => {
+        // If there's a backslash before the character, return the match unchanged. (To prevent double escaping)
+        return backslash ? match : `\\${char}`;
+    });
+} //Reference for regex syntax chars: https://262.ecma-international.org/13.0/index.html#prod-SyntaxCharacter
 
 function getPodName(node: NodeName) {
     return `debug-${node}`;

--- a/src/tests/suite/TcpDumpPanel.test.ts
+++ b/src/tests/suite/TcpDumpPanel.test.ts
@@ -21,8 +21,8 @@ describe("testEscapeRegExp", function () {
     });
 
     it("should not double escape already escaped characters", function () {
-        //const input = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
+        const input = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
         const expected = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
-        assert.equal("", expected);
+        assert.equal("escapeRegExp(input)", expected);
     });
 });

--- a/src/tests/suite/TcpDumpPanel.test.ts
+++ b/src/tests/suite/TcpDumpPanel.test.ts
@@ -1,0 +1,28 @@
+import * as assert from "assert";
+import { escapeRegExp } from "../../panels/TcpDumpPanel";
+
+describe("testEscapeRegExp", function () {
+    it("should escape special regex characters", function () {
+        const input = "a.b*c?d+e^f$g|h(i)j{k}l[m]n\\o";
+        const expected = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
+        assert.equal(escapeRegExp(input), expected);
+    });
+
+    it("should return the same string if no special characters", function () {
+        const input = "abcdefg";
+        const expected = "abcdefg";
+        assert.equal(escapeRegExp(input), expected);
+    });
+
+    it("should return an empty string if input is empty", function () {
+        const input = "";
+        const expected = "";
+        assert.equal(escapeRegExp(input), expected);
+    });
+
+    it("should not double escape already escaped characters", function () {
+        //const input = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
+        const expected = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
+        assert.equal("", expected);
+    });
+});

--- a/src/tests/suite/TcpDumpPanel.test.ts
+++ b/src/tests/suite/TcpDumpPanel.test.ts
@@ -1,28 +1,32 @@
 import * as assert from "assert";
 import { escapeRegExp } from "../../panels/TcpDumpPanel";
 
-describe("testEscapeRegExp", function () {
-    it("should escape special regex characters", function () {
+describe("testEscapeRegExp", () => {
+    it("should escape special regex characters", () => {
         const input = "a.b*c?d+e^f$g|h(i)j{k}l[m]n\\o";
         const expected = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
-        assert.equal(escapeRegExp(input), expected);
+        const escapedInput = escapeRegExp(input);
+        assert.equal(escapedInput, expected);
     });
 
-    it("should return the same string if no special characters", function () {
-        const input = "abcdefg";
-        const expected = "abcdefg";
-        assert.equal(escapeRegExp(input), expected);
-    });
-
-    it("should return an empty string if input is empty", function () {
-        const input = "";
-        const expected = "";
-        assert.equal(escapeRegExp(input), expected);
-    });
-
-    it("should not double escape already escaped characters", function () {
+    it("should not double escape already escaped characters", () => {
         const input = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
         const expected = "a\\.b\\*c\\?d\\+e\\^f\\$g\\|h\\(i\\)j\\{k\\}l\\[m\\]n\\\\o";
-        assert.equal("escapeRegExp(input)", expected);
+        const escapedInput = escapeRegExp(input);
+        assert.equal(escapedInput, expected);
+    });
+
+    it("should return an empty string if input is empty", () => {
+        const input = "";
+        const expected = "";
+        const escapedInput = escapeRegExp(input);
+        assert.equal(escapedInput, expected);
+    });
+
+    it("should return the same string if no special characters", () => {
+        const input = "abcdefg";
+        const expected = "abcdefg";
+        const escapedInput = escapeRegExp(input);
+        assert.equal(escapedInput, expected);
     });
 });


### PR DESCRIPTION
To properly sanitize input strings we have to escape any special characters.

Wanted to get some feedback on this implementation, where I manually specified the special characters and are escaping.

Some other potential routes would be to use a library with this feature but, this would create a new dependency.

Currently have a simple test function in the same file. Can move this to a more appropriate location after feedback.