### PR TITLE
add node os upgrade channel

### DIFF
--- a/src/panels/templates/DevTestCreateCluster.json
+++ b/src/panels/templates/DevTestCreateCluster.json
@@ -742,7 +742,8 @@
                 "disableLocalAccounts": "[parameters('disableLocalAccounts')]",
                 "aadProfile": "[if(parameters('enableAadProfile'), variables('defaultAadProfile'), null())]",
                 "autoUpgradeProfile": {
-                    "upgradeChannel": "[parameters('upgradeChannel')]"
+                    "upgradeChannel": "[parameters('upgradeChannel')]",
+                    "nodeOSUpgradeChannel": "[parameters('nodeOSUpgradeChannel')]"
                 },
                 "agentPoolProfiles": [
                     {


### PR DESCRIPTION
This PR fixes an issue where nodeOSUpgradeChannel was missing in the properties for AKS cluster creation ARM template causing CVE alerts. This has been set to NodeImage which updates NodeImage weekly - more details below 
https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image?tabs=azure-cli#update-ownership-and-schedule

![image](https://github.com/user-attachments/assets/0888fa3d-bc8f-4fea-8c58-35b5d4a32a77)


customers control these upgrades via maintenance configurations. More details here - https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image?tabs=azure-cli#node-os-planned-maintenance-windows