### PR TITLE
Release to publish 1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.4.9]
+
+* AKS diagnostic bug resolved & storage diagnostic added.
+* Updated github auth scope to repo.
+* Adding flag to prevent draft from checking for manifests.
+* U/X add border for the row.
+* Fix the eslint no-unused-vars errors.
+* changing draft version to .38 and removing manual appname.
+* Dependabot updates and bumps.
+
+Welcome new contributor @ReinierCC to the repo. Thanks to  @ivelisseca, @qpetraroia, @hsubramanianaks, @ReinierCC for contributions, testing and reviews.
+
 ## [1.4.8]
 
 * Add Support Plan and Preview information in cluster Properties Page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * changing draft version to .38 and removing manual appname.
 * Dependabot updates and bumps.
 
-Welcome new contributor @ReinierCC to the repo. Thanks to  @ivelisseca, @qpetraroia, @hsubramanianaks, @ReinierCC for contributions, testing and reviews.
+Welcome new contributors @tejhan & @ReinierCC to the repo. Thanks to  @ivelisseca, @qpetraroia, @hsubramanianaks, @ReinierCC, @tejhan for contributions, testing and reviews.
 
 ## [1.4.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * U/X add border for the row.
 * Fix the eslint no-unused-vars errors.
 * changing draft version to .38 and removing manual appname.
+* Add U/X tooltip changes.
 * Dependabot updates and bumps.
 
 Welcome new contributors @tejhan & @ReinierCC to the repo. Thanks to  @ivelisseca, @qpetraroia, @hsubramanianaks, @ReinierCC, @tejhan for contributions, testing and reviews.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.8",
+    "version": "1.4.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.8",
+    "version": "1.4.9",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release 1.4.9, please see the details below.

We need to wait for https://github.com/Azure/vscode-aks-tools/pull/888 to get merge and then we can send the vsix to quick test and release.

Parking this in a queue before we add more to this repo.

 AKS diagnostic bug resolved & storage diagnostic added.

* Updated github auth scope to repo.
* Adding flag to prevent draft from checking for manifests.
* U/X add border for the row.
* Fix the eslint no-unused-vars errors.
* changing draft version to .38 and removing manual appname.
* Dependabot updates and bumps.

Thanks all. 