### PR TITLE
Fixing freezing dockerfile create page 

### DIFF
--- a/src/panels/draft/DraftDockerfilePanel.ts
+++ b/src/panels/draft/DraftDockerfilePanel.ts
@@ -135,7 +135,7 @@ export class DraftDockerfileDataProvider implements PanelDataProvider<"draftDock
         const variables = {
             PORT: port,
             VERSION: runtimeImageTag,
-            BUILDERVERSION: builderImageTag || "null",
+            BUILDERVERSION: builderImageTag,
         };
 
         const variableArgs = Object.entries(variables)

--- a/src/panels/draft/DraftDockerfilePanel.ts
+++ b/src/panels/draft/DraftDockerfilePanel.ts
@@ -135,7 +135,7 @@ export class DraftDockerfileDataProvider implements PanelDataProvider<"draftDock
         const variables = {
             PORT: port,
             VERSION: runtimeImageTag,
-            BUILDERVERSION: builderImageTag || "",
+            BUILDERVERSION: builderImageTag || "null",
         };
 
         const variableArgs = Object.entries(variables)


### PR DESCRIPTION
This PR is to fix the following issue:

<img width="582" alt="Screenshot 2024-09-24 at 11 15 44 AM" src="https://github.com/user-attachments/assets/3e9b9aa5-b1ee-4e70-9d16-2e1d25437c7b">

where the "Automated Deployments: Draft a Dockerfile" page would freeze for any user input after clicking the create button.

This occured because the draft command being executed to create the dockerfile was waiting for cli style user input about the BUILDVERSION.

<img width="566" alt="Screenshot 2024-09-24 at 11 17 50 AM" src="https://github.com/user-attachments/assets/b19109ec-38fb-4655-9e48-303d7b8893c2">

Previously the builderImageTag was or'ed with an empty string. But builderImageTag was already of type string | null .
<img width="310" alt="Screenshot 2024-09-24 at 11 19 46 AM" src="https://github.com/user-attachments/assets/4d16c3ea-d79f-49cc-8c35-4e35553caf15">

<img width="405" alt="Screenshot 2024-09-24 at 11 21 28 AM" src="https://github.com/user-attachments/assets/a3dce121-0d8e-4196-9636-f72c5d258058">

By removing the empty string, the draft binary uses BUILDERTAG as null and does not request user input.

There still exists issue #944 for python dockerfiles. But the fix for that would best come from a modification to the draft binary itself. 
