### PR TITLE
Fix the dependabot related issue.

### DIFF
--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
-        "typescript": "^5.6.3",
+        "typescript": "^5.7.2",
         "vite": "^5.4.11",
         "vite-plugin-checker": "^0.8.0",
         "vite-plugin-eslint": "^1.8.1"
@@ -5584,10 +5584,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9959,9 +9960,9 @@
       }
     },
     "typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -32,7 +32,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "typescript": "^5.6.3",
+    "typescript": "^5.7.2",
     "vite": "^5.4.11",
     "vite-plugin-checker": "^0.8.0",
     "vite-plugin-eslint": "^1.8.1"

--- a/webview-ui/src/InspektorGadget/TraceOutput.tsx
+++ b/webview-ui/src/InspektorGadget/TraceOutput.tsx
@@ -53,7 +53,7 @@ function displayValue(value: unknown, property: ItemProperty<string>) {
         case ValueType.CharByte:
             return <>{String.fromCharCode(value as number)}</>;
         case ValueType.Bytes:
-            return <>{value} B</>;
+            return <>{String(value)} B</>;
         case ValueType.StackTrace:
             return <pre>{value as string}</pre>;
         case ValueType.AddressArray:
@@ -61,7 +61,7 @@ function displayValue(value: unknown, property: ItemProperty<string>) {
         case ValueType.Timestamp:
             return <>{value ? formatTime(value as number) : ""}</>;
         default:
-            return <>{value}</>;
+            return <>{String(value)}</>;
     }
 }
 

--- a/webview-ui/src/InspektorGadget/TraceOutput.tsx
+++ b/webview-ui/src/InspektorGadget/TraceOutput.tsx
@@ -53,7 +53,7 @@ function displayValue(value: unknown, property: ItemProperty<string>) {
         case ValueType.CharByte:
             return <>{String.fromCharCode(value as number)}</>;
         case ValueType.Bytes:
-            return <>{String(value)} B</>;
+            return <>{String(value ?? "")} B</>;
         case ValueType.StackTrace:
             return <pre>{value as string}</pre>;
         case ValueType.AddressArray:
@@ -61,7 +61,7 @@ function displayValue(value: unknown, property: ItemProperty<string>) {
         case ValueType.Timestamp:
             return <>{value ? formatTime(value as number) : ""}</>;
         default:
-            return <>{String(value)}</>;
+            return <>{String(value ?? "")}</>;
     }
 }
 


### PR DESCRIPTION
Hiya, This PR fixes #1088 

### Sample VISX:

[vscode-aks-tools-1.5.2-dependabot-fix.vsix.zip](https://github.com/user-attachments/files/17910482/vscode-aks-tools-1.5.2-dependabot-fix.vsix.zip)

### Details

I think the error `TS2322: Type '{ children: unknown[]; }' is not assignable to type '{ children?: ReactNode; }'` occurs because the `children` prop in JSX expects a type assignable to `ReactNode`, and in the code, the `children` prop contains `unknown[]`, which is incompatible.

This issue typically arises from returning `<>{value}</>` where `value` has the type `unknown`. To resolve the error, you need to ensure that the `value` is safely cast or transformed into a type compatible with `ReactNode` before being rendered.

### Additional Details:

   - In cases where `value` is `unknown`, explicitly cast or transform it into a string using `String(value)`. This makes the type compatible with `ReactNode`.

   - For `ValueType.Bytes` and the default case, `value` is wrapped in `String(value)` to ensure it's rendered as a string.

   - For `ValueType.AddressArray`, ensure that the `value` is correctly parsed into a string array and joined with a separator. Ensure `JSON.parse` operates on valid JSON to avoid runtime errors.

This approach ensures type safety and fixes the `TS2322` error while maintaining the intended functionality.

fyi: please: ❤️ @hsubramanianaks , @ReinierCC , @tejhan , @qpetraroia 