### PR TITLE
role assignments for automatic sku

### DIFF
--- a/src/commands/utils/env.ts
+++ b/src/commands/utils/env.ts
@@ -14,3 +14,10 @@ export function getPortalResourceUrl(environment: Environment, armId: string): s
     const portalUrl = environment.portalUrl.replace(/\/$/, "");
     return `${portalUrl}/#resource${armId}?referrer_source=vscode&referrer_context=${meta.name}`;
 }
+
+export function getDeploymentPortalUrl(environment: Environment, armId: string): string {
+    const portalUrl = environment.portalUrl.replace(/\/$/, "");
+    const encodedArmId = encodeURIComponent(armId);
+    const encodedReferrerContext = encodeURIComponent(meta.name);
+    return `${portalUrl}/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/${encodedArmId}?api-version=2020-06-01&referrer_source=vscode&referrer_context=${encodedReferrerContext}`;
+}

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -6,7 +6,7 @@ import { Uri, window } from "vscode";
 import { getEnvironment } from "../auth/azureAuth";
 import { AzureAuthenticationSession, ReadyAzureSessionProvider } from "../auth/types";
 import { getAksClient, getFeatureClient, getResourceManagementClient } from "../commands/utils/arm";
-import { getPortalResourceUrl } from "../commands/utils/env";
+import { getDeploymentPortalUrl, getPortalResourceUrl } from "../commands/utils/env";
 import { failed, getErrorMessage } from "../commands/utils/errorable";
 import {
     createMultipleFeatureRegistrations,
@@ -307,7 +307,7 @@ async function createCluster(
             deploymentSpec,
         );
         const deploymentArmId = `/subscriptions/${subscriptionId}/resourcegroups/${groupName}/providers/Microsoft.Resources/deployments/${deploymentName}`;
-        const deploymentPortalUrl = getPortalResourceUrl(environment, deploymentArmId);
+        const deploymentPortalUrl = getDeploymentPortalUrl(environment, deploymentArmId);
         webview.postProgressUpdate({
             event: ProgressEventType.InProgress,
             operationDescription,

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -440,8 +440,7 @@ function isDefaultK8sVersion(version: KubernetesVersion): boolean {
     return "isDefault" in version && version.isDefault === true;
 }
 function getServicePrincipalId(result: AzureAuthenticationSession): string {
-    // we need servicePrincipalId of the logged in user which is after slash 
-    // example value: 'xxxxx-xxxx-xxxx-xxxx-2d7cd011db47/dcef9120-72c4-452c-8a69-xxxxxxx'
+    // we need servicePrincipalId of the logged in user which is after slash
     if (!result || !result.account || !result.account.id) {
         return "";
     }

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -440,7 +440,8 @@ function isDefaultK8sVersion(version: KubernetesVersion): boolean {
     return "isDefault" in version && version.isDefault === true;
 }
 function getServicePrincipalId(result: AzureAuthenticationSession): string {
-    // we need servicePrincipalId of the logged in user which is after slash example value: '72f988bf-86f1-41af-91ab-2d7cd011db47/dcef9120-72c4-452c-8a69-0462341b25bc'
+    // we need servicePrincipalId of the logged in user which is after slash 
+    // example value: 'xxxxx-xxxx-xxxx-xxxx-2d7cd011db47/dcef9120-72c4-452c-8a69-xxxxxxx'
     if (!result || !result.account || !result.account.id) {
         return "";
     }

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -4,7 +4,7 @@ import { ResourceGroup as ARMResourceGroup, ResourceManagementClient } from "@az
 import { RestError } from "@azure/storage-blob";
 import { Uri, window } from "vscode";
 import { getEnvironment } from "../auth/azureAuth";
-import { ReadyAzureSessionProvider } from "../auth/types";
+import { AzureAuthenticationSession, ReadyAzureSessionProvider } from "../auth/types";
 import { getAksClient, getFeatureClient, getResourceManagementClient } from "../commands/utils/arm";
 import { getPortalResourceUrl } from "../commands/utils/env";
 import { failed, getErrorMessage } from "../commands/utils/errorable";
@@ -249,6 +249,23 @@ async function createCluster(
         return;
     }
 
+    // if automatic preset, we need role assignments for the cluster RBAC admin role which requires service principal id
+    let servicePrincipalId = "";
+    if (preset === PresetType.Automatic) {
+        servicePrincipalId = getServicePrincipalId(session.result);
+        if (!servicePrincipalId) {
+            window.showErrorMessage("No service principal id available for logged in user.");
+            webview.postProgressUpdate({
+                event: ProgressEventType.Failed,
+                operationDescription,
+                errorMessage: "No service principal id available for logged in user.",
+                deploymentPortalUrl: null,
+                createdCluster: null,
+            });
+            return;
+        }
+    }
+
     const clusterSpec: ClusterSpec = {
         location,
         name,
@@ -256,6 +273,7 @@ async function createCluster(
         subscriptionId: subscriptionId,
         kubernetesVersion: kubernetesVersion.version,
         username: session.result.account.label, // Account label seems to be email address
+        servicePrincipalId: servicePrincipalId,
     };
 
     // Create a unique deployment name.
@@ -420,4 +438,11 @@ function isRestError(ex: unknown): ex is RestError {
 
 function isDefaultK8sVersion(version: KubernetesVersion): boolean {
     return "isDefault" in version && version.isDefault === true;
+}
+function getServicePrincipalId(result: AzureAuthenticationSession): string {
+    // we need servicePrincipalId of the logged in user which is after slash example value: '72f988bf-86f1-41af-91ab-2d7cd011db47/dcef9120-72c4-452c-8a69-0462341b25bc'
+    if (!result || !result.account || !result.account.id) {
+        return "";
+    }
+    return result.account.id.split("/")[1];
 }

--- a/src/panels/templates/AutomaticCreateCluster.json
+++ b/src/panels/templates/AutomaticCreateCluster.json
@@ -1,6 +1,13 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
+    "variables": {
+        "defaultAadProfile": {
+            "managed": true,
+            "adminGroupObjectIDs": "[parameters('adminGroupObjectIDs')]",
+            "enableAzureRBAC": "[parameters('azureRbac')]"
+        }
+    },
     "parameters": {
         "apiVersion": {
             "type": "string"
@@ -35,6 +42,111 @@
             "metadata": {
                 "description": "The identity of the managed cluster, if configured."
             }
+        },
+        "enableRBAC": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Boolean flag to turn on and off of RBAC."
+            }
+        },
+        "nodeResourceGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the resource group containing agent pool nodes."
+            }
+        },
+        "subscriptionId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The subscription id of the cluster."
+            }
+        },
+        "resourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The resource group name of the cluster."
+            }
+        },
+        "rbacName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the role assignment."
+            }
+        },
+        "nodeResourceGroupProfile": {
+            "type": "object",
+            "defaultValue": {
+                "restrictionLevel": "ReadOnly"
+            },
+            "metadata": {
+                "description": "Node resource group lockdown profile for a managed cluster."
+            }
+        },
+        "nodeProvisioningProfile": {
+            "type": "object",
+            "defaultValue": {
+                "mode": "Auto"
+            },
+            "metadata": {
+                "description": "The node provisioning mode."
+            }
+        },
+        "upgradeChannel": {
+            "defaultValue": "stable",
+            "type": "string",
+            "metadata": {
+                "description": "Auto upgrade channel for a managed cluster."
+            }
+        },
+        "adminGroupObjectIDs": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "An array of Microsoft Entra group object ids to give administrative access."
+            }
+        },
+        "azureRbac": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Enable or disable Azure RBAC."
+            }
+        },
+        "disableLocalAccounts": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Enable or disable local accounts."
+            }
+        },
+        "enableAadProfile": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Flag to turn on or off of Microsoft Entra ID Profile."
+            }
+        },
+        "nodeOSUpgradeChannel": {
+            "defaultValue": "NodeImage",
+            "type": "string",
+            "metadata": {
+                "description": "Auto upgrade channel for node OS security."
+            }
+        },
+        "supportPlan": {
+            "type": "string",
+            "defaultValue": "KubernetesOfficial"
+        },
+        "userPrincipalId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The user principal id."
+            }
         }
     },
     "resources": [
@@ -44,7 +156,18 @@
             "sku": "[parameters('clusterSku')]",
             "location": "[parameters('location')]",
             "name": "[parameters('resourceName')]",
+            "dependsOn": [],
             "properties": {
+                "enableRBAC": "[parameters('enableRBAC')]",
+                "nodeResourceGroup": "[parameters('nodeResourceGroup')]",
+                "nodeResourceGroupProfile": "[parameters('nodeResourceGroupProfile')]",
+                "nodeProvisioningProfile": "[parameters('nodeProvisioningProfile')]",
+                "disableLocalAccounts": "[parameters('disableLocalAccounts')]",
+                "aadProfile": "[if(parameters('enableAadProfile'), variables('defaultAadProfile'), null())]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "[parameters('upgradeChannel')]",
+                    "nodeOSUpgradeChannel": "[parameters('nodeOSUpgradeChannel')]"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "systempool",
@@ -53,9 +176,42 @@
                         "count": 3,
                         "osType": "Linux"
                     }
-                ]
+                ],
+                "supportPlan": "[parameters('supportPlan')]"
             },
             "identity": "[parameters('clusterIdentity')]"
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "[parameters('rbacName')]",
+            "apiVersion": "2019-05-01",
+            "resourceGroup": "[parameters('resourceGroupName')]",
+            "subscriptionId": "[parameters('subscriptionId')]",
+            "dependsOn": [
+                "[concat('Microsoft.ContainerService/managedClusters/', parameters('resourceName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "type": "Microsoft.ContainerService/managedClusters/providers/roleAssignments",
+                            "apiVersion": "2018-09-01-preview",
+                            "name": "[parameters('rbacName')]",
+                            "properties": {
+                                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')]",
+                                "principalId": "[parameters('userPrincipalId')]",
+                                "scope": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', parameters('resourceName'))]",
+                                "principalType": "User"
+                            }
+                        }
+                    ]
+                }
+            }
         }
     ]
 }

