### PR TITLE
kaito needs to be KAITO named.

### DIFF
--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -24,7 +24,7 @@ Azure Kubernetes Service (AKS) Extension for Visual Studio Code helps enable AKS
 * [Run Image Cleaner Eraser Tool](./features/image-cleaner-eraser-tool.md)
 * [Run Retina Capture](./features/retina-capture.md)
 * [Run Automated Deployments Commands](./features/draft-integration.md)
-* [Install & Deploy Kaito Models](./features/kaito-integration.md)
+* [Install & Deploy KAITO Models](./features/kaito-integration.md)
 
 ## Development and Release
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -25,7 +25,7 @@
   - [Run Image Cleaner Eraser Tool](./features/image-cleaner-eraser-tool.md)
   - [Run Retina Capture](./features/retina-capture.md)
   - [Run Draft Command](./features/draft-integration.md)
-  - [Install & Deploy Kaito Models](./features/kaito-integration.md)
+  - [Install & Deploy KAITO Models](./features/kaito-integration.md)
 
 - [Release](./release.md)
   - [Releasing Information](./release/releasing.md)

--- a/package.json
+++ b/package.json
@@ -310,15 +310,15 @@
             },
             {
                 "command": "aks.aksKaitoGenerateYaml",
-                "title": "Create Kaito Workspace"
+                "title": "Create KAITO Workspace"
             },
             {
                 "command": "aks.aksKaitoCreateCRD",
-                "title": "Create Kaito Workspace"
+                "title": "Create KAITO Workspace"
             },
             {
                 "command": "aks.aksKaito",
-                "title": "Install Kaito"
+                "title": "Install KAITO"
             }
         ],
         "menus": {

--- a/src/commands/aksKaito/akskaitoGenerateYaml.ts
+++ b/src/commands/aksKaito/akskaitoGenerateYaml.ts
@@ -51,7 +51,7 @@ export default async function aksKaitoGenerateYaml(_context: IActionContext, tar
     // Check if Kaito pods  exist
     if (filterKaitoPodNames.result.length === 0) {
         vscode.window.showWarningMessage(
-            `Please install Kaito for cluster ${clusterName}. \n \n Kaito Workspace generation is only enabled when kaito is installed. Skipping generation.`,
+            `Please install KAITO for cluster ${clusterName}. \n \n Kaito Workspace generation is only enabled when kaito is installed. Skipping generation.`,
         );
         return;
     }

--- a/src/panels/KaitoPanel.ts
+++ b/src/panels/KaitoPanel.ts
@@ -170,7 +170,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
 
         // Install kaito enablement
         const kaitoInstallationResult = await longRunning(
-            `Enabling the kaito for cluster '${this.clusterName}'.`,
+            `Enabling the KAITO for cluster '${this.clusterName}'.`,
             () => {
                 return this.handleKaitoInstallationLogic(currentJson, webview);
             },
@@ -178,7 +178,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
 
         if (kaitoInstallationResult && failed(kaitoInstallationResult)) {
             vscode.window.showErrorMessage(
-                `Error installing Kaito addon for ${this.clusterName}: ${kaitoInstallationResult.error}`,
+                `Error installing KAITO addon for ${this.clusterName}: ${kaitoInstallationResult.error}`,
             );
             return;
         }
@@ -186,7 +186,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
         // install Kaito Federated Credentials and role Assignments
         try {
             const installKaitoFederatedCredentialsAndRoleAssignments = await longRunning(
-                `Installing Kaito Federated Credentials and role Assignments.`,
+                `Installing KAITO Federated Credentials and role Assignments.`,
                 () => {
                     return this.installKaitoComponents();
                 },
@@ -194,20 +194,20 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
 
             if (failed(installKaitoFederatedCredentialsAndRoleAssignments)) {
                 vscode.window.showErrorMessage(
-                    `Error installing Kaito Federated Credentials and role Assignments: ${installKaitoFederatedCredentialsAndRoleAssignments.error}`,
+                    `Error installing KAITO Federated Credentials and role Assignments: ${installKaitoFederatedCredentialsAndRoleAssignments.error}`,
                 );
             }
 
             //kaito installation succeeded
             webview.postKaitoInstallProgressUpdate({
-                operationDescription: "Installing Kaito succeeded",
+                operationDescription: "Installing KAITO succeeded",
                 event: 4,
                 errorMessage: undefined,
                 models: listKaitoSupportedModels(),
             });
         } catch (ex) {
             vscode.window.showErrorMessage(
-                `Error installing Kaito Federated Credentials and role Assignments: ${getErrorMessage(ex)}`,
+                `Error installing KAITO Federated Credentials and role Assignments: ${getErrorMessage(ex)}`,
             );
         }
     }
@@ -224,7 +224,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
         };
 
         try {
-            const poller = await longRunning(`Enabling the kaito for this cluster.`, () => {
+            const poller = await longRunning(`Configuring the KAITO for ${this.clusterName} cluster.`, () => {
                 return this.containerServiceClient.managedClusters.beginCreateOrUpdate(
                     this.resourceGroupName,
                     this.clusterName,
@@ -233,7 +233,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             });
             // kaito installation in progress
             webview.postKaitoInstallProgressUpdate({
-                operationDescription: "Installing Kaito",
+                operationDescription: "Installing KAITO",
                 event: 1,
                 errorMessage: undefined,
                 models: [],
@@ -241,14 +241,14 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             poller.onProgress((state) => {
                 if (state.status === "succeeded") {
                     webview.postKaitoInstallProgressUpdate({
-                        operationDescription: "Kaito Federated Credentials and role Assignments",
+                        operationDescription: "KAITO Federated Credentials and role Assignments",
                         event: 1,
                         errorMessage: undefined,
                         models: [],
                     });
                 } else if (state.status === "failed") {
                     webview.postKaitoInstallProgressUpdate({
-                        operationDescription: "Installing Kaito failed",
+                        operationDescription: "Installing KAITO failed",
                         event: 3,
                         errorMessage: state.error?.message,
                         models: [],
@@ -257,7 +257,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             });
             await poller.pollUntilDone();
 
-            return { succeeded: true, result: "Kaito installation logic completed successfully" };
+            return { succeeded: true, result: "KAITO installation logic completed successfully" };
         } catch (ex) {
             const errorMessage = isInvalidTemplateDeploymentError(ex)
                 ? getInvalidTemplateErrorMessage(ex)
@@ -267,7 +267,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             if (RETRY_COUNT < MAX_RETRY) {
                 RETRY_COUNT++;
                 const answer = await vscode.window.showErrorMessage(
-                    `Error installing Kaito addon for ${this.clusterName}: ${errorMessage}`,
+                    `Error installing KAITO addon for ${this.clusterName}: ${errorMessage}`,
                     { modal: true },
                     "Retry",
                 );
@@ -279,11 +279,11 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             }
 
             if (RETRY_COUNT >= MAX_RETRY) {
-                vscode.window.showErrorMessage(`Error installing Kaito addon for ${this.clusterName}: ${errorMessage}`);
+                vscode.window.showErrorMessage(`Error installing KAITO addon for ${this.clusterName}: ${errorMessage}`);
             }
 
             webview.postKaitoInstallProgressUpdate({
-                operationDescription: "Installing Kaito failed",
+                operationDescription: "Installing KAITO failed",
                 event: 3,
                 errorMessage: ex instanceof Error ? ex.message : String(ex),
                 models: [],
@@ -337,7 +337,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             return { succeeded: false, error: kubectlresult.error };
         }
 
-        return { succeeded: true, result: "Kaito components installed successfully" };
+        return { succeeded: true, result: "KAITO components installed successfully" };
     }
 
     private async registerKaitoFeature(webview: MessageSink<ToWebViewMsgDef>) {
@@ -355,7 +355,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
 
         if (getFeatureClientRegisterStateAfterDelay.properties?.state !== "Registered") {
             webview.postKaitoInstallProgressUpdate({
-                operationDescription: "Installing Kaito",
+                operationDescription: "Installing KAITO",
                 event: 3,
                 errorMessage: "Failed to register feature",
                 models: [],
@@ -389,7 +389,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
 
         if (failed(roleAssignment)) {
             vscode.window.showWarningMessage(
-                `Error installing Kaito Federated Credentials and role Assignments: ${roleAssignment.error}`,
+                `Error installing KAITO Federated Credentials and role Assignments: ${roleAssignment.error}`,
             );
         }
     }

--- a/webview-ui/src/Kaito/Kaito.tsx
+++ b/webview-ui/src/Kaito/Kaito.tsx
@@ -31,7 +31,7 @@ export function Kaito(initialState: InitialState) {
                 <h4 className={styles.subHeaderForVersion}>Version: v1.0</h4>
                 <h3 className={styles.architecture}>Architecture</h3>
                 <div className={styles.architectureSubHeader}>
-                    Kaito follows the classic Kubernetes Custom Resource Definition(CRD)/controller design pattern. User
+                    KAITO follows the classic Kubernetes Custom Resource Definition(CRD)/controller design pattern. User
                     manages a workspace custom resource which describes the GPU requirements and the inference or tuning
                     specification. Kaito controllers will automate the deployment by reconciling the workspace custom
                     resource.


### PR DESCRIPTION
This PR fixes the typo of misrepresenting Kaito as word to KAITO as I guess (Kubernetes AI ToolChain Operation) 

fyi to all.


<img width="758" alt="Screenshot 2024-10-25 at 1 42 26 PM" src="https://github.com/user-attachments/assets/7a6160d1-5b86-48c7-8c8e-a05fc83ee253">



<img width="475" alt="Screenshot 2024-10-25 at 1 42 10 PM" src="https://github.com/user-attachments/assets/1b7527ae-e487-4ab4-9414-8f0cfd093716">
