### PR TITLE
Proper Devhub Callback Auth

### DIFF
--- a/src/commands/devhub/aksAutomatedDeployments.ts
+++ b/src/commands/devhub/aksAutomatedDeployments.ts
@@ -111,7 +111,7 @@ async function checkAndAuthenticateWithGitHub(
 ): Promise<string | undefined> {
     try {
         const parameters: GitHubOAuthCallRequest = {
-            redirectUrl: "vscode://ms-kubernetes-tools.vscode-aks-tools/callback",
+            redirectUrl: "vscode://ms-kubernetes-tools.vscode-aks-tools/callback", //After GitHub redirects to DevHub with token, DevHub will redirect the user back to the extension. Causing the flow to continue. 
         };
         const properOptionsWithCallback: GitHubOAuthOptionalParams = { parameters };
         client.listGitHubOAuth(location, properOptionsWithCallback);
@@ -130,7 +130,7 @@ async function checkAndAuthenticateWithGitHub(
             try {
                 await onCallbackHandled;
             } catch (error) {
-                vscode.window.showErrorMessage(`Failed to handle callback: ${getErrorMessage(error)}`);
+                vscode.window.showErrorMessage(`Failed to handle GitHub Auth callback: ${getErrorMessage(error)}`);
                 console.error("Failed to handle callback:", getErrorMessage(error));
             }
 

--- a/src/commands/devhub/aksAutomatedDeployments.ts
+++ b/src/commands/devhub/aksAutomatedDeployments.ts
@@ -111,7 +111,7 @@ async function checkAndAuthenticateWithGitHub(
 ): Promise<string | undefined> {
     try {
         const parameters: GitHubOAuthCallRequest = {
-            redirectUrl: "vscode://ms-kubernetes-tools.vscode-aks-tools/callback", //After GitHub redirects to DevHub with token, DevHub will redirect the user back to the extension. Causing the flow to continue. 
+            redirectUrl: "vscode://ms-kubernetes-tools.vscode-aks-tools/callback", //After GitHub redirects to DevHub with token, DevHub will redirect the user back to the extension. Causing the flow to continue.
         };
         const properOptionsWithCallback: GitHubOAuthOptionalParams = { parameters };
         client.listGitHubOAuth(location, properOptionsWithCallback);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import * as k8s from "vscode-kubernetes-tools-api";
 import { setAssetContext } from "./assets";
 import { getReadySessionProvider } from "./auth/azureAuth";
 import { activateAzureSessionProvider, getSessionProvider } from "./auth/azureSessionProvider";
+import { registerUriHandler } from "./uriHandler";
 import { selectSubscriptions, selectTenant, signInToAzure } from "./commands/aksAccount/aksAccount";
 import { attachAcrToCluster } from "./commands/aksAttachAcrToCluster/attachAcrToCluster";
 import aksClusterProperties from "./commands/aksClusterProperties/aksClusterProperties";
@@ -60,6 +61,8 @@ export async function activate(context: vscode.ExtensionContext) {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
     context.subscriptions.push(new Reporter());
     setAssetContext(context);
+
+    registerUriHandler(context);
 
     // Create and register the Azure session provider before accessing it.
     activateAzureSessionProvider(context);

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+
+//Defines a type that represents a function that returns void or null, initalized to null
+let resolveCallback: (() => void) | null = null;
+
+// Create a Promise with a timeout
+export const onCallbackHandled = new Promise<void>((resolve, reject) => {
+    resolveCallback = resolve;
+
+    const timeout = setTimeout(() => {
+        reject(new Error("Timeout: Callback was not handled within the expected time."));
+        resolveCallback = null; // Clear the callback
+    }, 180000); //3 Minute Timeout
+
+    // Ensure the timeout is cleared when the Promise resolves
+    resolveCallback = () => {
+        clearTimeout(timeout);
+        resolve();
+        resolveCallback = null; // Ensure the Promise resolves only once
+    };
+});
+
+//Gets called once upon extension registration in the extension.ts file
+export function registerUriHandler(context: vscode.ExtensionContext) {
+    const handleUri = (uri: vscode.Uri) => {
+        vscode.window.showInformationMessage("inside handleUri");
+
+        if (uri.path === "/callback") {
+            vscode.window.showInformationMessage("AKS extension: Handling callback");
+            console.log("AKS extension: Handling callback");
+
+            // Resolve the Promise
+            // Checks to make sure resolveCallback is not null
+            if (resolveCallback) {
+                resolveCallback(); // Calls the resolve function
+            }
+        } else {
+            console.log(`Unexpected URI path: ${uri.path}`);
+        }
+    };
+
+    // Register the URI handler
+    context.subscriptions.push(vscode.window.registerUriHandler({ handleUri }));
+}


### PR DESCRIPTION
To leverage DevHub's callback abilities I registered callback URI inside the extension.

This is a unique uri that only the vscode extension can utilize: "vscode://ms-kubernetes-tools.vscode-aks-tools/callback".

Once the user provides goes through OATH, DevHub will redirect back to the VScode extension alerting the user that the authentication was successful or it will timeout.

Currently, there's a small edge case in where if the user revokes authorization to DevHub and quickly tries to login in again they are met with an invalid state error. 
' {"error":{"code":"400", "message":"invalid state parameter", "details":[]}} '

I believe this issue might be from the DevHub side temporarily caching the state, but the state has changed.

Still the Automated Deployments command is not available to the user but, the following vsix allows you to test the login functionality: 
[vscode-aks-tools-1.5.5-callback-test.vsix.zip](https://github.com/user-attachments/files/18740137/vscode-aks-tools-1.5.5-callback-test.vsix.zip)
Under "Automated Deployments" -> "Deploy an App with DevHub"

Clicking on the command will initiate the auth flow.