--- a/src/panels/templates/AutomaticCreateCluster.json
+++ b/src/panels/templates/AutomaticCreateCluster.json
@@ -183,8 +183,11 @@
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
+            "apiVersion": "2022-04-01",
             "name": "[guid(resourceGroup().id)]",
+            "dependsOn": [
+                "[concat('Microsoft.ContainerService/managedClusters/', parameters('resourceName'))]"
+            ],
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Authorization/roleDefinitions/', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')]",
                 "principalId": "[parameters('userPrincipalId')]",

--- a/src/panels/templates/AutomaticCreateCluster.json
+++ b/src/panels/templates/AutomaticCreateCluster.json
@@ -182,35 +182,14 @@
             "identity": "[parameters('clusterIdentity')]"
         },
         {
-            "type": "Microsoft.Resources/deployments",
-            "name": "[parameters('rbacName')]",
-            "apiVersion": "2019-05-01",
-            "resourceGroup": "[parameters('resourceGroupName')]",
-            "subscriptionId": "[parameters('subscriptionId')]",
-            "dependsOn": [
-                "[concat('Microsoft.ContainerService/managedClusters/', parameters('resourceName'))]"
-            ],
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[guid(resourceGroup().id)]",
             "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "type": "Microsoft.ContainerService/managedClusters/providers/roleAssignments",
-                            "apiVersion": "2018-09-01-preview",
-                            "name": "[parameters('rbacName')]",
-                            "properties": {
-                                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')]",
-                                "principalId": "[parameters('userPrincipalId')]",
-                                "scope": "[concat('/subscriptions/', subscription().subscriptionId, '/resourcegroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', parameters('resourceName'))]",
-                                "principalType": "User"
-                            }
-                        }
-                    ]
-                }
+                "roleDefinitionId": "[concat('/subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Authorization/roleDefinitions/', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')]",
+                "principalId": "[parameters('userPrincipalId')]",
+                "scope": "[resourceGroup().id]",
+                "principalType": "User"
             }
         }
     ]

