### PR TITLE
Copy commands for Kaito Federated Credentials

### DIFF
--- a/webview-ui/src/Kaito/Kaito.module.css
+++ b/webview-ui/src/Kaito/Kaito.module.css
@@ -80,22 +80,22 @@
     display: flex;
     align-items: center;
     border: 1px solid var(--Dark-Base-04, #9d9d9d);
-    padding: 10px;
-    border-radius: 5px;
+    padding: 0.625rem; /* 10px */
+    border-radius: 0.3125rem; /* 5px */
     width: fit-content;
-    margin-top: 10px;
+    margin-top: 0.625rem; /* 10px */
 }
 
 .commandText {
-    margin-right: 10px;
+    margin-right: 0.625rem;
 }
 
 .copyButton {
     background-color: #007acc;
     color: white;
     border: none;
-    padding: 5px 10px;
-    border-radius: 3px;
+    padding: 0.3125rem 0.625rem;
+    border-radius: 0.1875rem;
     cursor: pointer;
 }
 

--- a/webview-ui/src/Kaito/Kaito.module.css
+++ b/webview-ui/src/Kaito/Kaito.module.css
@@ -75,3 +75,36 @@
     font-weight: 700;
     line-height: normal;
 }
+
+.commandContainer {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--Dark-Base-04, #9d9d9d);
+    padding: 10px;
+    border-radius: 5px;
+    width: fit-content;
+    margin-top: 10px;
+}
+
+.commandText {
+    margin-right: 10px;
+}
+
+.copyButton {
+    background-color: #007acc;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.copyButton:hover {
+    background-color: #005fa3;
+}
+
+pre {
+    width: auto;
+    white-space: pre-wrap; /* This ensures that long lines wrap instead of overflowing */
+    word-wrap: break-word; /* This ensures that long words break to fit within the container */
+}

--- a/webview-ui/src/Kaito/Kaito.tsx
+++ b/webview-ui/src/Kaito/Kaito.tsx
@@ -2,6 +2,7 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { InitialState, ProgressEventType } from "../../../src/webview-contract/webviewDefinitions/kaito";
 import { useStateManagement } from "../utilities/state";
 import styles from "./Kaito.module.css";
+import { KaitoCredentialCopy } from "./KaitoCredentialCopy";
 import kaitoimage from "./kaitoimage.png";
 import { stateUpdater, vscode } from "./state";
 
