### PR TITLE
Fix Cluster filter default behaviour

### DIFF
--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -70,9 +70,11 @@ export default async function aksClusterFilter(_context: IActionContext, target:
     });
 
     // Set Cluster Instance
-    const newFilteredClusters = selectedItems ? [
-        ...selectedItems.map((item) => item.Cluster), // Retain filters in any other tenants.
-    ] : [];
+    const newFilteredClusters = selectedItems
+        ? [
+              ...selectedItems.map((item) => item.Cluster), // Retain filters in any other tenants.
+          ]
+        : [];
 
     await setFilteredClusters(newFilteredClusters, clusterList);
 }

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -69,16 +69,12 @@ export default async function aksClusterFilter(_context: IActionContext, target:
         placeHolder: "Select Cluster",
     });
 
-    if (!selectedItems) {
-        return;
-    }
-
     // Set Cluster Instance
-    const newFilteredClusters = [
+    const newFilteredClusters = selectedItems ? [
         ...selectedItems.map((item) => item.Cluster), // Retain filters in any other tenants.
-    ];
+    ] : [];
 
-    await setFilteredClusters(newFilteredClusters);
+    await setFilteredClusters(newFilteredClusters, clusterList);
 }
 
 async function getUniqueClusters() {

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -127,8 +127,8 @@ export async function setFilteredClusters(filters: ClusterFilter[], allClusters:
     const existingFilters = getFilteredClusters();
 
     // Select all clusters if no filters are provided
-    const newFilters = filters.length 
-        ? filters 
+    const newFilters = filters.length
+        ? filters
         : allClusters.map(({ subscriptionId, name }) => ({ subscriptionId, clusterName: name }));
 
     // Merge and deduplicate filters
@@ -142,8 +142,9 @@ export async function setFilteredClusters(filters: ClusterFilter[], allClusters:
     const values = finalFilters.map(({ subscriptionId, clusterName }) => `${subscriptionId}/${clusterName}`).sort();
 
     // Check if filters have changed
-    const filtersChanged = existingFilters.length !== finalFilters.length || 
-        !existingFilters.every(({ clusterName }) => finalFilters.some(f => f.clusterName === clusterName));
+    const filtersChanged =
+        existingFilters.length !== finalFilters.length ||
+        !existingFilters.every(({ clusterName }) => finalFilters.some((f) => f.clusterName === clusterName));
 
     if (filtersChanged) {
         await vscode.workspace

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -123,19 +123,27 @@ export async function setFilteredSubscriptions(filters: SubscriptionFilter[]): P
     }
 }
 
-export async function setFilteredClusters(filters: ClusterFilter[]): Promise<void> {
+export async function setFilteredClusters(filters: ClusterFilter[], allClusters: AksClusterAndFleet[]): Promise<void> {
     const existingFilters = getFilteredClusters();
 
-    // Get merged list of filters
-    const uniqueFilters = mergeClusterFilterLists(existingFilters, filters);
+    // Select all clusters if no filters are provided
+    const newFilters = filters.length 
+        ? filters 
+        : allClusters.map(({ subscriptionId, name }) => ({ subscriptionId, clusterName: name }));
 
-    // Determine if filters have changed
-    const filtersChanged =
-        existingFilters.length !== uniqueFilters.length ||
-        !existingFilters.every((ef) => uniqueFilters.some((uf) => uf.clusterName === ef.clusterName));
+    // Merge and deduplicate filters
+    const uniqueFilters = mergeClusterFilterLists(existingFilters, newFilters);
+
+    // If all clusters are selected, clear filters
+    const shouldClearFilters = uniqueFilters.length === allClusters.length;
+    const finalFilters = shouldClearFilters ? [] : uniqueFilters;
 
     // Construct values as "subscriptionId/clusterName"
-    const values = uniqueFilters.map((f) => `${f.subscriptionId}/${f.clusterName}`).sort();
+    const values = finalFilters.map(({ subscriptionId, clusterName }) => `${subscriptionId}/${clusterName}`).sort();
+
+    // Check if filters have changed
+    const filtersChanged = existingFilters.length !== finalFilters.length || 
+        !existingFilters.every(({ clusterName }) => finalFilters.some(f => f.clusterName === clusterName));
 
     if (filtersChanged) {
         await vscode.workspace


### PR DESCRIPTION
Hiya all, ❤️ Thank you as always! The previous implementation had redundant reassignment of `filters`, multiple checks for the same condition, and slightly convoluted logic. This refactor makes the function more intuitive and performant while preserving its intended functionality.  

I think we can do this much better with fleet type filtering as well. But for the next release opening this for thoughts. 

As a key sidetone the reason currently `mergeFilter` is needed is because the tree fire event refreshes the whole node tree, we should avoid it. This kind of fixes #1223 

Rest here is the VSIX for quick spin as well please: 
[vscode-aks-tools-1.5.5-clusterfilterfix.vsix.zip](https://github.com/user-attachments/files/18777089/vscode-aks-tools-1.5.5-clusterfilterfix.vsix.zip)
