### PR TITLE
Automatic Cluster handling for KAITO installation

### DIFF
--- a/webview-ui/src/Kaito/Kaito.module.css
+++ b/webview-ui/src/Kaito/Kaito.module.css
@@ -123,3 +123,7 @@
 .installBlurb {
     margin: 0.5rem 0rem 0.06rem 0rem;
 }
+.errorMessage {
+    font-weight: 400;
+    width: 90%;
+}

--- a/webview-ui/src/Kaito/Kaito.tsx
+++ b/webview-ui/src/Kaito/Kaito.tsx
@@ -64,7 +64,7 @@ export function Kaito(initialState: InitialState) {
                         </p>
                     </ul>
                 </div>
-                <div>
+                <div className={styles.installationDiv}>
                     {state.kaitoInstallStatus === ProgressEventType.NotStarted && (
                         <button className={styles.button} onClick={handleClick} disabled={isDisabled}>
                             Install KAITO
@@ -109,6 +109,12 @@ export function Kaito(initialState: InitialState) {
                                     Generate Workspace
                                 </VSCodeButton>
                             </div>
+                        </div>
+                    )}
+                    {state.kaitoInstallStatus === ProgressEventType.Failed && (
+                        <div className={styles.postInstall}>
+                            <p>Error installing KAITO.</p>
+                            <p className={styles.errorMessage}>{state.errors}</p>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
This PR handles attempted installation of KAITO on automatic clusters. 

Context : Due to nrg lockdown & deny permissions of Automatic cluster, we are unable to create federated credentials in the node resource group. This is necessary for proper KAITO installation & due to the Automatic cluster SKU configuration, we are unable to change access / permissions to allow for such. Thus, I've added safeguards to prevent failed install on auto clusters alongside a message to the user. 

Additionally, there have been some additions to the KAITO installation logic to terminate installation when errors do occur (were some cases where error would be caught but installation would continue). Also added conditional render to display error messages for failed installations. 

![image](https://github.com/user-attachments/assets/f828a44b-26cc-44ea-9dcc-34481b268bc1)

.vsix for testing -> [vscode-aks-tools-1.5.5-autokaito.vsix.zip](https://github.com/user-attachments/files/18607130/vscode-aks-tools-1.5.5-autokaito.vsix.zip)
