### PR TITLE
Fix for walkthrough and show welcome dependency.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,9 +69,11 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(uiExtensionVariables.outputChannel);
 
         registerUIExtensionVariables(uiExtensionVariables);
-        vscode.commands.executeCommand("workbench.action.openWalkthrough", {
-            category: "ms-kubernetes-tools.vscode-aks-tools#aksvscodewalkthrough",
-        });
+        if (vscode.workspace.getConfiguration("workbench").get("startupEditor") !== "none") {
+            vscode.commands.executeCommand("workbench.action.openWalkthrough", {
+                category: "ms-kubernetes-tools.vscode-aks-tools#aksvscodewalkthrough",
+            });
+        }
         registerCommandWithTelemetry("aks.signInToAzure", signInToAzure);
         registerCommandWithTelemetry("aks.selectTenant", selectTenant);
         registerCommandWithTelemetry("aks.selectSubscriptions", selectSubscriptions);


### PR DESCRIPTION
This fix is purely for the aspect of things which leads to the fixing #930 Now once user select the aka **uncheck** `show welcome page` the walk thought will not show up.

because upon uncheck the property in workspace gets set like this, and we are making sure walkthrough is not called until that is set. Thank you so much @ReinierCC for testing and fyi/collab. <3 

* VSIX for testing: 
[vscode-aks-tools-1.4.9-fixwalkthrough.vsix.zip](https://github.com/user-attachments/files/17067610/vscode-aks-tools-1.4.9-fixwalkthrough.vsix.zip)

* This one is proper zip file so unzip and then use the vsix under that to install.
[Uploading vscode-aks-tools-1.4.9-fixwalkthrough.vsix.zip…]()



<img width="549" alt="Screenshot 2024-09-20 at 10 18 07 AM" src="https://github.com/user-attachments/assets/a4da979c-9dd8-4796-9efb-7f117fd59efe">

