### PR TITLE
kubectl-gadget: Update to v0.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.25.1",
+                    "default": "v0.34.0",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },


### PR DESCRIPTION
The newest version of Inspektor Gadget was released yesterday: https://github.com/inspektor-gadget/inspektor-gadget/releases/tag/v0.34.0

This PR updates the `kubectl-gadget` binary to be pulled from the latest release `v0.34.0`