### PR TITLE
Publish version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [1.5.0]
+
+* Kaito deployment & ux updates.
+* New Publish Action on Secure Runner.
+* Improvements for GH copilot handlers.
+* New Publish Workflow Fix.
+* Manually fetching package.json version.
+* Changing npm to npx.
+* Kaito additional error & quota handling.
+* kaito needs to be KAITO named.
+* Add documentation for GH Copilot handlers and telemetry.
+* Dependabot updates and bumps.
+
+Thank you so much to @tejhan, @ReinierCC, @kejatura-dev, @ivelisseca, @qpetraroia, @hsubramanianaks, Joy, Sachi for contributions, testing and reviews.
+
 ## [1.4.11]
 
 * Add deploy manifest handler for GH Copilot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.4.11",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.4.11",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.4.11",
+    "version": "1.5.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release `1.5.0`, please see the details below.

* Kaito deployment & ux updates.
* New Publish Action on Secure Runner.
* Improvements for GH copilot handlers.
* New Publish Workflow Fix.
* Manually fetching package.json version.
* Changing npm to npx.
* Kaito additional error & quota handling.
* kaito needs to be KAITO named.
* Add documentation for GH Copilot handlers and telemetry.
* Dependabot updates and bumps.

Thank you so much to @tejhan, @ReinierCC, @kejatura-dev, @ivelisseca, @qpetraroia, @hsubramanianaks, Joy, Sachi for contributions, testing and reviews.

❤️ 

* Here is the vsix:  [vscode-aks-tools-1.4.11-buttondisabled-fixdoubelinfo.vsix.zip](https://github.com/user-attachments/files/17517118/vscode-aks-tools-1.4.11-buttondisabled-fixdoubelinfo.vsix.zip)

- **Important Note please:** Lets make sure: #1023 , #1021  are all merged before release and we merge: #1016 Just after release.

Thank you so much all!

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaW4xZ3hqbnE4YTh1azdyMmttMHRlNXN5NmZoMTM4MHoxaHFvMWRpMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/x5AlLBS6YmXUQ/giphy.gif)