--- a/src/panels/utilities/ClusterSpecCreationBuilder.ts
+++ b/src/panels/utilities/ClusterSpecCreationBuilder.ts
@@ -10,6 +10,7 @@ export type ClusterSpec = {
     subscriptionId: string;
     kubernetesVersion: string;
     username: string;
+    servicePrincipalId: string;
 };
 
 type TemplateContent = Record<string, unknown>;
@@ -58,6 +59,52 @@ export class ClusterDeploymentBuilder {
                     name: "Automatic",
                     tier: "Standard",
                 },
+            },
+            enableRBAC: {
+                value: true,
+            },
+            nodeResourceGroup: {
+                value: generateNodeResourceGroup(clusterSpec.resourceGroupName, clusterSpec.name, clusterSpec.location),
+            },
+            subscriptionId: {
+                value: clusterSpec.subscriptionId,
+            },
+            resourceGroupName: {
+                value: clusterSpec.resourceGroupName,
+            },
+            nodeResourceGroupProfile: {
+                value: {
+                    restrictionLevel: "ReadOnly",
+                },
+            },
+            nodeProvisioningProfile: {
+                value: {
+                    mode: "Auto",
+                },
+            },
+            upgradeChannel: {
+                value: "stable",
+            },
+            disableLocalAccounts: {
+                value: true,
+            },
+            enableAadProfile: {
+                value: true,
+            },
+            azureRbac: {
+                value: true,
+            },
+            adminGroupObjectIDs: {
+                value: [],
+            },
+            supportPlan: {
+                value: "KubernetesOfficial",
+            },
+            nodeOSUpgradeChannel: {
+                value: "NodeImage",
+            },
+            userPrincipalId: {
+                value: clusterSpec.servicePrincipalId,
             },
         };
 

--- a/src/panels/utilities/ClusterSpecCreationBuilder.ts
+++ b/src/panels/utilities/ClusterSpecCreationBuilder.ts
@@ -106,6 +106,9 @@ export class ClusterDeploymentBuilder {
             userPrincipalId: {
                 value: clusterSpec.servicePrincipalId,
             },
+            rbacName: {
+                value: generateRbacName(),
+            },
         };
 
         return this;
@@ -178,4 +181,8 @@ function generateNodeResourceGroup(resourceGroupName: string, clusterName: strin
 
 function removeWhitespace(str: string): string {
     return str.replace(/\s+/g, "");
+}
+
+function generateRbacName() {
+    return "AzureKubernetesServiceRbacAdmin".concat("-", new Date().toISOString().replace(/[^0-9]/g, ""));
 }


### PR DESCRIPTION
This PR address two issues 

1. enhances the automatic sku preset cluster creation with Azure Kubernetes Service RBAC Cluster Admin role assigned to the user whoever creates the cluster. 
2. fixes the deployment url same to portal deploment blades