@@ -47,7 +48,11 @@ export function Kaito(initialState: InitialState) {
                         <VSCodeButton onClick={onClickKaitoInstall}>Install</VSCodeButton>
                     )}
                     {state.kaitoInstallStatus === ProgressEventType.InProgress && (
-                        <p className={styles.installingMessage}>Installing KAITO, this may take a few minutes...</p>
+                        <KaitoCredentialCopy
+                            resourceGroup={state.resourceGroupName}
+                            subscription={state.subscriptionId}
+                            clusterName={state.clusterName}
+                        />
                     )}
                     {state.kaitoInstallStatus === ProgressEventType.Success && state.models.length > 0 && (
                         // <KaitoFamilyModelInput modelDetails={state.models} />

--- a/webview-ui/src/Kaito/KaitoCredentialCopy.tsx
+++ b/webview-ui/src/Kaito/KaitoCredentialCopy.tsx
@@ -1,0 +1,94 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import styles from "./Kaito.module.css";
+
+export type KaitoCredentialCopyProps = {
+    resourceGroup: string;
+    clusterName: string;
+    subscription: string;
+};
+
+export function KaitoCredentialCopy(props: KaitoCredentialCopyProps) {
+    const roleAssigmentCommand = `export IDENTITY_NAME="kaitoprovisioner"
+az identity create --name $IDENTITY_NAME -g $RESOURCE_GROUP
+export IDENTITY_PRINCIPAL_ID=$(az identity show --name $IDENTITY_NAME -g $RESOURCE_GROUP --subscription $SUBSCRIPTION --query 'principalId' -o tsv)\n
+export IDENTITY_CLIENT_ID=$(az identity show --name $IDENTITY_NAME -g $RESOURCE_GROUP --subscription $SUBSCRIPTION --query 'clientId' -o tsv)\n
+az role assignment create --assignee $IDENTITY_PRINCIPAL_ID --scope /subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.ContainerService/managedClusters/$MY_CLUSTER  --role "Contributor"`
+        .replaceAll("$RESOURCE_GROUP", props.resourceGroup)
+        .replaceAll("$SUBSCRIPTION", props.subscription)
+        .replaceAll("$MY_CLUSTER", props.clusterName);
+
+    const federatedCredentialsCommand =
+        `export AKS_OIDC_ISSUER=$(az aks show -n $MY_CLUSTER -g $RESOURCE_GROUP --subscription $SUBSCRIPTION --query "oidcIssuerProfile.issuerUrl" -o tsv)
+az identity federated-credential create --name kaito-federatedcredential --identity-name $IDENTITY_NAME -g $RESOURCE_GROUP --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:"gpu-provisioner:gpu-provisioner" --audience api://AzureADTokenExchange --subscription $SUBSCRIPTION`
+            .replaceAll("$RESOURCE_GROUP", props.resourceGroup)
+            .replaceAll("$SUBSCRIPTION", props.subscription)
+            .replaceAll("$MY_CLUSTER", props.clusterName);
+
+    const kubectlRolloutRestartCommand = `kubectl rollout restart deployment kaito-gpu-provisioner -n kube-system`;
+
+    const copyCommand = (text: string) => {
+        navigator.clipboard
+            .writeText(text)
+            .then(() => {
+                alert("Command copied to clipboard!");
+            })
+            .catch((err) => {
+                console.error("Failed to copy command: ", err);
+            });
+    };
+
+    return (
+        <div>
+            <p className={styles.installingMessage}>Installing KAITO, this may take a few minutes...</p>
+            <label className={styles.installingMessage}>
+                For the gpu provisioner pod to work, please follow the steps below to create role assignments and
+                federated credentials using terminal while KAITO is installing.
+            </label>
+            <ul>
+                <li>
+                    <p>Create an identity and assign permissions</p>
+                    <label>
+                        The identity kaitoprovisioner is created for the gpu-provisioner controller. It is assigned
+                        Contributor role for the managed cluster resource to allow changing {props.clusterName} (e.g.,
+                        provisioning new nodes in it).
+                    </label>
+                    <div className={styles.commandContainer}>
+                        <pre className={styles.commandText}>{roleAssigmentCommand}</pre>
+                        <VSCodeButton className={styles.copyButton} onClick={() => copyCommand(roleAssigmentCommand)}>
+                            Copy
+                        </VSCodeButton>
+                    </div>
+                </li>
+                <li>
+                    <p>Create the federated credential</p>
+                    <label>
+                        The federated identity credential between the managed identity kaitoprovisioner and the service
+                        account used by the gpu-provisioner controller is created.
+                    </label>
+                    <div className={styles.commandContainer}>
+                        <pre className={styles.commandText}>{federatedCredentialsCommand}</pre>
+                        <VSCodeButton
+                            className={styles.copyButton}
+                            onClick={() => copyCommand(federatedCredentialsCommand)}
+                        >
+                            Copy
+                        </VSCodeButton>
+                    </div>
+                </li>
+                <li>
+                    <p>Rollout restart gpu provisioner pods</p>
+                    <label>Restart the gpu provisioner pods to apply the new configuration.</label>
+                    <div className={styles.commandContainer}>
+                        <pre className={styles.commandText}>{kubectlRolloutRestartCommand}</pre>
+                        <VSCodeButton
+                            className={styles.copyButton}
+                            onClick={() => copyCommand(kubectlRolloutRestartCommand)}
+                        >
+                            Copy
+                        </VSCodeButton>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    );
+}

--- a/webview-ui/src/Kaito/KaitoCredentialCopy.tsx
+++ b/webview-ui/src/Kaito/KaitoCredentialCopy.tsx
@@ -78,7 +78,7 @@ az identity federated-credential create --name "kaito-federated-identity" --iden
                 <li>
                     <p>Rollout restart gpu provisioner pods after KAITO is installed</p>
                     <label>
-                        Restart the gpu provisioner pods to apply the new configuration after KAITO is installe.
+                        Restart the gpu provisioner pods to apply the new configuration after KAITO is installed.
                     </label>
                     <div className={styles.commandContainer}>
                         <pre className={styles.commandText}>{kubectlRolloutRestartCommand}</pre>

--- a/webview-ui/src/manualTest/kaitoTests.tsx
+++ b/webview-ui/src/manualTest/kaitoTests.tsx
@@ -6,7 +6,7 @@ import { Scenario } from "../utilities/manualTest";
 
 export function getKaitoScenarios() {
     const initialState: InitialState = {
-        clusterName: "MyCluster",
+        clusterName: "MyAksCluster",
         subscriptionId: "MySubscriptionId",
         resourceGroupName: "MyResourceGroup",
     };


### PR DESCRIPTION
This PR adds UX for copy commands to create Kaito Federated Credentials without this, gpu-provisioner pod will be crash loop. 

![image](https://github.com/user-attachments/assets/5ad93c44-2049-4207-912a-def3a64c7c71)
