### PR TITLE
Fix multiclick by disabling the button.

### DIFF
--- a/src/panels/KaitoPanel.ts
+++ b/src/panels/KaitoPanel.ts
@@ -224,7 +224,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
         };
 
         try {
-            const poller = await longRunning(`Configuring the KAITO for ${this.clusterName} cluster.`, () => {
+            const poller = await longRunning("", () => {
                 return this.containerServiceClient.managedClusters.beginCreateOrUpdate(
                     this.resourceGroupName,
                     this.clusterName,

--- a/webview-ui/src/Kaito/Kaito.tsx
+++ b/webview-ui/src/Kaito/Kaito.tsx
@@ -3,11 +3,18 @@ import { InitialState, ProgressEventType } from "../../../src/webview-contract/w
 import { useStateManagement } from "../utilities/state";
 import styles from "./Kaito.module.css";
 import kaitoimage from "./kaitoimage.png";
+import { useState } from "react";
 
 // import { KaitoModels } from "./KaitoModels";
 import { stateUpdater, vscode } from "./state";
 export function Kaito(initialState: InitialState) {
     const { state } = useStateManagement(stateUpdater, initialState, vscode);
+    const [isDisabled, setIsDisabled] = useState(false);
+
+    const handleClick = () => {
+        onClickKaitoInstall();
+        setIsDisabled(true); // Disable the button after click
+    };
 
     function onClickKaitoInstall() {
         vscode.postInstallKaitoRequest();
@@ -51,7 +58,9 @@ export function Kaito(initialState: InitialState) {
                 </div>
                 <div>
                     {state.kaitoInstallStatus === ProgressEventType.NotStarted && (
-                        <VSCodeButton onClick={onClickKaitoInstall}>Install</VSCodeButton>
+                        <VSCodeButton onClick={handleClick} disabled={isDisabled}>
+                            Install
+                        </VSCodeButton>
                     )}
                     {state.kaitoInstallStatus === ProgressEventType.InProgress &&
                         state.operationDescription.includes("Installing Kaito") && (


### PR DESCRIPTION
This PR fixes few leftover KAITO stuff, which we noticed, it made sense to merge the long running PR and whatever was left we cover in small one part of which was covered in previous #1022 and next part is the disable of the button so user cannot press install multiple times which lead to failure of too many operation.

Idea for the implementation is: 

- The `isDisabled` state is **initialized** as `false`.
- After clicking the button, `onClickKaitoInstall` is triggered, and the button is disabled by setting `**isDisabled**` to `true`.
- The `disabled` attribute on the button prevents further clicks once it's **disabled**.

Thanks heaps, and result is here:

<img width="782" alt="Screenshot 2024-10-25 at 3 26 35 PM" src="https://github.com/user-attachments/assets/44226338-cb2d-4bde-929a-59d5e1ead3b7">


