### PR TITLE
Fix dependabot update for 1.94 with engine update.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "@types/sinon": "^17.0.3",
                 "@types/tmp": "^0.2.6",
                 "@types/uuid": "^10.0.0",
-                "@types/vscode": "^1.93.0",
+                "@types/vscode": "^1.94.0",
                 "@typescript-eslint/eslint-plugin": "^8.8.1",
                 "@typescript-eslint/parser": "^8.8.1",
                 "@vscode/test-electron": "^2.4.1",
@@ -67,7 +67,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.93.0"
+                "vscode": "^1.94.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -1511,10 +1511,11 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.93.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
-            "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
-            "dev": true
+            "version": "1.94.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz",
+            "integrity": "sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",
     "engines": {
-        "vscode": "^1.93.0"
+        "vscode": "^1.94.0"
     },
     "capabilities": {
         "untrustedWorkspaces": {
@@ -562,7 +562,7 @@
         "@types/sinon": "^17.0.3",
         "@types/tmp": "^0.2.6",
         "@types/uuid": "^10.0.0",
-        "@types/vscode": "^1.93.0",
+        "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
         "@typescript-eslint/parser": "^8.8.1",
         "@vscode/test-electron": "^2.4.1",


### PR DESCRIPTION
This PR fixes the dependabot update for 1.94 with engine update. https://github.com/Azure/vscode-aks-tools/pull/977 

Thanks heaps,
