### PR TITLE
Publish release 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.5.4]
+
+* Add node os upgrade channel.
+* Adding refresh option to cluster properties page.
+* Dependabot updates and bumps.
+
+Thank you so much to @hsubramanianaks, @tejhan, @qpetraroia, @ReinierCC, @Tatsinnit for contributions, testing and reviews.
+
 ## [1.5.3]
 
 * KAITO - Model Management & Chat Features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.5.3",
+            "version": "1.5.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release `1.5.4`, please see the details below. For all folks to take a look and we can do the release early next week.

• Add node os upgrade channel.
• Adding refresh option to cluster properties page.
• Dependabot updates and bumps.

Thank you so much to @hsubramanianaks, @tejhan, @qpetraroia, @ReinierCC, @Tatsinnit for contributions, testing and reviews.

VSIX for quick test for anyone keen, please:

[vscode-aks-tools-1.5.4-test.vsix.zip](https://github.com/user-attachments/files/18132264/vscode-aks-tools-1.5.4-test.vsix.zip)


![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3p3cWZiOWhoNWNqbm9pNWkxM3I5MGNxMDU1YWZzMWdoNGdmY3V0bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/x6FyODo9mHhOU/giphy.gif)