### PR TITLE
Treeview bug fix: showing members from different subscriptions

### DIFF
--- a/src/tree/subscriptionTreeItem.ts
+++ b/src/tree/subscriptionTreeItem.ts
@@ -123,6 +123,12 @@ class SubscriptionTreeItem extends AzExtParentTreeItem implements SubscriptionTr
             // filter out members that do not satisfy the filter (so that they are not shown in the tree)
             const membersAfterFilt = members.result.filter((m) => {
                 // for each member cluster of the fleet
+                if (parseResource(m.clusterResourceId).subscriptionId !== this.subscriptionId) {
+                    // if the member is not in the same subscription as the fleet,
+                    // there is no way it can be in the filter, as cluster-filter only contains clusters from the same subscription
+                    // to avoid being filtered out, add it to the list before applying the filter
+                    return true;
+                }
                 const filteredClusters = getFilteredClusters();
                 return filteredClusters.some(
                     // check if the member is one of the clusters in the filter


### PR DESCRIPTION
This PR resolves the issue where member clusters from different subscriptions were not displayed as part of the Fleet (**case 1 was not correct**). The Treeview now accurately displays clusters and Fleets following the rules illustrated in the picture below.

![image](https://github.com/user-attachments/assets/fc4a3b71-57da-4f51-9974-523ba15f997a)

**Before this PR:**
- Cluster 1 was only displayed under Subscription 1 and not under Fleet 1 in Subscription 2.

**With this PR:**
- Cluster 1 is now displayed under both Subscription 1 and Fleet 1 in Subscription 2.

**What is the issue?**
Previously, the cluster filter applied to all member clusters within a Fleet, regardless of their subscription. However, the cluster filter only includes clusters within the current subscription. As a result, member clusters from other subscriptions were always filtered out, preventing users from seeing them under the Fleet.

**How is it fixed?**
The solution involves adding an if statement before applying the filter. The logic is: if a member cluster is from another subscription, it is added to the treeview immediately before the filter is applied.