### PR TITLE
Track Version in the Extension Code, for walkthrough.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,12 +73,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
         context.subscriptions.push(uiExtensionVariables.outputChannel);
 
-        registerUIExtensionVariables(uiExtensionVariables);
-        if (vscode.workspace.getConfiguration("workbench").get("startupEditor") !== "none") {
-            vscode.commands.executeCommand("workbench.action.openWalkthrough", {
+        const currentVersion = vscode.extensions.getExtension("ms-kubernetes-tools.vscode-aks-tools")?.packageJSON
+            .version;
+        const lastShownVersion = context.globalState.get<string>("vscode-aks-tools.lastWalkthroughVersion");
+        // Check if the walkthrough needs to be shown
+        if (currentVersion && currentVersion !== lastShownVersion) {
+            await vscode.commands.executeCommand("workbench.action.openWalkthrough", {
                 category: "ms-kubernetes-tools.vscode-aks-tools#aksvscodewalkthrough",
             });
+
+            // Update the version in global state after showing the walkthrough
+            await context.globalState.update("vscode-aks-tools.lastWalkthroughVersion", currentVersion);
         }
+
+        registerUIExtensionVariables(uiExtensionVariables);
         registerCommandWithTelemetry("aks.signInToAzure", signInToAzure);
         registerCommandWithTelemetry("aks.selectTenant", selectTenant);
         registerCommandWithTelemetry("aks.selectSubscriptions", selectSubscriptions);


### PR DESCRIPTION
Thanks all in advance, this work is part of the multi pronged work which may be needed for the walkthrough scenarios, the key discussion reside here (specific to this implementation) : https://github.com/Azure/vscode-aks-tools/discussions/1050#discussioncomment-11185795 

In our activate function, compare the stored version with the current extension version. If they differ, show the walkthrough and update the stored version.

To display a VS Code walkthrough only once per version, we can use the extension's context to track whether the walkthrough has been shown for the current version. Here's how you can implement this:

### **Further Explanation:**

1. **Version Check**: The code checks the current version of your extension using `packageJSON.version`.
2. **Stored Version**: It retrieves the last shown version from `context.globalState`.
3. **Condition**: If the current version differs from the stored version (or the stored version is `undefined`), it displays the walkthrough.
4. **Update Stored Version**: After showing the walkthrough, it updates the stored version to the current one.

### **Testing and Usage**

1. **On First Install**: The walkthrough will be shown since there's no stored version yet.
2. **On Version Upgrade**: When you update the version in `package.json` (e.g., from `1.0.0` to `1.1.0`), the walkthrough will show again.
3. **No Repeat Until Upgrade**: If the version is the same as the stored version, the walkthrough will not be shown again.

### **Benefits:**

- **No Extra Settings**: This approach does not require extra user settings.
- **Seamless Experience**: Users see the walkthrough only on new installations or upgrades.

This way, the walkthrough shows up only once per version, providing users with an onboarding or update guide without repeating unnecessarily.

Fyi and gentle fyi: @qpetraroia , @joybb , @kejatura-dev , @hsubramanianaks , @ReinierCC , @tejhan 

[vscode-aks-tools-1.5.0-test-not-clause-5.vsix.zip](https://github.com/user-attachments/files/17682780/vscode-aks-tools-1.5.0-test-not-clause-5.vsix.zip)

