### PR TITLE
Improvements for GH copilot handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.11-handler-improvements",
+    "version": "1.4.11",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",

--- a/src/auth/azureSessionProvider.ts
+++ b/src/auth/azureSessionProvider.ts
@@ -291,14 +291,14 @@ async function getTenants(session: AuthenticationSession): Promise<Errorable<Ten
     const subscriptionClient = new SubscriptionClient(credential, { endpoint: armEndpoint });
 
     const tenantsResult = await listAll(subscriptionClient.tenants.list());
-    return errmap(tenantsResult, (t) => t.filter(isTenant).map((t) => ({ name: t.displayName, id: t.tenantId })));
+    return errmap(tenantsResult, (t) => t.filter(isTenant).map((t) => ({ name: t.displayName, id: t.tenantId, countryCode: t.countryCode })));
 }
 
 function findTenant(tenants: Tenant[], tenantId: string): Tenant | null {
     return tenants.find((t) => t.id === tenantId) || null;
 }
 
-function isTenant(tenant: TenantIdDescription): tenant is { tenantId: string; displayName: string } {
+function isTenant(tenant: TenantIdDescription): tenant is { tenantId: string; displayName: string, countryCode: string } {
     return tenant.tenantId !== undefined && tenant.displayName !== undefined;
 }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -15,6 +15,7 @@ export type AzureAuthenticationSession = AuthenticationSession & {
 export type Tenant = {
     name: string;
     id: string;
+    countryCode?: string;
 };
 
 export type GetAuthSessionOptions = {

--- a/src/commands/aksCreateCluster/aksCreateCluster.ts
+++ b/src/commands/aksCreateCluster/aksCreateCluster.ts
@@ -18,6 +18,7 @@ export default async function aksCreateCluster(_context: IActionContext, target:
     let subscriptionNode: Errorable<SubscriptionTreeNode>;
     let subscriptionId: string | undefined;
     let subscriptionName: string | undefined;
+    let commandId: string = "";
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
 
     const sessionProvider = await getReadySessionProvider();
@@ -33,6 +34,7 @@ export default async function aksCreateCluster(_context: IActionContext, target:
                 vscode.window.showErrorMessage(subscriptionResult.error);
                 return;
             }
+            commandId = "aks.aksCreateClusterFromCopilot";
             subscriptionId = subscriptionResult.result?.subscriptionId;
             subscriptionName = subscriptionResult.result?.displayName;
             break;
@@ -48,11 +50,11 @@ export default async function aksCreateCluster(_context: IActionContext, target:
                 vscode.window.showErrorMessage("Subscription not found.");
                 return;
             }
+            commandId = "aks.createCluster";
             subscriptionId = subscriptionNode.result?.subscriptionId;
             subscriptionName = subscriptionNode.result?.name;
             break;
         }
-
     }
 
     const extension = getExtension();
@@ -68,8 +70,12 @@ export default async function aksCreateCluster(_context: IActionContext, target:
         return;
     }
 
-    const dataProvider = new CreateClusterDataProvider(sessionProvider.result, subscriptionId, subscriptionName, () =>
-        vscode.commands.executeCommand("aks.refreshSubscription", target),
+    const dataProvider = new CreateClusterDataProvider(
+        sessionProvider.result,
+        subscriptionId,
+        subscriptionName,
+        () => vscode.commands.executeCommand("aks.refreshSubscription", target),
+        commandId,
     );
 
     panel.show(dataProvider);

--- a/src/commands/aksCreateCluster/aksCreateCluster.ts
+++ b/src/commands/aksCreateCluster/aksCreateCluster.ts
@@ -4,10 +4,9 @@ import * as k8s from "vscode-kubernetes-tools-api";
 import { getReadySessionProvider } from "../../auth/azureAuth";
 import { CreateClusterDataProvider, CreateClusterPanel } from "../../panels/CreateClusterPanel";
 import { getAksClusterSubscriptionNode } from "../utils/clusters";
-import { Errorable, failed } from "../utils/errorable";
+import { failed } from "../utils/errorable";
 import { getExtension } from "../utils/host";
 import { getSubscription } from "../utils/subscriptions";
-import { SubscriptionTreeNode } from "../../tree/subscriptionTreeItem";
 
 /**
  * A multi-step input using window.createQuickPick() and window.createInputBox().
@@ -15,46 +14,45 @@ import { SubscriptionTreeNode } from "../../tree/subscriptionTreeItem";
  * This first part uses the helper class `MultiStepInput` that wraps the API for the multi-step case.
  */
 export default async function aksCreateCluster(_context: IActionContext, target: unknown): Promise<void> {
-    let subscriptionNode: Errorable<SubscriptionTreeNode>;
     let subscriptionId: string | undefined;
     let subscriptionName: string | undefined;
-    let commandId: string = "";
-    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+    let commandId: string | undefined;
 
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
     const sessionProvider = await getReadySessionProvider();
+
     if (failed(sessionProvider)) {
         vscode.window.showErrorMessage(sessionProvider.error);
         return;
     }
 
-    switch (typeof target) {
-        case "string": {
-            const subscriptionResult = await getSubscription(sessionProvider.result, target);
-            if (failed(subscriptionResult)) {
-                vscode.window.showErrorMessage(subscriptionResult.error);
-                return;
-            }
-            commandId = "aks.aksCreateClusterFromCopilot";
-            subscriptionId = subscriptionResult.result?.subscriptionId;
-            subscriptionName = subscriptionResult.result?.displayName;
-            break;
+    if (typeof target === "string") {
+        const subscriptionResult = await getSubscription(sessionProvider.result, target);
+
+        if (failed(subscriptionResult)) {
+            vscode.window.showErrorMessage(subscriptionResult.error);
+            return;
         }
 
-        default: {
-            subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
-            if (failed(subscriptionNode)) {
-                vscode.window.showErrorMessage(subscriptionNode.error);
-                return;
-            }
-            if (!subscriptionNode.result || !subscriptionNode.result.subscriptionId || !subscriptionNode.result.name) {
-                vscode.window.showErrorMessage("Subscription not found.");
-                return;
-            }
-            commandId = "aks.createCluster";
-            subscriptionId = subscriptionNode.result?.subscriptionId;
-            subscriptionName = subscriptionNode.result?.name;
-            break;
+        commandId = "aks.aksCreateClusterFromCopilot";
+        subscriptionId = subscriptionResult.result?.subscriptionId;
+        subscriptionName = subscriptionResult.result?.displayName;
+    } else {
+        const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
+
+        if (failed(subscriptionNode)) {
+            vscode.window.showErrorMessage(subscriptionNode.error);
+            return;
         }
+
+        if (!subscriptionNode.result?.subscriptionId || !subscriptionNode.result?.name) {
+            vscode.window.showErrorMessage("Subscription not found.");
+            return;
+        }
+
+        commandId = "aks.createCluster";
+        subscriptionId = subscriptionNode.result?.subscriptionId;
+        subscriptionName = subscriptionNode.result?.name;
     }
 
     const extension = getExtension();

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -23,7 +23,7 @@ export async function aksCreateClusterFromCopilot(): Promise<void> {
     const subscriptionId = await selectSubscription();
 
     if (!subscriptionId) {
-        vscode.window.showErrorMessage("A Subscription Id is required to create an AKS cluster.");
+        vscode.window.showWarningMessage("Creating an AKS cluster requires a Subscription Id");
         return;
     }
 

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -9,6 +9,7 @@ import {
 } from "../utils/subscriptions";
 import { window } from "vscode";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
+import { reporter } from "../utils/reporter";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
@@ -23,6 +24,10 @@ export async function aksCreateClusterFromCopilot(): Promise<void> {
     const subscriptionId = await selectSubscription();
 
     if (!subscriptionId) {
+        reporter.sendTelemetryEvent("aks.ghcp", {
+            command: "aks.aksCreateClusterFromCopilot",
+            subscriptionSelected: "false",
+        });
         vscode.window.showWarningMessage("Creating an AKS cluster requires a Subscription Id");
         return;
     }

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/subscriptions";
 import { window } from "vscode";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
-import { reporter } from "../utils/reporter";
+import { logPluginHandlerEvent } from "../../plugins/shared/telemetry/logger";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
@@ -24,10 +24,7 @@ export async function aksCreateClusterFromCopilot(): Promise<void> {
     const subscriptionId = await selectSubscription();
 
     if (!subscriptionId) {
-        reporter.sendTelemetryEvent("aks.ghcp", {
-            command: "aks.aksCreateClusterFromCopilot",
-            subscriptionSelected: "false",
-        });
+        logPluginHandlerEvent({ commandId: "aks.aksCreateClusterFromCopilot", subscriptionSelected: "false" });
         vscode.window.showWarningMessage("Creating an AKS cluster requires a Subscription Id");
         return;
     }

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/subscriptions";
 import { window } from "vscode";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
-import { logPluginHandlerEvent } from "../../plugins/shared/telemetry/logger";
+import { logGitHubCopilotPluginEvent } from "../../plugins/shared/telemetry/logger";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
@@ -24,7 +24,7 @@ export async function aksCreateClusterFromCopilot(): Promise<void> {
     const subscriptionId = await selectSubscription();
 
     if (!subscriptionId) {
-        logPluginHandlerEvent({ commandId: "aks.aksCreateClusterFromCopilot", subscriptionSelected: "false" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksCreateClusterFromCopilot", subscriptionSelected: "false" });
         vscode.window.showWarningMessage("Creating an AKS cluster requires a Subscription Id");
         return;
     }

--- a/src/commands/aksDeployManifest/aksDeployManifest.ts
+++ b/src/commands/aksDeployManifest/aksDeployManifest.ts
@@ -53,6 +53,7 @@ export async function aksDeployManifest() {
         return;
     }
 
+    // Return value is boolean if user selects new cluster option, which should stop flow and guide user to create a new cluster first.
     if (cluster.result === true) {
         vscode.window.showInformationMessage("Please create AKS cluster before deploying the manifest.");
         return;

--- a/src/commands/aksDeployManifest/aksDeployManifest.ts
+++ b/src/commands/aksDeployManifest/aksDeployManifest.ts
@@ -14,6 +14,8 @@ import { createTempFile } from "../utils/tempfile";
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 const YAML_GLOB_PATTERN = "**/*.yaml";
 const EXCLUDE_PATTERN = "**/node_modules/**";
+const AUTOMATIC_WORKLOADS_PATH = "/aksAutomaticWorkloads";
+const BASE_WORKLOADS_PATH = "/workloads";
 
 export async function aksDeployManifest() {
     // Check if GitHub Copilot for Azure extension is installed
@@ -46,8 +48,8 @@ export async function aksDeployManifest() {
         return;
     }
 
-    if (cluster.result === false) {
-        vscode.window.showWarningMessage("No cluster selected.");
+    if (cluster.result === true) {
+        vscode.window.showInformationMessage("Please create AKS cluster before deploying the manifest.");
         return;
     }
 
@@ -172,6 +174,7 @@ async function deployApplicationToCluster(
     }
 
     // Generate and return the resource URL
-    const resourceUrl = getPortalResourceUrl(getEnvironment(), cluster.clusterId);
+    const clusterIdworkloadsPath = cluster.sku?.name === "Automatic" ? `${cluster.clusterId + AUTOMATIC_WORKLOADS_PATH}` : `${cluster.clusterId + BASE_WORKLOADS_PATH}`;
+    const resourceUrl = getPortalResourceUrl(getEnvironment(), clusterIdworkloadsPath);
     return { succeeded: true, result: { url: resourceUrl } };
 }

--- a/src/commands/aksDeployManifest/aksDeployManifest.ts
+++ b/src/commands/aksDeployManifest/aksDeployManifest.ts
@@ -10,7 +10,7 @@ import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotH
 import { longRunning } from "../utils/host";
 import { invokeKubectlCommand } from "../utils/kubectl";
 import { createTempFile } from "../utils/tempfile";
-import { logPluginHandlerEvent } from "../../plugins/shared/telemetry/logger";
+import { logGitHubCopilotPluginEvent } from "../../plugins/shared/telemetry/logger";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 const YAML_GLOB_PATTERN = "**/*.yaml";
@@ -31,11 +31,11 @@ export async function aksDeployManifest() {
     const manifest = await getManifestFile();
 
     if (manifest === undefined) {
-        logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", manifestSelected: "false" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", manifestSelected: "false" });
         return;
     }
 
-    logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", manifestSelected: "true" });
+    logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", manifestSelected: "true" });
 
     // Select cluster
     const sessionProvider = await getReadySessionProvider();
@@ -48,7 +48,7 @@ export async function aksDeployManifest() {
     const cluster = await selectClusterOptions(sessionProvider.result, undefined, "aks.aksDeployManifest");
 
     if (failed(cluster)) {
-        logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", clusterSelected: "false" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", clusterSelected: "false" });
         vscode.window.showErrorMessage(cluster.error);
         return;
     }
@@ -66,7 +66,7 @@ export async function aksDeployManifest() {
 
     if (!confirmed) {
         vscode.window.showWarningMessage("Manifest deployment cancelled.");
-        logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", deploymentCancelled: "true" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", manifestDeploymentCancelled: "true" });
         return;
     }
 
@@ -77,11 +77,11 @@ export async function aksDeployManifest() {
 
     if (failed(deploymentResult)) {
         vscode.window.showErrorMessage(deploymentResult.error);
-        logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", deploymentSuccess: "false" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", manifestDeploymentSuccess: "false" });
         return;
     }
 
-    logPluginHandlerEvent({ commandId: "aks.aksDeployManifest", deploymentSuccess: "true" });
+    logGitHubCopilotPluginEvent({ commandId: "aks.aksDeployManifest", manifestDeploymentSuccess: "true" });
 
     vscode.window
         .showInformationMessage(
@@ -90,9 +90,9 @@ export async function aksDeployManifest() {
         )
         .then((res) => {
             if (res) {
-                logPluginHandlerEvent({
+                logGitHubCopilotPluginEvent({
                     commandId: "aks.aksDeployManifest",
-                    successfulManifestDeploymentLinkClicked: "true",
+                    manifestDeploymentLinkClicked: "true",
                 });
                 vscode.env.openExternal(vscode.Uri.parse(deploymentResult.result.url));
             }

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -11,18 +11,18 @@ import { getReadySessionProvider } from "../../auth/azureAuth";
 import { selectClusterOptions, SelectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
 import { ClusterPreference } from "../../plugins/shared/types";
+import { reporter } from "../utils/reporter";
 
-const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot"
+const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
 export async function aksOpenKubectlPanel(_context: IActionContext, target: unknown) {
-
     const checkGitHubCopilotExtension = checkExtension(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
 
-    if(!checkGitHubCopilotExtension) {
+    if (!checkGitHubCopilotExtension) {
         handleExtensionDoesNotExist(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
         return;
     }
-    
+
     const kubectl = await k8s.extension.kubectl.v1;
 
     if (!kubectl.available) {
@@ -33,18 +33,24 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
     const responseCode = (target as CommandResponse).code;
     const sessionProvider = await getReadySessionProvider();
 
-    if(failed(sessionProvider)) {
+    if (failed(sessionProvider)) {
         vscode.window.showErrorMessage(sessionProvider.error);
         return;
     }
 
-    const cluster = await selectClusterOptions(sessionProvider.result, [SelectClusterOptions.NewCluster]);
+    const cluster = await selectClusterOptions(
+        sessionProvider.result,
+        [SelectClusterOptions.NewCluster],
+        "aks.aksOpenKubectlPanel",
+    );
 
     if (failed(cluster)) {
+        reporter.sendTelemetryEvent("aks.ghcp", { command: "aks.aksOpenKubectlPanel", clusterSelected: "false" });
         vscode.window.showErrorMessage(cluster.error);
         return;
     }
 
+    // This should never happen, since the new cluster option is excluded. Leaving here just in case.
     if (cluster.result === true) {
         vscode.window.showInformationMessage("No cluster selected. Please select a valid cluster.");
         return;
@@ -67,7 +73,7 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
         kubeConfigFile.filePath,
         clusterPreference.clusterName,
         customCommands,
-        responseCode
+        responseCode,
     );
     const panel = new KubectlPanel(extension.result.extensionUri);
 

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -11,7 +11,7 @@ import { getReadySessionProvider } from "../../auth/azureAuth";
 import { selectClusterOptions, SelectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
 import { ClusterPreference } from "../../plugins/shared/types";
-import { logPluginHandlerEvent } from "../../plugins/shared/telemetry/logger";
+import { logGitHubCopilotPluginEvent } from "../../plugins/shared/telemetry/logger";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
@@ -45,7 +45,7 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
     );
 
     if (failed(cluster)) {
-        logPluginHandlerEvent({ commandId: "aks.aksOpenKubectlPanel", clusterSelected: "false" });
+        logGitHubCopilotPluginEvent({ commandId: "aks.aksOpenKubectlPanel", clusterSelected: "false" });
         vscode.window.showErrorMessage(cluster.error);
         return;
     }

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -45,8 +45,8 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
         return;
     }
 
-    if (cluster.result === false) {
-        vscode.window.showErrorMessage("No cluster selected. Please select a valid cluster.");
+    if (cluster.result === true) {
+        vscode.window.showInformationMessage("No cluster selected. Please select a valid cluster.");
         return;
     }
 

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -11,7 +11,7 @@ import { getReadySessionProvider } from "../../auth/azureAuth";
 import { selectClusterOptions, SelectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
 import { ClusterPreference } from "../../plugins/shared/types";
-import { reporter } from "../utils/reporter";
+import { logPluginHandlerEvent } from "../../plugins/shared/telemetry/logger";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
@@ -45,7 +45,7 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
     );
 
     if (failed(cluster)) {
-        reporter.sendTelemetryEvent("aks.ghcp", { command: "aks.aksOpenKubectlPanel", clusterSelected: "false" });
+        logPluginHandlerEvent({ commandId: "aks.aksOpenKubectlPanel", clusterSelected: "false" });
         vscode.window.showErrorMessage(cluster.error);
         return;
     }

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -25,6 +25,7 @@ import {
 import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { ClusterDeploymentBuilder, ClusterSpec } from "./utilities/ClusterSpecCreationBuilder";
+import { reporter } from "../commands/utils/reporter";
 
 export class CreateClusterPanel extends BasePanel<"createCluster"> {
     constructor(extensionUri: Uri) {
@@ -40,16 +41,19 @@ export class CreateClusterDataProvider implements PanelDataProvider<"createClust
     private readonly resourceManagementClient: ResourceManagementClient;
     private readonly containerServiceClient: ContainerServiceClient;
     private readonly featureClient: FeatureClient;
+    private readonly commandId: string;
 
     public constructor(
         readonly sessionProvider: ReadyAzureSessionProvider,
         readonly subscriptionId: string,
         readonly subscriptionName: string,
         readonly refreshTree: () => void,
+        commandId: string,
     ) {
         this.resourceManagementClient = getResourceManagementClient(sessionProvider, this.subscriptionId);
         this.containerServiceClient = getAksClient(sessionProvider, this.subscriptionId);
         this.featureClient = getFeatureClient(sessionProvider, this.subscriptionId);
+        this.commandId = commandId;
     }
 
     getTitle(): string {
@@ -158,6 +162,7 @@ export class CreateClusterDataProvider implements PanelDataProvider<"createClust
             this.containerServiceClient,
             this.resourceManagementClient,
             this.featureClient,
+            this.commandId,
         );
 
         this.refreshTree();
@@ -209,6 +214,7 @@ async function createCluster(
     containerServiceClient: ContainerServiceClient,
     resourceManagementClient: ResourceManagementClient,
     featureClient: FeatureClient,
+    commandId: string,
 ) {
     const operationDescription = `Creating cluster ${name}`;
     webview.postProgressUpdate({
@@ -300,6 +306,9 @@ async function createCluster(
         return;
     }
 
+    // event name for telemetry reporter
+    const eventName = commandId === "aks.createCluster" ? "command" : "aks.ghcp";
+
     try {
         const poller = await resourceManagementClient.deployments.beginCreateOrUpdate(
             groupName,
@@ -326,6 +335,7 @@ async function createCluster(
                     createdCluster: null,
                 });
             } else if (state.status === "failed") {
+                reporter.sendTelemetryEvent(eventName, { command: commandId, creationSuccess: "false" });
                 const errorMessage = state.error ? getErrorMessage(state.error) : "Unknown error";
                 window.showErrorMessage(`Error creating AKS cluster ${name}: ${errorMessage}`);
                 webview.postProgressUpdate({
@@ -336,6 +346,7 @@ async function createCluster(
                     createdCluster: null,
                 });
             } else if (state.status === "succeeded") {
+                reporter.sendTelemetryEvent(eventName, { command: commandId, creationSuccess: "true" });
                 window.showInformationMessage(`Successfully created AKS cluster ${name}.`);
                 const armId = `/subscriptions/${subscriptionId}/resourceGroups/${groupName}/providers/Microsoft.ContainerService/managedClusters/${name}`;
                 webview.postProgressUpdate({

--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -335,7 +335,7 @@ async function createCluster(
                     createdCluster: null,
                 });
             } else if (state.status === "failed") {
-                reporter.sendTelemetryEvent(eventName, { command: commandId, creationSuccess: "false" });
+                reporter.sendTelemetryEvent(eventName, { command: commandId, clusterCreationSuccess: "false" });
                 const errorMessage = state.error ? getErrorMessage(state.error) : "Unknown error";
                 window.showErrorMessage(`Error creating AKS cluster ${name}: ${errorMessage}`);
                 webview.postProgressUpdate({
@@ -346,7 +346,7 @@ async function createCluster(
                     createdCluster: null,
                 });
             } else if (state.status === "succeeded") {
-                reporter.sendTelemetryEvent(eventName, { command: commandId, creationSuccess: "true" });
+                reporter.sendTelemetryEvent(eventName, { command: commandId, clusterCreationSuccess: "true" });
                 window.showInformationMessage(`Successfully created AKS cluster ${name}.`);
                 const armId = `/subscriptions/${subscriptionId}/resourceGroups/${groupName}/providers/Microsoft.ContainerService/managedClusters/${name}`;
                 webview.postProgressUpdate({

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -106,8 +106,7 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         // Function to escape JSONPATH expression
         function escapeJsonpath(jsonpath: string): string {
             let escapedJsonpath = "";
-            for (let i = 0; i < jsonpath.length; i++) {
-                const char = jsonpath[i];
+            for (const char of jsonpath) {
                 if (char === '"') {
                     escapedJsonpath += '\\"';
                 } else if (char === "'") {
@@ -120,13 +119,10 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         }
 
         // Replace JSONPATH expressions in the command
-        let match;
-        let transformedCommand = command;
-        while ((match = jsonpathRegex.exec(command)) !== null) {
-            const jsonpath = match[1];
+        const transformedCommand = command.replace(jsonpathRegex, (_match, jsonpath) => {
             const escapedJsonpath = escapeJsonpath(jsonpath);
-            transformedCommand = transformedCommand.replace(match[0], `-o jsonpath="${escapedJsonpath}"`);
-        }
+            return `-o jsonpath="${escapedJsonpath}"`;
+        });
 
         return transformedCommand;
     }

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -106,6 +106,7 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         // Replace single quotes with double quotes and escape inner double quotes
         const transformedCommand = command.replace(jsonpathRegex, (_match, jsonpath) => {
             const escapedJsonpath = jsonpath.replace(/"/g, '\\"').replace(/'/g, '"');
+            // eslint-disable-next-line no-useless-escape
             return `-o jsonpath=\"${escapedJsonpath}\"`;
         });
 

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -103,11 +103,13 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         // Regular expression to match JSONPATH expressions
         const jsonpathRegex = /-o jsonpath='([^']+)'/g;
 
-        // Replace single quotes with double quotes and escape inner double quotes
+        // Replace single quotes with double quotes and escape inner double quotes and backslashes
         const transformedCommand = command.replace(jsonpathRegex, (_match, jsonpath) => {
-            const escapedJsonpath = jsonpath.replace(/"/g, '\\"').replace(/'/g, '"');
-            // eslint-disable-next-line no-useless-escape
-            return `-o jsonpath=\"${escapedJsonpath}\"`;
+            const escapedJsonpath = jsonpath
+                .replace(/\\/g, "\\") // Escape backslashes
+                .replace(/"/g, '\\"') // Escape double quotes
+                .replace(/'/g, '"'); // Replace single quotes with double quotes
+            return `-o jsonpath="${escapedJsonpath}"`;
         });
 
         return transformedCommand;

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -106,7 +106,7 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         // Replace single quotes with double quotes and escape inner double quotes
         const transformedCommand = command.replace(jsonpathRegex, (_match, jsonpath) => {
             const escapedJsonpath = jsonpath.replace(/"/g, '\\"').replace(/'/g, '"');
-            return `-o jsonpath="${escapedJsonpath}"`;
+            return `-o jsonpath=\"${escapedJsonpath}\"`;
         });
 
         return transformedCommand;

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -65,6 +65,10 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
             command = command.replace("kubectl", "").trim();
         }
 
+        if (command.includes("jsonpath")) {
+            command = this.escapeAndReplaceQuotes(command);
+        }
+
         const kubectlresult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
 
         if (failed(kubectlresult)) {
@@ -93,5 +97,14 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
 
     private async handleDeleteCustomCommandRequest(name: string) {
         await deleteKubectlCustomCommand(name);
+    }
+
+    private escapeAndReplaceQuotes(command: string): string {
+        // Replace double quotes inside single quotes with escaped double quotes, then replace single outside with double quotes.
+        let escapedCommand = command.replace(/'([^']*)'/g, (_match, p1) => {
+            return '"' + p1.replace(/"/g, '\\"') + '"';
+        });
+
+        return escapedCommand;
     }
 }

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -66,7 +66,7 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         }
 
         if (command.includes("jsonpath")) {
-            command = this.transformCommand(command);
+            command = this.transformCommandForJSONPath(command);
         }
 
         const kubectlresult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
@@ -99,7 +99,7 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         await deleteKubectlCustomCommand(name);
     }
 
-    private transformCommand(command: string): string {
+    private transformCommandForJSONPath(command: string): string {
         // Regular expression to match JSONPATH expressions
         const jsonpathRegex = /-o jsonpath='([^']+)'/g;
 

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -104,26 +104,12 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         const jsonpathRegex = /-o jsonpath='([^']+)'/g;
 
         // Function to escape JSONPATH expression
-        function escapeJsonpath(jsonpath: string): string {
-            let escapedJsonpath = "";
-            for (const char of jsonpath) {
-                if (char === '"') {
-                    escapedJsonpath += '\\"';
-                } else if (char === "'") {
-                    escapedJsonpath += '"';
-                } else {
-                    escapedJsonpath += char;
-                }
-            }
-            return escapedJsonpath;
-        }
+        const escapeJsonpath = (jsonpath: string): string => jsonpath.replaceAll('"', '\\"').replaceAll("'", '"');
 
         // Replace JSONPATH expressions in the command
-        const transformedCommand = command.replace(jsonpathRegex, (_match, jsonpath) => {
+        return command.replace(jsonpathRegex, (_match, jsonpath) => {
             const escapedJsonpath = escapeJsonpath(jsonpath);
             return `-o jsonpath="${escapedJsonpath}"`;
         });
-
-        return transformedCommand;
     }
 }

--- a/src/plugins/kubectlGeneration/aksDocsRag/client.ts
+++ b/src/plugins/kubectlGeneration/aksDocsRag/client.ts
@@ -1,6 +1,6 @@
 import { ReadyAzureSessionProvider } from "../../../auth/types";
 import { Errorable, failed, getErrorMessage } from "../../../commands/utils/errorable";
-import { aksDocsRAGEndpoint, aksDocsRAGIntent, aksDocsRAGScenario, aksDocsRAGScopes } from "./constants";
+import { aksDocsRAGEndpoint, aksDocsRAGIntent, aksDocsRAGScenario, aksDocsRAGScopes, EUCountries } from "./constants";
 
 export function getAKSDocsRAGClient(sessionProvider: ReadyAzureSessionProvider) {
     return new AKSDocsRAGClient(sessionProvider);
@@ -69,6 +69,7 @@ export class AKSDocsRAGClient {
                     "Access-Control-Allow-Origin": "*",
                     Authorization: `Bearer ${this.authToken}`,
                     "App-Tenant-Id": this.sessionProvider.selectedTenant.id,
+                    "User-Data-Boundary": this.isEUBoundary(this.sessionProvider.selectedTenant.countryCode) ? "EU" : "Global",
                 },
                 body: JSON.stringify({
                     IsLocalEvaluation: false,
@@ -130,4 +131,12 @@ export class AKSDocsRAGClient {
             result: { response: parsedResponse },
         };
     }
+
+    private isEUBoundary(countryCode: string | undefined): boolean {
+        if(countryCode === undefined) {
+            // Default to EU if country code is not available, as this is the default used for the RAG endpoint
+            return true;
+        }
+        return EUCountries.includes(countryCode);
+    } 
 }

--- a/src/plugins/kubectlGeneration/aksDocsRag/client.ts
+++ b/src/plugins/kubectlGeneration/aksDocsRag/client.ts
@@ -1,6 +1,6 @@
 import { ReadyAzureSessionProvider } from "../../../auth/types";
 import { Errorable, failed, getErrorMessage } from "../../../commands/utils/errorable";
-import { aksDocsRAGEndpoint, aksDocsRAGIntent, aksDocsRAGScenario, aksDocsRAGScopes, EUCountries } from "./constants";
+import { aksDocsRAGEndpoint, aksDocsRAGIntent, aksDocsRAGScenario, aksDocsRAGScopes, EU_COUNTRIES } from "./constants";
 
 export function getAKSDocsRAGClient(sessionProvider: ReadyAzureSessionProvider) {
     return new AKSDocsRAGClient(sessionProvider);
@@ -69,7 +69,9 @@ export class AKSDocsRAGClient {
                     "Access-Control-Allow-Origin": "*",
                     Authorization: `Bearer ${this.authToken}`,
                     "App-Tenant-Id": this.sessionProvider.selectedTenant.id,
-                    "User-Data-Boundary": this.isEUBoundary(this.sessionProvider.selectedTenant.countryCode) ? "EU" : "Global",
+                    "User-Data-Boundary": this.isEUBoundary(this.sessionProvider.selectedTenant.countryCode)
+                        ? "EU"
+                        : "Global",
                 },
                 body: JSON.stringify({
                     IsLocalEvaluation: false,
@@ -133,10 +135,10 @@ export class AKSDocsRAGClient {
     }
 
     private isEUBoundary(countryCode: string | undefined): boolean {
-        if(countryCode === undefined) {
+        if (countryCode === undefined) {
             // Default to EU if country code is not available, as this is the default used for the RAG endpoint
             return true;
         }
-        return EUCountries.includes(countryCode);
-    } 
+        return EU_COUNTRIES.includes(countryCode);
+    }
 }

--- a/src/plugins/kubectlGeneration/aksDocsRag/client.ts
+++ b/src/plugins/kubectlGeneration/aksDocsRag/client.ts
@@ -136,7 +136,7 @@ export class AKSDocsRAGClient {
 
     private isEUBoundary(countryCode: string | undefined): boolean {
         if (countryCode === undefined) {
-            // Default to EU if country code is not available, as this is the default used for the RAG endpoint
+            // Default to EU data boundary if country code is not available, an iterim solution to ensure compliance with EU data protection regulations.
             return true;
         }
         return EU_COUNTRIES.includes(countryCode);

--- a/src/plugins/kubectlGeneration/aksDocsRag/constants.ts
+++ b/src/plugins/kubectlGeneration/aksDocsRag/constants.ts
@@ -7,4 +7,36 @@ export const aksDocsRAGScenario = "Azure Kubernetes Service";
 export const aksDocsRAGIntent = "RCH";
 
 // https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/communication-services/concepts/european-union-data-boundary.md
-export const EUCountries = ["AT", "BE", "BG", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MT", "NL", "NO", "PL", "PT", "RO", "SE", "SI", "SK"];
+export const EU_COUNTRIES = [
+    "AT",
+    "BE",
+    "BG",
+    "CH",
+    "CY",
+    "CZ",
+    "DE",
+    "DK",
+    "EE",
+    "ES",
+    "FI",
+    "FR",
+    "GR",
+    "HR",
+    "HU",
+    "IE",
+    "IS",
+    "IT",
+    "LI",
+    "LT",
+    "LU",
+    "LV",
+    "MT",
+    "NL",
+    "NO",
+    "PL",
+    "PT",
+    "RO",
+    "SE",
+    "SI",
+    "SK",
+];

--- a/src/plugins/kubectlGeneration/aksDocsRag/constants.ts
+++ b/src/plugins/kubectlGeneration/aksDocsRag/constants.ts
@@ -5,3 +5,6 @@ export const aksDocsRAGEndpoint = "https://pcnx-copilot-aqebbkc6frhyhkbx.z01.azu
 export const aksDocsRAGScenario = "Azure Kubernetes Service";
 
 export const aksDocsRAGIntent = "RCH";
+
+// https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/communication-services/concepts/european-union-data-boundary.md
+export const EUCountries = ["AT", "BE", "BG", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MT", "NL", "NO", "PL", "PT", "RO", "SE", "SI", "SK"];

--- a/src/plugins/shared/clusterOptions/options/selectExistingClusterOption.ts
+++ b/src/plugins/shared/clusterOptions/options/selectExistingClusterOption.ts
@@ -56,6 +56,7 @@ export async function selectExistingClusterOption(
         clusterId: properties.result.id,
         resourceGroup,
         kubeConfigYAML: kubeconfigYaml.result,
+        sku: properties.result.sku,
     };
 
     const saved = await RecentCluster.saveRecentCluster(cluster);

--- a/src/plugins/shared/clusterOptions/selectClusterOptions.ts
+++ b/src/plugins/shared/clusterOptions/selectClusterOptions.ts
@@ -1,12 +1,12 @@
 import { QuickPickItem, QuickPickItemKind, window } from "vscode";
 import { ReadyAzureSessionProvider } from "../../../auth/types";
-import { ClusterPreference } from "../types";
+import { ClusterPreference, CommandIdForPluginResponse } from "../types";
 import { Errorable } from "../../../commands/utils/errorable";
 import { RecentCluster } from "./state/recentCluster";
 import { selectExistingClusterOption } from "./options/selectExistingClusterOption";
 import { selectNewClusterOption } from "./options/selectNewClusterOption";
 import { selectRecentClusterOption } from "./options/selectRecentClusterOption";
-import { reporter } from "../../../commands/utils/reporter";
+import { logPluginHandlerEvent } from "../telemetry/logger";
 
 export enum SelectClusterOptions {
     RecentCluster = "RecentCluster",
@@ -26,7 +26,7 @@ const getClusterOptions = (): { label: string; type: SelectClusterOptions }[] =>
 export async function selectClusterOptions(
     sessionProvider: ReadyAzureSessionProvider,
     exclude?: SelectClusterOptions[],
-    commandId?: string,
+    commandId?: CommandIdForPluginResponse,
 ): Promise<Errorable<ClusterPreference | boolean>> {
     const options = getClusterOptions();
     let recentCluster: Errorable<ClusterPreference> | undefined;
@@ -74,7 +74,7 @@ export async function selectClusterOptions(
         return { succeeded: false, error: "Cluster option not selected." };
     }
 
-    reporter.sendTelemetryEvent("aks.ghcp", { clusterOptionSelected: selectedOption.type, commandId: commandId });
+    logPluginHandlerEvent({ clusterOptionSelected: selectedOption.type, commandId: commandId });
 
     switch (selectedOption.type) {
         case SelectClusterOptions.RecentCluster:

--- a/src/plugins/shared/clusterOptions/selectClusterOptions.ts
+++ b/src/plugins/shared/clusterOptions/selectClusterOptions.ts
@@ -6,7 +6,7 @@ import { RecentCluster } from "./state/recentCluster";
 import { selectExistingClusterOption } from "./options/selectExistingClusterOption";
 import { selectNewClusterOption } from "./options/selectNewClusterOption";
 import { selectRecentClusterOption } from "./options/selectRecentClusterOption";
-import { logPluginHandlerEvent } from "../telemetry/logger";
+import { logGitHubCopilotPluginEvent } from "../telemetry/logger";
 
 export enum SelectClusterOptions {
     RecentCluster = "RecentCluster",
@@ -74,7 +74,7 @@ export async function selectClusterOptions(
         return { succeeded: false, error: "Cluster option not selected." };
     }
 
-    logPluginHandlerEvent({ clusterOptionSelected: selectedOption.type, commandId: commandId });
+    logGitHubCopilotPluginEvent({ clusterOptionSelected: selectedOption.type, commandId: commandId });
 
     switch (selectedOption.type) {
         case SelectClusterOptions.RecentCluster:

--- a/src/plugins/shared/pluginResponses.ts
+++ b/src/plugins/shared/pluginResponses.ts
@@ -1,38 +1,46 @@
 import { Failed } from "../../commands/utils/errorable";
-import { GitHubCopilotForAzureChatPluginResponse, MessageForLanguageModel, GitHubCopilotForAzureChatPluginResponseExtended, GitHubCopilotForAzureChatPluginErrorResponse } from "./types";
+import {
+    GitHubCopilotForAzureChatPluginResponse,
+    MessageForLanguageModel,
+    GitHubCopilotForAzureChatPluginResponseExtended,
+    GitHubCopilotForAzureChatPluginErrorResponse,
+} from "./types";
 
 // Create AKS cluster plugin
 export const getAKSClusterPluginResponse = (): GitHubCopilotForAzureChatPluginResponse<MessageForLanguageModel> => {
     const messageForLanguageModel = {
-        description: "To create a new AKS cluster, please use the Azure Kubernetes Service (AKS) extension in Visual Studio Code. This extension provides a guided experience, making it easier to configure your cluster. Follow the extension's instructions to complete the setup.",
-        descriptionInstructions: "Focus on the description of the message, no need to add any other text. Also mention that the creation of an AKS cluster might take a few minutes.",
-    }
+        description:
+            "You can create an AKS cluster through Azure Kubernetes Service extension. This extension provides a guided experience, making it easier to configure your cluster.",
+        descriptionInstructions:
+            "Focus on the description of the message, no need to add any other text. Also mention that the creation of an AKS cluster might take a few minutes.",
+    };
 
     return {
         messageForLanguageModel: messageForLanguageModel,
         commandID: "aks.aksCreateClusterFromCopilot",
-        buttonLabel: "Get started"
-    }
-}
+        buttonLabel: "Get started",
+    };
+};
 
 //Deploy manifest to AKS cluster plugin
-export const getDeployManifestToAKSPluginResponse = (): GitHubCopilotForAzureChatPluginResponse<MessageForLanguageModel> => {
-    const messageForLanguageModel = {
-        description: "To deploy an application to an AKS cluster, you will need to do the following:",
-        steps: [
-            "1. Select the Kubernetes manifest *file* in your application.",
-            "2. Choose an existing cluster or create a new AKS Automatic or Dev/Test - (hint: add bullet) If you choose to create a new cluster, a page will guide you. (hint: add bullet) Once done, click 'Get Started' to continue deploying your application.",
-            "3. Deploy your application."
-        ],
-        stepsInstructions: "Focus on the steps of the message, no need to add any other text."
-    }
+export const getDeployManifestToAKSPluginResponse =
+    (): GitHubCopilotForAzureChatPluginResponse<MessageForLanguageModel> => {
+        const messageForLanguageModel = {
+            description: "To deploy an application to an AKS cluster, you will need to do the following:",
+            steps: [
+                "1. Select the Kubernetes manifest *file* in your application.",
+                "2. Choose an existing cluster or create a new AKS Automatic or Dev/Test - (hint: add bullet) If you choose to create a new cluster, a page will guide you. (hint: add bullet) Once done, click 'Get Started' to continue deploying your application.",
+                "3. Deploy your application.",
+            ],
+            stepsInstructions: "Focus on the steps of the message, no need to add any other text.",
+        };
 
-    return {
-        messageForLanguageModel: messageForLanguageModel,
-        commandID: "aks.aksDeployManifest",
-        buttonLabel: "Get started"
-    }
-};
+        return {
+            messageForLanguageModel: messageForLanguageModel,
+            commandID: "aks.aksDeployManifest",
+            buttonLabel: "Get started",
+        };
+    };
 
 // Kubectl command generation plugin
 export interface CommandResponse {
@@ -41,31 +49,39 @@ export interface CommandResponse {
     code: string;
 }
 
-type MessageForLanguageModelForKubectlCommandPlugin = MessageForLanguageModel & { kubectlCommand: string; kubectlCommandInstructions: string; }
+type MessageForLanguageModelForKubectlCommandPlugin = MessageForLanguageModel & {
+    kubectlCommand: string;
+    kubectlCommandInstructions: string;
+};
 
-export const getKubectlCommandPluginResponse = (response: CommandResponse): GitHubCopilotForAzureChatPluginResponseExtended<MessageForLanguageModelForKubectlCommandPlugin, CommandResponse> => {
+export const getKubectlCommandPluginResponse = (
+    response: CommandResponse,
+): GitHubCopilotForAzureChatPluginResponseExtended<MessageForLanguageModelForKubectlCommandPlugin, CommandResponse> => {
     const messageForLanguageModel = {
-        description: response.message,
-        desciptionInstructions: "Remove any text that says `use the followin command:`, replace with `here's what we'll need to do`",
-        steps: ["1. Select an AKS cluster.", "2. Run the kubectl command within the AKS extension panel."],
+        description: `${response.message}. You can run this command in the Azure Kubernetes Service Extension panel`,
+        steps: ["You can also scope the information to a specific cluster, and then run the kubectl command"],
         kubectlCommand: response.code,
-        kubectlCommandInstructions: "Display the kubectl command *as is*, *do not alter the generated command, or suggest*. *KEEP ALL PLACEHOLDERS if present, DO NOT CHANGE COMMAND WHATSOEVER*",
-        responseInstructions: "*Important* Show the following in order without any titles, combine the description and steps together (make it flow), kubectl command, then display the chat response button to excute the command",
-    }
+        kubectlCommandInstructions:
+            "Display the kubectl command *as is*, *do not alter the generated command, or suggest*. *KEEP ALL PLACEHOLDERS if present, DO NOT CHANGE COMMAND WHATSOEVER*",
+        responseInstructions:
+            "*Important* Show the following in order without any titles, show the description, kubectl command, display steps, then the chat response button to launch the panel",
+    };
     return {
         messageForLanguageModel: messageForLanguageModel,
         commandID: "aks.aksOpenKubectlPanel",
-        buttonLabel: "Execute kubectl command",
-        arguments: [response]
-    }
-}
+        buttonLabel: "Open kubectl command",
+        arguments: [response],
+    };
+};
 
-export const getKubectlCommandPluginErrorResponse = (response: Failed): GitHubCopilotForAzureChatPluginErrorResponse<MessageForLanguageModel> => {
+export const getKubectlCommandPluginErrorResponse = (
+    response: Failed,
+): GitHubCopilotForAzureChatPluginErrorResponse<MessageForLanguageModel> => {
     const messageForLanguageModel = {
         description: response.error,
         desciptionInstructions: "Display error message *as is*.",
-    }
+    };
     return {
         messageForLanguageModel: messageForLanguageModel,
-    }
-}
+    };
+};

--- a/src/plugins/shared/pluginResponses.ts
+++ b/src/plugins/shared/pluginResponses.ts
@@ -18,7 +18,7 @@ export const getAKSClusterPluginResponse = (): GitHubCopilotForAzureChatPluginRe
     return {
         messageForLanguageModel: messageForLanguageModel,
         commandID: "aks.aksCreateClusterFromCopilot",
-        buttonLabel: "Get started",
+        buttonLabel: "Create cluster",
     };
 };
 
@@ -69,7 +69,7 @@ export const getKubectlCommandPluginResponse = (
     return {
         messageForLanguageModel: messageForLanguageModel,
         commandID: "aks.aksOpenKubectlPanel",
-        buttonLabel: "Open kubectl command",
+        buttonLabel: "Open kubectl panel",
         arguments: [response],
     };
 };

--- a/src/plugins/shared/pluginResponses.ts
+++ b/src/plugins/shared/pluginResponses.ts
@@ -60,6 +60,7 @@ export const getKubectlCommandPluginResponse = (
     const messageForLanguageModel = {
         description: `${response.message}. You can run this command in the Azure Kubernetes Service Extension panel`,
         steps: ["You can also scope the information to a specific cluster, and then run the kubectl command"],
+        stepsInstructions: "Do not show steps title, just list the steps with bullet points",
         kubectlCommand: response.code,
         kubectlCommandInstructions:
             "Display the kubectl command *as is*, *do not alter the generated command, or suggest*. *KEEP ALL PLACEHOLDERS if present, DO NOT CHANGE COMMAND WHATSOEVER*",

--- a/src/plugins/shared/telemetry/logger.ts
+++ b/src/plugins/shared/telemetry/logger.ts
@@ -2,37 +2,33 @@ import { reporter } from "../../../commands/utils/reporter";
 import { SelectClusterOptions } from "../clusterOptions/selectClusterOptions";
 import { CommandIdForPluginResponse } from "../types";
 
-interface EventProperties {
-    // command that invoked the telemetry event, log only the command Id
+interface GHCopilotEventProperties {
+    // command that invoked the telemetry event, log only the VS Code command Id
     commandId?: CommandIdForPluginResponse;
 
-    // determine if subscription was successfully selected or not
+    // determine if subscription was successfully selected or not during flow
     subscriptionSelected?: "true" | "false";
 
-    // determine if manifest was successfully selected or not
+    // determine if manifest was successfully selected or not during flow
     manifestSelected?: "true" | "false";
 
-    // determine if cluster was successfully selected or not
+    // determine if cluster was successfully selected or not during flow
     clusterSelected?: "true" | "false";
 
-    // determine if deployment was cancelled or not
-    deploymentCancelled?: "true" | "false";
+    // determine if manifest deployment was cancelled or not during flow
+    manifestDeploymentCancelled?: "true" | "false";
 
-    // determine if deployment was successful or not
-    deploymentSuccess?: "true" | "false";
+    // determine if manifest deployment was successful or not during flow
+    manifestDeploymentSuccess?: "true" | "false";
 
-    // command that was generated from ghcp handler and copied into Kubectl panel
-    kubectlCommand?: string;
-
-    // cluster option selected by user
+    // cluster option selected by user during flow
     clusterOptionSelected?: SelectClusterOptions;
 
     // determine if successful manifest deployment link was clicked or not
-    successfulManifestDeploymentLinkClicked?: "true" | "false";
+    manifestDeploymentLinkClicked?: "true" | "false";
 }
-
 const TELEMETRY_EVENT_NAME = "aks.ghcp";
 
-export function logPluginHandlerEvent(properties?: EventProperties): void {
+export function logGitHubCopilotPluginEvent(properties?: GHCopilotEventProperties): void {
     reporter.sendTelemetryEvent(TELEMETRY_EVENT_NAME, { ...properties });
 }

--- a/src/plugins/shared/telemetry/logger.ts
+++ b/src/plugins/shared/telemetry/logger.ts
@@ -1,0 +1,38 @@
+import { reporter } from "../../../commands/utils/reporter";
+import { SelectClusterOptions } from "../clusterOptions/selectClusterOptions";
+import { CommandIdForPluginResponse } from "../types";
+
+interface EventProperties {
+    // command that invoked the telemetry event, log only the command Id
+    commandId?: CommandIdForPluginResponse;
+
+    // determine if subscription was successfully selected or not
+    subscriptionSelected?: "true" | "false";
+
+    // determine if manifest was successfully selected or not
+    manifestSelected?: "true" | "false";
+
+    // determine if cluster was successfully selected or not
+    clusterSelected?: "true" | "false";
+
+    // determine if deployment was cancelled or not
+    deploymentCancelled?: "true" | "false";
+
+    // determine if deployment was successful or not
+    deploymentSuccess?: "true" | "false";
+
+    // command that was generated from ghcp handler and copied into Kubectl panel
+    kubectlCommand?: string;
+
+    // cluster option selected by user
+    clusterOptionSelected?: SelectClusterOptions;
+
+    // determine if successful manifest deployment link was clicked or not
+    successfulManifestDeploymentLinkClicked?: "true" | "false";
+}
+
+const TELEMETRY_EVENT_NAME = "aks.ghcp";
+
+export function logPluginHandlerEvent(properties?: EventProperties): void {
+    reporter.sendTelemetryEvent(TELEMETRY_EVENT_NAME, { ...properties });
+}

--- a/src/plugins/shared/types.ts
+++ b/src/plugins/shared/types.ts
@@ -15,18 +15,23 @@ export type MessageForLanguageModel = {
     steps?: string[];
     stepsInstructions?: string;
     chatResponseInstructions?: string;
-}
+};
 
 export type GitHubCopilotForAzureChatPluginResponse<T> = {
     messageForLanguageModel: T;
     buttonLabel: string;
-    commandID: string;
-}
+    commandID: CommandIdForPluginResponse;
+};
 
 export type GitHubCopilotForAzureChatPluginResponseExtended<E, T> = GitHubCopilotForAzureChatPluginResponse<E> & {
     arguments: T[] | undefined;
-}
+};
 
 export type GitHubCopilotForAzureChatPluginErrorResponse<T> = {
     messageForLanguageModel: T;
-}
+};
+
+export type CommandIdForPluginResponse =
+    | "aks.aksDeployManifest"
+    | "aks.aksOpenKubectlPanel"
+    | "aks.aksCreateClusterFromCopilot";

--- a/src/plugins/shared/types.ts
+++ b/src/plugins/shared/types.ts
@@ -1,9 +1,12 @@
+import { ManagedClusterSKU } from "@azure/arm-containerservice";
+
 export type ClusterPreference = {
     subscriptionId: string;
     clusterName: string;
     clusterId: string;
     resourceGroup: string;
     kubeConfigYAML: string;
+    sku?: ManagedClusterSKU;
 };
 
 export type MessageForLanguageModel = {


### PR DESCRIPTION
This PR makes improvements to GHCP handlers UX:
- Fixes the jsonpath escape quotes for the kubectl command invocation.
- Deployment of manifest success link is now routed to workloads page in Azure portal.
- Adds EU boundary header for RAG client. This is ensures compliance with EUDP. 
    - Maintain list of EU regions as stated in azure docs (link in commented code)  
- Adds useful telemetry for the handlers. --- No PII or user data are getting logged, only actions/commands.
- Improve plugin responses:
    - Kubectl command generation handler:  
      ![image](https://github.com/user-attachments/assets/63667c25-1261-4fce-8209-1d568aae9cc8)

    - Create AKS cluster handler:
      ![image](https://github.com/user-attachments/assets/03b947dc-ca4f-4d53-af51-bff83c4cae37)
   