### PR TITLE
fix for different format of serviceprincal id from auth sessions

### DIFF
--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -444,5 +444,13 @@ function getServicePrincipalId(result: AzureAuthenticationSession): string {
     if (!result || !result.account || !result.account.id) {
         return "";
     }
-    return result.account.id.split("/")[1];
+    // account id is in the format of tenantID/servicePrincipalId
+    // sometimes in case of non aad auth it is in the format of servicePrincipalId.tenantID
+    if (result.account.id.includes("/")) {
+        return result.account.id.split("/")[1];
+    } else if (result.account.id.includes(".")) {
+        return result.account.id.split(".")[0];
+    } else {
+        return "";
+    }
 }

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -441,15 +441,16 @@ function isDefaultK8sVersion(version: KubernetesVersion): boolean {
 }
 function getServicePrincipalId(result: AzureAuthenticationSession): string {
     // we need servicePrincipalId of the logged in user which is after slash
-    if (!result || !result.account || !result.account.id) {
+    if (!result?.account?.id) {
         return "";
     }
     // account id is in the format of tenantID/servicePrincipalId
     // sometimes in case of non aad auth it is in the format of servicePrincipalId.tenantID
-    if (result.account.id.includes("/")) {
-        return result.account.id.split("/")[1];
-    } else if (result.account.id.includes(".")) {
-        return result.account.id.split(".")[0];
+    const accountId = result.account.id;
+    if (accountId.includes("/")) {
+        return accountId.split("/")[1];
+    } else if (accountId.includes(".")) {
+        return accountId.split(".")[0];
     } else {
         return "";
     }


### PR DESCRIPTION
This PR fixes when vscode authentication api returns tenantId and servicePrincipal in different formats. 