### PR TITLE
New namespace creation in github workflow

### DIFF
--- a/resources/draft/workflow-helm.yml
+++ b/resources/draft/workflow-helm.yml
@@ -46,6 +46,7 @@ env:
   CHART_PATH: "your-chart-path"
   CHART_OVERRIDE_PATH: "your-chart-override-path"
   CHART_OVERRIDES: "your-chart-overrides"
+  NAMESPACE: 'your-namespace-name'
 
 jobs:
   buildImage:
@@ -102,6 +103,11 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
           admin: 'false'
           use-kubelogin: 'true'
+
+      # Check if namespace exists, if not create it
+      - name: Ensure Namespace exists
+        run: |
+          kubectl get namespace ${{ env.NAMESPACE }} || kubectl create namespace ${{ env.NAMESPACE }}
 
       # Deploys application based on manifest files from previous step
       - name: Deploy application

--- a/resources/draft/workflow-manifests.yml
+++ b/resources/draft/workflow-manifests.yml
@@ -39,6 +39,7 @@ env:
   ACR_RESOURCE_GROUP: "your-cluster-resource-group"
   CLUSTER_NAME: "your-cluster-name"
   DEPLOYMENT_MANIFEST_PATH: 'your-deployment-manifest-path'
+  NAMESPACE: 'your-namespace-name'
 
 jobs:
   buildImage:
@@ -95,6 +96,11 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
           admin: 'false'
           use-kubelogin: 'true'
+
+       # Check if namespace exists, if not create it
+      - name: Ensure Namespace exists
+        run: |
+          kubectl get namespace ${{ env.NAMESPACE }} || kubectl create namespace ${{ env.NAMESPACE }}
 
       # Deploys application based on given manifest file
       - name: Deploys application

--- a/src/commands/draft/baseWorkflowEditor.ts
+++ b/src/commands/draft/baseWorkflowEditor.ts
@@ -96,6 +96,7 @@ export abstract class BaseWorkflowEditor<TDeploymentType extends WorkflowDeploym
         this.updateEnvVar(envSymbol, "AZURE_CONTAINER_REGISTRY", this.createParams.acrName);
         this.updateEnvVar(envSymbol, "CLUSTER_RESOURCE_GROUP", this.createParams.clusterResourceGroup);
         this.updateEnvVar(envSymbol, "ACR_RESOURCE_GROUP", this.createParams.acrResourceGroup);
+        this.updateEnvVar(envSymbol, "NAMESPACE", this.createParams.namespace);
     }
 
     /**

--- a/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
+++ b/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
@@ -391,6 +391,9 @@ export function DraftWorkflow(initialState: InitialState) {
     const gitHubRepoTooltipMessage =
         "Select the primary/upstream fork of this repository.\n\nThis will allow you to select which branch will trigger the workflow.";
 
+    const namespaceTooltipMessage =
+        "Select the namespace in which the deployment will be created.\n\nIf the namespace does not exist, it will be created.";
+
     return (
         <>
             <form className={styles.wrapper} onSubmit={handleFormSubmit}>
@@ -656,6 +659,9 @@ export function DraftWorkflow(initialState: InitialState) {
                         <>
                             <label htmlFor="namespace-input" className={styles.label}>
                                 Namespace *
+                                <span className={"tooltip-holder"} data-tooltip-text={namespaceTooltipMessage}>
+                                    <i className={`${styles.inlineIcon} codicon codicon-info`} />
+                                </span>
                             </label>
 
                             <TextWithDropdown


### PR DESCRIPTION
Problem:

When a user specified a new namespace in the "Create a GitHub Workflow" page, the workflow created would crash because the new namespace was not being created prior to trying to deploy the application.

On the "Draft Deployment" page, the user is told that the namespace would be created if the namespace was new but, it would never get created:

![Screenshot 2024-09-24 at 3 07 23 PM](https://github.com/user-attachments/assets/92eda0cf-48a3-4f07-92b4-1c15e632ec43)

Solution:

Modified the yaml template files used to create the manifest and helm workflows to check if the namespace exists and if not creates it. As well provided a hover over text to the user to let them know the namespace would be created if not present: 

![Screenshot 2024-09-26 at 11 21 57 AM](https://github.com/user-attachments/assets/cf198e85-3706-4f01-b8e7-a16ea391f1a4)

Example action step when namespace exists:
![Screenshot 2024-09-26 at 10 48 54 AM](https://github.com/user-attachments/assets/4c0fa596-2ff0-4adb-ae9b-b863929eb601)

Example action step when namespace gets created:
![Screenshot 2024-09-26 at 10 46 50 AM](https://github.com/user-attachments/assets/43051039-3a62-4bd3-a599-ac11717e768e)

