### PR TITLE
Publish release 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.5.3]
+
+* KAITO - Model Management & Chat Features.
+* Auto Deployments Utility Logic.
+* Remove activation event trigger.
+* kubectl-gadget: Update to v0.34.0.
+* Dependabot updates and bumps.
+
+Thank you so much to @burak-ok, @ReinierCC, @tejhan, @qpetraroia, @hsubramanianaks, @Tatsinnit for contributions, testing and reviews.
+
 ## [1.5.2]
 
 * Engine and VSCE package update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release `1.5.3`, please see the details below. For all folks to take a look and we can do the release early next week.

Please Note: Documentation of KAITO is taken care of in #1105 

* KAITO - Model Management & Chat Features.
* Auto Deployments Utility Logic.
* Remove activation event trigger.
* `kubectl-gadget`: Update to v0.34.0.
* Dependabot updates and bumps.

Thank you so much to @burak-ok, @ReinierCC, @tejhan, @qpetraroia, @hsubramanianaks, @Tatsinnit for contributions, testing and reviews.

❤️

VSIX for quick test for anyone keen. please: 
[vscode-aks-tools-1.5.3-test.vsix.zip](https://github.com/user-attachments/files/18028894/vscode-aks-tools-1.5.3-test.vsix.zip)



![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3E5dzlxcGt3dHhyajE0cjc4OGEza210bGtnanlpYW4wNnkyZ3F3biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qKoL4yYvT16z7AYw33/giphy.gif)