### PR TITLE
[Webview UI toolkit deprecation] Cluster & fleet create, cluster properties component removal

### DIFF
--- a/webview-ui/src/ClusterProperties/AgentPoolDisplay.tsx
+++ b/webview-ui/src/ClusterProperties/AgentPoolDisplay.tsx
@@ -1,6 +1,5 @@
 import styles from "./ClusterProperties.module.css";
 import { AgentPoolProfileInfo, ClusterInfo } from "../../../src/webview-contract/webviewDefinitions/clusterProperties";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { EventDef, vscode } from "./state";
 import { EventHandlers } from "../utilities/state";
 
@@ -32,13 +31,13 @@ export function AgentPoolDisplay(props: AgentPoolDisplayProps) {
                 {showAbortButton && (
                     <>
                         &nbsp;
-                        <VSCodeButton
+                        <button
                             disabled={props.clusterOperationRequested}
                             onClick={() => handleAbortClick(props.profileInfo.name)}
-                            appearance="secondary"
+                            className="secondary-button"
                         >
                             Abort
-                        </VSCodeButton>
+                        </button>
                     </>
                 )}
             </dd>

--- a/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
@@ -1,4 +1,3 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { ClusterInfo } from "../../../src/webview-contract/webviewDefinitions/clusterProperties";
 import { EventHandlers } from "../utilities/state";
 import styles from "./ClusterProperties.module.css";
@@ -73,25 +72,25 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
                     {showAbortButton && (
                         <>
                             &nbsp;
-                            <VSCodeButton
+                            <button
                                 disabled={props.clusterOperationRequested}
                                 onClick={() => handleAbortClick()}
-                                appearance="secondary"
+                                className="secondary-button"
                             >
                                 Abort
-                            </VSCodeButton>
+                            </button>
                         </>
                     )}
                     {showReconcileButton && (
                         <>
                             &nbsp;
-                            <VSCodeButton
+                            <button
                                 disabled={props.clusterOperationRequested}
                                 onClick={() => handleReconcileClick()}
-                                appearance="secondary"
+                                className="secondary-button"
                             >
                                 Reconcile
-                            </VSCodeButton>
+                            </button>
                         </>
                     )}
                 </div>
@@ -111,31 +110,29 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
                         It is important that you don&#39;t repeatedly start/stop your cluster. Repeatedly
                         starting/stopping your cluster may result in errors. Once your cluster is stopped, you should
                         wait 15-30 minutes before starting it up again. &nbsp;
-                        <VSCodeLink href="https://docs.microsoft.com/en-au/azure/aks/start-stop-cluster?tabs=azure-cli#start-an-aks-cluster">
+                        <a href="https://docs.microsoft.com/en-au/azure/aks/start-stop-cluster?tabs=azure-cli#start-an-aks-cluster">
                             Learn more
-                        </VSCodeLink>
+                        </a>
                     </span>
                 </span>
                 <div className={styles.buttonDiv}>
                     {startStopState === "Started" && (
-                        <VSCodeButton
+                        <button
                             disabled={props.clusterOperationRequested}
                             onClick={handleStopCluster}
-                            className={styles.controlButton}
-                            appearance="secondary"
+                            className={`${styles.controlButton} secondary-button`}
                         >
                             Stop Cluster
-                        </VSCodeButton>
+                        </button>
                     )}
                     {startStopState === "Stopped" && (
-                        <VSCodeButton
+                        <button
                             disabled={props.clusterOperationRequested}
                             onClick={handleStartCluster}
-                            className={styles.controlButton}
-                            appearance="secondary"
+                            className={`${styles.controlButton} secondary-button`}
                         >
                             Start Cluster
-                        </VSCodeButton>
+                        </button>
                     )}
                     {(startStopState === "Starting" || startStopState === "Stopping") && (
                         <span>{`Cluster is in ${startStopState} state`}</span>

--- a/webview-ui/src/ClusterProperties/ClusterDisplayToolTip.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplayToolTip.tsx
@@ -1,4 +1,3 @@
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { ClusterInfo } from "../../../src/webview-contract/webviewDefinitions/clusterProperties";
 import styles from "./ClusterProperties.module.css";
 
@@ -42,9 +41,9 @@ export function ClusterDisplayToolTip(props: ClusterDisplayToolTipProps) {
                     <tfoot>
                         <tr>
                             <td colSpan={3} className={styles.textLeftAlign}>
-                                <VSCodeLink href="https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar">
+                                <a href="https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar">
                                     Learn more
-                                </VSCodeLink>
+                                </a>
                             </td>
                         </tr>
                     </tfoot>

--- a/webview-ui/src/CreateCluster/CreateCluster.tsx
+++ b/webview-ui/src/CreateCluster/CreateCluster.tsx
@@ -3,7 +3,7 @@ import { CreateClusterInput } from "./CreateClusterInput";
 import { Success } from "./Success";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/createCluster";
 import { Stage, stateUpdater, vscode } from "./helpers/state";
-import { VSCodeLink, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useStateManagement } from "../utilities/state";
 
 export function CreateCluster(initialState: InitialState) {
@@ -45,8 +45,8 @@ export function CreateCluster(initialState: InitialState) {
                         </h3>
                         {state.deploymentPortalUrl && (
                             <p>
-                                Click <VSCodeLink href={state.deploymentPortalUrl}>here</VSCodeLink> to view the
-                                deployment in the Azure Portal.
+                                Click <a href={state.deploymentPortalUrl}>here</a> to view the deployment in the Azure
+                                Portal.
                             </p>
                         )}
 

--- a/webview-ui/src/CreateCluster/CreateClusterInput.tsx
+++ b/webview-ui/src/CreateCluster/CreateClusterInput.tsx
@@ -1,6 +1,6 @@
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
 import { FormEvent, useState } from "react";
 import { MessageSink } from "../../../src/webview-contract/messaging";
 import {
@@ -164,9 +164,9 @@ export function CreateClusterInput(props: CreateClusterInputProps) {
                         )}
                     </VSCodeDropdown>
 
-                    <VSCodeButton className={styles.sideControl} onClick={() => setIsNewResourceGroupDialogShown(true)}>
+                    <button className={styles.sideControl} onClick={() => setIsNewResourceGroupDialogShown(true)}>
                         Create New
-                    </VSCodeButton>
+                    </button>
                     {hasMessage(existingResourceGroup) && (
                         <span className={styles.validationMessage}>
                             <FontAwesomeIcon className={styles.errorIndicator} icon={faTimesCircle} />
@@ -177,7 +177,8 @@ export function CreateClusterInput(props: CreateClusterInputProps) {
                     <label htmlFor="name-input" className={styles.label}>
                         Cluster Name*
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="name-input"
                         value={isValueSet(name) ? name.value : ""}
                         className={`${styles.longControl} ${styles.validatable}`}
@@ -216,7 +217,7 @@ export function CreateClusterInput(props: CreateClusterInputProps) {
                 </div>
 
                 <div className={styles.buttonContainer}>
-                    <VSCodeButton type="submit">Create</VSCodeButton>
+                    <button type="submit">Create</button>
                 </div>
             </form>
 

--- a/webview-ui/src/CreateCluster/CreateResourceGroup.tsx
+++ b/webview-ui/src/CreateCluster/CreateResourceGroup.tsx
@@ -1,6 +1,5 @@
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { FormEvent, useState } from "react";
 import { Dialog } from "../components/Dialog";
 import { Validatable, hasMessage, invalid, isValid, isValueSet, unset, valid } from "../utilities/validation";
@@ -54,7 +53,8 @@ export function CreateResourceGroupDialog(props: CreateResourceGroupDialogProps)
                     <label htmlFor="rg-name-input" className={styles.label}>
                         Name*
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="rg-name-input"
                         value={isValueSet(name) ? name.value : ""}
                         className={`${styles.longControl} ${styles.validatable}`}
@@ -70,8 +70,8 @@ export function CreateResourceGroupDialog(props: CreateResourceGroupDialogProps)
                 </div>
 
                 <div className={styles.buttonContainer} style={{ justifyContent: "flex-end" }}>
-                    <VSCodeButton type="submit">Create</VSCodeButton>
-                    <VSCodeButton onClick={props.onCancel}>Cancel</VSCodeButton>
+                    <button type="submit">Create</button>
+                    <button onClick={props.onCancel}>Cancel</button>
                 </div>
             </form>
         </Dialog>

--- a/webview-ui/src/CreateCluster/Success.tsx
+++ b/webview-ui/src/CreateCluster/Success.tsx
@@ -1,5 +1,3 @@
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
-
 interface SuccessProps {
     portalClusterUrl: string;
     name: string;
@@ -10,8 +8,7 @@ export function Success(props: SuccessProps) {
         <>
             <h3>Cluster {props.name} was created successfully</h3>
             <p>
-                Click <VSCodeLink href={props.portalClusterUrl}>here</VSCodeLink> to view your cluster in the Azure
-                Portal.
+                Click <a href={props.portalClusterUrl}>here</a> to view your cluster in the Azure Portal.
             </p>
         </>
     );

--- a/webview-ui/src/CreateFleet/CreateFleet.tsx
+++ b/webview-ui/src/CreateFleet/CreateFleet.tsx
@@ -3,7 +3,7 @@ import { InitialState } from "../../../src/webview-contract/webviewDefinitions/c
 import { CreateFleetInput } from "./CreateFleetInput";
 import { useStateManagement } from "../utilities/state";
 import { Stage, stateUpdater, vscode } from "./helpers/state";
-import { VSCodeLink, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 
 export function CreateFleet(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -60,8 +60,8 @@ export function CreateFleet(initialState: InitialState) {
                     <>
                         <h3>Fleet {state.createParams!.name} was created successfully</h3>
                         <p>
-                            Click <VSCodeLink href={state.createdFleet?.portalUrl}>here</VSCodeLink> to view your fleet
-                            in the Azure Portal.
+                            Click <a href={state.createdFleet?.portalUrl}>here</a> to view your fleet in the Azure
+                            Portal.
                         </p>
                     </>
                 );

--- a/webview-ui/src/CreateFleet/CreateFleetInput.tsx
+++ b/webview-ui/src/CreateFleet/CreateFleetInput.tsx
@@ -5,7 +5,7 @@ import {
     ResourceGroup,
     ToVsCodeMsgDef,
 } from "../../../src/webview-contract/webviewDefinitions/createFleet";
-import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
 import {
     hasMessage,
     invalid,
@@ -133,7 +133,8 @@ export function CreateFleetInput(props: CreateFleetInputProps) {
                 </label>
 
                 <label className={styles.label}>Fleet Name*</label>
-                <VSCodeTextField
+                <input
+                    type="text"
                     id="name-input"
                     value={isValueSet(fleetName) ? fleetName.value : ""}
                     className={`${styles.longControl} ${styles.validatable}`}
@@ -210,7 +211,7 @@ export function CreateFleetInput(props: CreateFleetInputProps) {
             ></CreateFleetModeInput>
 
             <div className={styles.buttonContainer}>
-                <VSCodeButton type="submit">Create</VSCodeButton>
+                <button type="submit">Create</button>
             </div>
         </form>
     );

--- a/webview-ui/src/CreateFleet/CreateFleetModeInput.tsx
+++ b/webview-ui/src/CreateFleet/CreateFleetModeInput.tsx
@@ -1,7 +1,6 @@
 import { FormEvent } from "react";
 import { HubMode } from "../../../src/webview-contract/webviewDefinitions/createFleet";
 import { hasMessage, invalid, isValueSet, valid, Validatable } from "../utilities/validation";
-import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import styles from "./CreateFleet.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
@@ -79,7 +78,8 @@ export function CreateFleetModeInput(props: CreateFleetInputProps) {
                 {props.hubMode === HubMode.With && (
                     <div className={styles.inputContainer}>
                         <label className={styles.label}>DNS name prefix*</label>
-                        <VSCodeTextField
+                        <input
+                            type="text"
                             id="dns-input"
                             value={isValueSet(props.dnsPrefix) ? props.dnsPrefix.value : ""}
                             className={`${styles.longControl} ${styles.validatable}`}

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -49,7 +49,7 @@ button:hover {
     cursor: pointer;
 }
 
-button:focus {
+button:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 2px;
 }
@@ -74,14 +74,40 @@ button:disabled {
     cursor: pointer;
 }
 
+.secondary-button:disabled {
+    background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
 .secondary-button:hover:disabled {
     opacity: 0.4;
     cursor: not-allowed;
-    background-color: var(--vscode-button-hoverBackground);
+    background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
 .secondary-button code {
     color: var(--vscode-textPreformat-foreground);
+}
+
+.icon-button,
+.choose-location-button {
+    color: inherit;
+    background: none;
+    padding: 0rem 0.3rem 0rem 0.3rem;
+    border-radius: 5px;
+}
+.icon-button:hover,
+.choose-location-button:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.choose-location-button {
+    margin-top: 0.1rem;
+    padding: 0.15rem 0.3rem 0.15rem 0.1rem;
+}
+
+.icon-button:disabled,
+.choose-location-button:disabled {
+    background: none;
 }
 
 blockquote {
@@ -95,22 +121,64 @@ hr {
     margin: 4px 0 4px 0;
 }
 
-input,
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
     height: calc(var(--input-height) * 1px);
     color: var(--input-foreground);
     background-color: var(--input-background);
-    border: 1px solid var(--input-border);
+    border: 1px solid var(--vscode-dropdown-border);
     padding: 0 9px;
     box-sizing: border-box;
     border-radius: 2px;
     font-family: inherit;
 }
 
-option:hover {
-    color: var(--vscode-list-focusForeground);
+input[type="text"]:read-only {
+    cursor: not-allowed;
+}
+
+input[type="checkbox"] {
+    width: 18.25px;
+    height: 18.25px;
     cursor: pointer;
-    background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+input[type="radio"] {
+    box-sizing: border-box;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    margin: 0;
+    border: 2px solid var(--radio-border-color);
+    border-radius: 50%;
+    background-color: none;
+    outline: none;
+    position: relative;
+    top: 0.18rem;
+    color: white;
+}
+
+input[type="radio"] {
+    cursor: pointer;
+}
+
+select {
+    height: calc(var(--input-height) * 1px);
+    color: var(--input-foreground);
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    padding: 0px 0px 0px 4px;
+    box-sizing: border-box;
+    font-family: inherit;
+    border-radius: 2px;
+}
+
+select:hover {
+    cursor: pointer;
+}
+
+option {
+    font-size: var(--vscode-font-size);
 }
 
 option:focus {


### PR DESCRIPTION
This PR specifically removes elements from the Cluster Create, Fleet Create, and Cluster Properties commands.

**.vsix for testing:** [vscode-aks-tools-1.6.0-deprecate1.vsix.zip](https://github.com/user-attachments/files/18893405/vscode-aks-tools-1.6.0-deprecate1.vsix.zip)


This is broken up as part of incremental PR's to make review & testing smoother.

For future reference:
- .secondary-button replaces VSCodeButton's appearance="secondary"
- .icon-button replaces VSCodeButton's appearance="icon"
- input[type="text"] replaces VSCodeTextInput
- input[type="checkbox"] replaces VSCodeCheckbox
- input[type="radio"] replaces VSCodeRadio
- Default "< hr >" element now has identical styling to VSCodeDivider
-  Default "< a >" element also has identical styling to VSCodeLink