### PR TITLE
Publish release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## [1.6.0]
+
+* [Backend] ACR Creation, App Registration Creation & Role Privileges (#1238)
+* Fix Cluster filter default behaviour (#1240)
+* Showing Fleets in the Treeview (#1237)
+* Proper Devhub Callback Auth (#1228)
+* Removing unused KAITO functions & variables (#1226)
+* Small addition to prettierrc & version bump (#1225)
+* Created vscode themed styling to replace several webview-ui-toolkit elements (#1222)
+* Added automatic cluster creation safeguards & feedback section for failed kaito installations (#1209)
+* Update kubectl generation RAG endpoint (#1221)
+* Create Fleet: UX Enhancement and Webview Testing (#1194)
+* Feature: Add Cluster Filtering in AKS VS Code Extension Tree Node (#1208)
+* Git Repo & Branch Population for Automated Deployments [Backend] (#1195)
+* Get Namespaces & Create Namespace Functionality [Backend] (#1196)
+* Initial Setup for Automated Deployments (Panel & Webview) (#1193)
+* Create Fleet: Full Cycle Completed (#1179)
+* Add prettier badge and development link. (#1181)
+* Add instruction for local vsix share. (#1180)
+* Create Fleet: panel implementation (#1161)
+* Remove old publishing workflow. (#1178)
+* Fix/permissions and pin actions format check (#1177)
+* Add prettier format check. (#1163)
+* Auto run Prettier-format. (#1164)
+* Fix the upgrade for eslint 9.17.0. (#1159)
+* Kaito Models - Code cleanup & memory/file handling improvements (#1122)
+* Fleet backend code. (#1160)
+* Dependabot updates and bumps.
+
+Thank you so much to @JunyuQian, @serbrech, @ReinierCC, @hsubramanianaks, @tejhan, @qpetraroia, @Tatsinnit for contributions, testing and reviews.
+
 ## [1.5.5]
 
 * Right Click Draft Validate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.5.5",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.5.5",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.5.5",
+    "version": "1.6.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is for the release `1.6.0`, please see the details below. For all folks to take a look and we can do the release early next week.

* [Backend] ACR Creation, App Registration Creation & Role Privileges (#1238)
* Fix Cluster filter default behaviour (#1240)
* Showing Fleets in the Treeview (#1237)
* Proper Devhub Callback Auth (#1228)
* Removing unused KAITO functions & variables (#1226)
* Small addition to prettierrc & version bump (#1225)
* Created vscode themed styling to replace several webview-ui-toolkit elements (#1222)
* Added automatic cluster creation safeguards & feedback section for failed kaito installations (#1209)
* Update kubectl generation RAG endpoint (#1221)
* Create Fleet: UX Enhancement and Webview Testing (#1194)
* Feature: Add Cluster Filtering in AKS VS Code Extension Tree Node (#1208)
* Git Repo & Branch Population for Automated Deployments [Backend] (#1195)
* Get Namespaces & Create Namespace Functionality [Backend] (#1196)
* Initial Setup for Automated Deployments (Panel & Webview) (#1193)
* Create Fleet: Full Cycle Completed (#1179)
* Add prettier badge and development link. (#1181)
* Add instruction for local vsix share. (#1180)
* Create Fleet: panel implementation (#1161)
* Remove old publishing workflow. (#1178)
* Fix/permissions and pin actions format check (#1177)
* Add prettier format check. (#1163)
* Auto run Prettier-format. (#1164)
* Fix the upgrade for eslint 9.17.0. (#1159)
* Kaito Models - Code cleanup & memory/file handling improvements (#1122)
* Fleet backend code. (#1160)
* Dependabot updates and bumps.

Thank you so much to @JunyuQian, @ivelisseca, @serbrech, @ReinierCC, @hsubramanianaks, @tejhan, @qpetraroia, @Tatsinnit for contributions, testing and reviews. 

VSIX to test:
[vscode-aks-tools-1.6.0-test.vsix.zip](https://github.com/user-attachments/files/18804050/vscode-aks-tools-1.6.0-test.vsix.zip)

 
