### PR TITLE
Publish release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.5.2]
+
+* Engine and VSCE package update.
+* Dependabot updates and bumps.
+
+Thank you so much to @tejhan, @qpetraroia, @hsubramanianaks, @Tatsinnit for contributions, testing and reviews.
+
 ## [1.5.1]
 
 * Track Version in the Extension Code, for walkthrough.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release 1.5.2, please see the details below. Small release to testing new publishing pipeline.

* Engine and VSCE package update.
* Dependabot updates and bumps.

Thank you so much to @tejhan, @qpetraroia, @hsubramanianaks, @Tatsinnit for contributions, testing and reviews.

VSIX for testing (rename and remove '.zip'): [vscode-aks-tools-1.5.2-test.vsix.zip](https://github.com/user-attachments/files/17738979/vscode-aks-tools-1.5.2-test.vsix.zip)

![smallstep](https://github.com/user-attachments/assets/950a0849-7750-40c0-997b-2fcb37caf0a3)
