### PR TITLE
Publishing version 1.4.11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [1.4.11]
+
+* <Place Holder for last PR to be Reviewed>
+* Kubectl savedialog UX changes.
+* Support creating automatic aks from GH Copilot.
+* Kubectl command generation plugin for GH Copilot.
+* Add cluster options util for GH Copilot scenarios
+* Fix dependabot update for 1.94 with engine update.
+* Fix for different format of serviceprincal id from auth sessions.
+* Role assignments for automatic sku.
+* Support create automatic aks cluster.
+* New namespace creation in github workflow.
+* Dependabot updates and bumps.
+
+Welcome new contributors @kejatura-dev to the repo. Thanks to  @tejhan, @ReinierCC,  @ivelisseca, @qpetraroia, @hsubramanianaks, Joy for contributions, testing and reviews.
+
 ## [1.4.10]
 
 * Fix for walkthrough and show welcome dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.10",
+    "version": "1.4.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.10",
+            "version": "1.4.11",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.10",
+    "version": "1.4.11",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release `1.4.11`, please see the details below.

* ~<Place Holder for last PR to be Reviewed>~ Add deploy manifest handler for GH Copilot. 
* Kubectl savedialog UX changes.
* Support creating automatic aks from GH Copilot.
* Kubectl command generation plugin for GH Copilot.
* Add cluster options util for GH Copilot scenarios
* Fix dependabot update for 1.94 with engine update.
* Fix for different format of serviceprincal id from auth sessions.
* Role assignments for automatic sku.
* Support create automatic aks cluster.
* New namespace creation in github workflow.
* Dependabot updates and bumps.

Thanks all. fyi @kejatura-dev to the repo. Thanks heaps to  @tejhan, @ReinierCC,  @ivelisseca, @qpetraroia, @hsubramanianaks, Joy, @gambtho
