### PR TITLE
Minor bug fix for cluster properties panel

### DIFF
--- a/webview-ui/src/ClusterProperties/ClusterProperties.module.css
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.module.css
@@ -25,7 +25,7 @@
 }
 
 .tooltip {
-    position: fixed;
+    position: absolute;
     display: inline-block;
     border-bottom: 1px dotted black;
 }
@@ -41,17 +41,20 @@
     padding: 0.5rem;
 
     /* Position the tooltip */
-    position: fixed;
+    position: absolute;
     z-index: 1;
+    width: max-content;
+    max-width: 55vw;
 }
 
 .tooltip:hover .tooltiptext {
     visibility: visible;
 }
 
-th:not(:last-child),
-td:not(:last-child) {
-    padding-right: 6px; /* Adds space to the right except for the last <th> and <td> in each row */
+td,
+th {
+    padding: 5px 3px 5px 3px;
+    text-align: center;
 }
 
 .buttonDiv {


### PR DESCRIPTION
### Description

This PR fixes a minor bug observed when scrolling through a cluster properties page. The information tooltip & icon are fixed & overlap with other content upon scrolling. This fixed behavior also caused the version chart to overflow vertically off of the page in some circumstances. (See video Below)

### Before
https://github.com/user-attachments/assets/ab49324f-b532-422b-a189-766fd3175714


### After

https://github.com/user-attachments/assets/9b3e7b7f-fd77-4579-9769-8190056e9814
- Fixed tooltip issue & made slight changes to improve readability


