### PR TITLE
fix version to node-version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
-        version: 20
+        node-version: 20
     - name: Build Extension
       run: |
         npm run install:all


### PR DESCRIPTION
This PR fixes the github action for build with right syntax of node-version instead of version. 