### PR TITLE
[Webview UI toolkit deprecation] Inspektor Gadget, Retina Capture & TCP Dump component removal

### DIFF
--- a/webview-ui/src/InspektorGadget/InspektorGadget.module.css
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.module.css
@@ -33,6 +33,7 @@ table.tracelist th {
 
 table.tracelist td {
     padding: 5px;
+    text-align: left;
 }
 
 table.tracelist td > * {
@@ -126,4 +127,32 @@ ul.hierarchyList li * {
 
 .panelContent .main {
     grid-column: 2 / 3;
+}
+
+.displayCheckbox {
+    display: inline;
+}
+
+.displayLabel {
+    display: inline;
+    position: relative;
+    top: -0.3rem;
+    margin-left: 0.1rem;
+}
+
+.tableData {
+    text-align: left;
+}
+
+.checkBoxLabel {
+    position: relative;
+    top: -0.05rem;
+}
+
+.radioLabel {
+    margin-left: 0.62rem;
+}
+
+.radioLine {
+    margin-bottom: 0.3rem;
 }

--- a/webview-ui/src/InspektorGadget/InspektorGadget.tsx
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.tsx
@@ -1,4 +1,4 @@
-import { VSCodeLink, VSCodePanelTab, VSCodePanelView, VSCodePanels } from "@vscode/webview-ui-toolkit/react";
+import { VSCodePanelTab, VSCodePanelView, VSCodePanels } from "@vscode/webview-ui-toolkit/react";
 import { Overview } from "./Overview";
 import { Traces, TracesProps } from "./Traces";
 import styles from "./InspektorGadget.module.css";
@@ -53,7 +53,7 @@ export function InspektorGadget(initialState: InitialState) {
             <h2>Inspektor Gadget</h2>
             <p>
                 Inspektor Gadget provides a wide selection of BPF tools to dig deep into your Kubernetes cluster.
-                <VSCodeLink href="https://www.inspektor-gadget.io/">&nbsp;Learn more</VSCodeLink>
+                <a href="https://www.inspektor-gadget.io/">&nbsp;Learn more</a>
             </p>
 
             <VSCodePanels aria-label="Inspektory Gadget functions">

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./InspektorGadget.module.css";
 import { Dialog } from "../components/Dialog";
 import { FormEvent, useEffect, useState, ChangeEvent as InputChangeEvent } from "react";
@@ -146,7 +146,7 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
             <h2>New Trace</h2>
 
             <form onSubmit={handleSubmit}>
-                <VSCodeDivider />
+                <hr />
 
                 <div className={styles.inputContainer}>
                     <label htmlFor="gadget-dropdown" className={styles.label}>
@@ -227,12 +227,14 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
                     )}
 
                     {extraProperties.threadExclusionAllowed && (
-                        <VSCodeCheckbox
-                            checked={traceConfig.excludeThreads === false}
-                            onChange={handleDisplayThreadsChange}
-                        >
-                            Display threads
-                        </VSCodeCheckbox>
+                        <div>
+                            <input
+                                className={styles.displayCheckbox}
+                                type="checkbox"
+                                onChange={handleDisplayThreadsChange}
+                            />
+                            <label className={styles.displayLabel}>Display Threads</label>
+                        </div>
                     )}
 
                     {extraProperties.requiresTimeout && (
@@ -254,13 +256,13 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
                     )}
                 </div>
 
-                <VSCodeDivider />
+                <hr />
 
                 <div className={styles.buttonContainer}>
-                    <VSCodeButton type="submit" disabled={!canCreate()}>
+                    <button type="submit" disabled={!canCreate()}>
                         Ok
-                    </VSCodeButton>
-                    <VSCodeButton onClick={props.onCancel}>Cancel</VSCodeButton>
+                    </button>
+                    <button onClick={props.onCancel}>Cancel</button>
                 </div>
             </form>
         </Dialog>

--- a/webview-ui/src/InspektorGadget/Overview.tsx
+++ b/webview-ui/src/InspektorGadget/Overview.tsx
@@ -1,4 +1,3 @@
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEraser, faRocket } from "@fortawesome/free-solid-svg-icons";
 import styles from "./InspektorGadget.module.css";
@@ -35,17 +34,17 @@ export function Overview(props: OverviewProps) {
                         <dd>{props.version.server}</dd>
                     </dl>
                     <br />
-                    <VSCodeButton onClick={handleUndeploy}>
+                    <button onClick={handleUndeploy}>
                         <FontAwesomeIcon icon={faEraser} />
                         &nbsp;Undeploy
-                    </VSCodeButton>
+                    </button>
                 </>
             )}
             {props.version && !props.version.server && (
-                <VSCodeButton onClick={handleDeploy}>
+                <button onClick={handleDeploy}>
                     <FontAwesomeIcon icon={faRocket} />
                     &nbsp;Deploy
-                </VSCodeButton>
+                </button>
             )}
         </>
     );

--- a/webview-ui/src/InspektorGadget/ResourceSelector.tsx
+++ b/webview-ui/src/InspektorGadget/ResourceSelector.tsx
@@ -4,7 +4,7 @@ import { faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons
 import styles from "./InspektorGadget.module.css";
 import { NamespaceResources, PodResources } from "./helpers/clusterResources";
 import { Lazy, isLoaded, isNotLoaded, map as lazyMap, orDefault } from "../utilities/lazy";
-import { VSCodeProgressRing, VSCodeRadio } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { Lookup, asLookup, exclude, intersection } from "../utilities/array";
 import { EventHandlers } from "../utilities/state";
 import { EventDef, vscode } from "./helpers/state";
@@ -109,9 +109,14 @@ export function ResourceSelector(props: ResourceSelectorProps) {
             className={props.className ? `${props.className} ${styles.hierarchyList}` : styles.hierarchyList}
         >
             <li>
-                <VSCodeRadio onChange={handleNoResourceChange} checked={isNoResource(selectedResource)}>
-                    All
-                </VSCodeRadio>
+                <div className={styles.radioLine}>
+                    <input
+                        type="radio"
+                        onChange={handleNoResourceChange}
+                        checked={isNoResource(selectedResource)}
+                    ></input>
+                    <label className={styles.radioLabel}>All</label>
+                </div>
             </li>
             {renderNamespaceItems(props.resources, updatedStatus)}
         </ul>
@@ -125,13 +130,15 @@ export function ResourceSelector(props: ResourceSelectorProps) {
                     onClick={() => toggleNamespaceExpanded(item.name)}
                     icon={status[item.name].isExpanded ? faChevronDown : faChevronRight}
                 />
-                <VSCodeRadio
-                    className={styles.selector}
-                    onChange={(e) => handleNamespaceChange(e, item.name)}
-                    checked={isNamespaceResource(selectedResource) && selectedResource.namespace === item.name}
-                >
-                    {item.name}
-                </VSCodeRadio>
+                <div className={styles.radioLine}>
+                    <input
+                        type="radio"
+                        className={styles.selector}
+                        onChange={(e) => handleNamespaceChange(e, item.name)}
+                        checked={isNamespaceResource(selectedResource) && selectedResource.namespace === item.name}
+                    ></input>
+                    <label className={styles.radioLabel}>{item.name}</label>
+                </div>
                 {status[item.name].isExpanded && (
                     <ul className={styles.hierarchyList}>
                         {isLoaded(item.children) ? (
@@ -153,16 +160,19 @@ export function ResourceSelector(props: ResourceSelectorProps) {
                     onClick={() => togglePodExpanded(namespace, item.name)}
                     icon={status[item.name].isExpanded ? faChevronDown : faChevronRight}
                 />
-                <VSCodeRadio
-                    onChange={(e) => handlePodChange(e, namespace, item.name)}
-                    checked={
-                        isPodResource(selectedResource) &&
-                        selectedResource.namespace === namespace &&
-                        selectedResource.podName === item.name
-                    }
-                >
-                    {item.name}
-                </VSCodeRadio>
+                <div className={styles.radioLine}>
+                    <input
+                        type="radio"
+                        onChange={(e) => handlePodChange(e, namespace, item.name)}
+                        checked={
+                            isPodResource(selectedResource) &&
+                            selectedResource.namespace === namespace &&
+                            selectedResource.podName === item.name
+                        }
+                    ></input>
+
+                    <label className={styles.radioLabel}>{item.name}</label>
+                </div>
                 {status[item.name].isExpanded && (
                     <ul className={styles.hierarchyList}>
                         {isLoaded(item.children) ? (
@@ -179,17 +189,19 @@ export function ResourceSelector(props: ResourceSelectorProps) {
     function renderContainerItems(namespace: string, podName: string, containerNames: string[]) {
         return containerNames.map((c) => (
             <li key={c}>
-                <VSCodeRadio
-                    onChange={(e) => handleContainerChange(e, namespace, podName, c)}
-                    checked={
-                        isContainerResource(selectedResource) &&
-                        selectedResource.namespace === namespace &&
-                        selectedResource.podName === podName &&
-                        selectedResource.container === c
-                    }
-                >
-                    {c}
-                </VSCodeRadio>
+                <div className={styles.radioLine}>
+                    <input
+                        type="radio"
+                        onChange={(e) => handleContainerChange(e, namespace, podName, c)}
+                        checked={
+                            isContainerResource(selectedResource) &&
+                            selectedResource.namespace === namespace &&
+                            selectedResource.podName === podName &&
+                            selectedResource.container === c
+                        }
+                    ></input>
+                    <label className={styles.radioLabel}>{c}</label>
+                </div>
             </li>
         ));
     }

--- a/webview-ui/src/InspektorGadget/TraceItemSortSelector.tsx
+++ b/webview-ui/src/InspektorGadget/TraceItemSortSelector.tsx
@@ -1,4 +1,3 @@
-import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { FormEvent } from "react";
 import { ItemProperty, SortSpecifier, fromSortString, toSortString } from "./helpers/gadgets/types";
 
@@ -24,13 +23,14 @@ export function TraceItemSortSelector(props: TraceItemSortSelectorProps) {
     const allowedIdentifiers = props.allProperties.map((p) => p.identifier).sort();
     const title = `Allowed properties:\n${allowedIdentifiers.join("\n")}`;
     return (
-        <VSCodeTextField
+        <input
+            type="text"
             title={title}
             id={props.id}
             className={props.className}
             required={props.required}
             value={sortString}
             onInput={handleSortStringChange}
-        ></VSCodeTextField>
+        ></input>
     );
 }

--- a/webview-ui/src/InspektorGadget/Traces.tsx
+++ b/webview-ui/src/InspektorGadget/Traces.tsx
@@ -1,4 +1,3 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faTrashCan, faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 import styles from "./InspektorGadget.module.css";
@@ -35,7 +34,6 @@ export function Traces(props: TracesProps) {
     }
 
     function ignoreClick(e: Event | FormEvent<HTMLElement>) {
-        e.preventDefault();
         e.stopPropagation();
     }
 
@@ -140,13 +138,15 @@ export function Traces(props: TracesProps) {
                                 className={getTraceRowClassNames(trace.traceId)}
                             >
                                 <td>
-                                    <VSCodeCheckbox
-                                        checked={checkedTraceIds.includes(trace.traceId)}
+                                    <input
+                                        type="checkbox"
                                         onClick={ignoreClick}
                                         onChange={() => toggleCheckedTraceId(trace.traceId)}
-                                        style={{ margin: "0", paddingRight: "0.5rem" }}
+                                        style={{ margin: "0 0.5rem 0 0" }}
                                     />
-                                    {getGadgetMetadata(trace.category, trace.resource)?.name}
+                                    <span className={styles.checkBoxLabel}>
+                                        {getGadgetMetadata(trace.category, trace.resource)?.name}
+                                    </span>
                                 </td>
                                 <td>{getNamespaceText(trace.filters.namespace)}</td>
                                 <td>{trace.filters.nodeName}</td>
@@ -159,19 +159,19 @@ export function Traces(props: TracesProps) {
             )}
 
             <div className={styles.buttonContainer}>
-                <VSCodeButton onClick={handleAdd}>
+                <button onClick={handleAdd}>
                     <FontAwesomeIcon icon={faPlus} />
                     &nbsp;Add
-                </VSCodeButton>
+                </button>
                 {checkedTraceIds.length > 0 && (
-                    <VSCodeButton onClick={handleDelete}>
+                    <button onClick={handleDelete}>
                         <FontAwesomeIcon icon={faTrashCan} />
                         &nbsp;Delete
-                    </VSCodeButton>
+                    </button>
                 )}
             </div>
 
-            <VSCodeDivider />
+            <hr />
 
             {selectedTrace && (
                 <>

--- a/webview-ui/src/RetinaCapture/DeleteNodeExplorerDialog.tsx
+++ b/webview-ui/src/RetinaCapture/DeleteNodeExplorerDialog.tsx
@@ -1,4 +1,3 @@
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { Dialog } from "../components/Dialog";
 import styles from "./RetinaCapture.module.css";
 
@@ -29,8 +28,8 @@ export function DeleteNodeExplorerDialog(props: DeleteNodeExplorerDialogProps) {
                 </div>
 
                 <div className={styles.buttonContainer} style={{ justifyContent: "flex-end" }}>
-                    <VSCodeButton onClick={handleYes}>Yes</VSCodeButton>
-                    <VSCodeButton onClick={handleNo}>No</VSCodeButton>
+                    <button onClick={handleYes}>Yes</button>
+                    <button onClick={handleNo}>No</button>
                 </div>
             </form>
         </Dialog>

--- a/webview-ui/src/RetinaCapture/RetinaCapture.tsx
+++ b/webview-ui/src/RetinaCapture/RetinaCapture.tsx
@@ -1,6 +1,5 @@
 import { faInfoCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { VSCodeButton, VSCodeCheckbox, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
 import { FormEvent, useState } from "react";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/retinaCapture";
 import { useStateManagement } from "../utilities/state";
@@ -43,44 +42,52 @@ export function RetinaCapture(initialState: InitialState) {
                 <h2>Retina Distributed Capture for {state.clusterName}</h2>
             </header>
 
-            <VSCodeDivider style={{ marginBottom: "1rem" }} />
+            <hr style={{ marginBottom: "1rem" }} />
             <div>
                 <FontAwesomeIcon icon={faInfoCircle} /> Retina capture command allows the user to capture network
                 traffic and metadata for the capture target, and then send the capture file to the location by Output
                 Configuration. More info:{" "}
                 <a href="https://retina.sh/docs/captures/cli/#output-configurationrequired">Retina Capture Command</a>
             </div>
-            <VSCodeDivider style={{ marginBottom: "1rem" }} />
+            <hr style={{ marginBottom: "1rem" }} />
             <h3>Retina Output</h3>
             <div>{state.retinaOutput}</div>
 
-            <VSCodeDivider style={{ marginTop: "1rem" }} />
+            <hr style={{ marginTop: "1rem" }} />
             <h3>Retina Distributed Capture is Successfully Completed for this Cluster</h3>
 
             <div className={styles.content}>
                 <div style={{ flexDirection: "row", width: "31.25rem" }}>
                     {state.allNodes.map((node) => (
                         <div key={node}>
-                            <VSCodeCheckbox onChange={(e) => onSelectNode(e, node)} checked={isNodeSelected(node)}>
-                                {node}
-                            </VSCodeCheckbox>
+                            <input
+                                onChange={(e) => onSelectNode(e, node)}
+                                checked={isNodeSelected(node)}
+                                type="checkbox"
+                                style={{
+                                    margin: "0rem 0.5rem 0.5rem 0",
+                                    position: "relative",
+                                    top: ".125rem",
+                                }}
+                            />
+                            <span style={{ position: "relative", top: "-.2rem" }}>{node}</span>
                         </div>
                     ))}
-                    <div style={{ display: "flex" }}>
-                        <VSCodeButton
+                    <div style={{ display: "flex", marginTop: ".5rem" }}>
+                        <button
                             type="submit"
                             style={{ marginRight: "0.625rem" }}
                             onClick={() => handleCaptureFileDownload()}
                         >
                             Download Retina Logs to Host Machine.
-                        </VSCodeButton>
+                        </button>
                         {state.isNodeExplorerPodExists && (
-                            <VSCodeButton appearance="secondary" onClick={() => handleDeleteExplorerPod()}>
-                                <span slot="start">
+                            <>
+                                <button className="secondary-button" onClick={() => handleDeleteExplorerPod()}>
                                     <FontAwesomeIcon icon={faTrash} />
-                                </span>
-                                Delete Node Explorer Pod
-                            </VSCodeButton>
+                                    &nbsp;Delete Node Explorer Pod
+                                </button>
+                            </>
                         )}
                     </div>
                 </div>

--- a/webview-ui/src/TCPDump/CaptureFilters.tsx
+++ b/webview-ui/src/TCPDump/CaptureFilters.tsx
@@ -8,7 +8,6 @@ import { SpecificPodFilters } from "./filterScenarios/SpecificPodFilters";
 import { TwoPodsFilters } from "./filterScenarios/TwoPodsFilters";
 import { CaptureScenario, EventDef, NodeState, ReferenceData } from "./state";
 import { EventHandlerFunc, loadCaptureInterfaces } from "./state/dataLoading";
-import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import {
     ApplicationLayerProtocol,
     TransportLayerProtocol,
@@ -178,7 +177,8 @@ export function CaptureFilters(props: CaptureFiltersProps) {
             <label htmlFor="pcap-filter-string-input" className={styles.label}>
                 Pcap Filter
             </label>
-            <VSCodeTextField
+            <input
+                type="text"
                 id="pcap-filter-string-input"
                 className={styles.control}
                 value={props.nodeState.currentCaptureFilters.pcapFilterString || ""}

--- a/webview-ui/src/TCPDump/TcpDump.module.css
+++ b/webview-ui/src/TCPDump/TcpDump.module.css
@@ -62,4 +62,9 @@ table.capturelist th {
 
 table.capturelist td {
     padding: 5px;
+    text-align: left;
+}
+
+button span {
+    margin-right: 0.5rem;
 }

--- a/webview-ui/src/TCPDump/TcpDump.tsx
+++ b/webview-ui/src/TCPDump/TcpDump.tsx
@@ -1,7 +1,7 @@
 import { CaptureName, InitialState } from "../../../src/webview-contract/webviewDefinitions/tcpDump";
 import styles from "./TcpDump.module.css";
 import { useEffect } from "react";
-import { VSCodeButton, VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useStateManagement } from "../utilities/state";
 import { CaptureStatus, NodeState, NodeStatus, TcpDumpState, stateUpdater, vscode } from "./state";
 import { NodeSelector } from "../components/NodeSelector";
@@ -93,7 +93,7 @@ export function TcpDump(initialState: InitialState) {
                 <h2>TCP Capture on {state.clusterName}</h2>
             </header>
 
-            <VSCodeDivider style={{ marginBottom: "1rem" }} />
+            <hr style={{ marginBottom: "1rem" }} />
 
             <div className={styles.content}>
                 <label htmlFor="node-dropdown" className={styles.label}>
@@ -115,7 +115,7 @@ export function TcpDump(initialState: InitialState) {
 
                 <label className={styles.label}>Debug Pod</label>
                 {hasStatus(NodeStatus.Clean, NodeStatus.CreatingDebugPod) && (
-                    <VSCodeButton
+                    <button
                         onClick={handleCreateDebugPod}
                         disabled={!hasStatus(NodeStatus.Clean)}
                         className={styles.controlButton}
@@ -131,7 +131,7 @@ export function TcpDump(initialState: InitialState) {
                             </span>
                         )}
                         Create
-                    </VSCodeButton>
+                    </button>
                 )}
                 {hasStatus(
                     NodeStatus.DebugPodRunning,
@@ -140,11 +140,10 @@ export function TcpDump(initialState: InitialState) {
                     NodeStatus.CaptureRunning,
                     NodeStatus.CaptureStopping,
                 ) && (
-                    <VSCodeButton
+                    <button
                         onClick={handleRemoveDebugPod}
                         disabled={!hasStatus(NodeStatus.DebugPodRunning)}
-                        className={styles.controlButton}
-                        appearance="secondary"
+                        className={`${styles.controlButton} secondary-button`}
                     >
                         {hasStatus(NodeStatus.DeletingDebugPod) && (
                             <span slot="start">
@@ -157,7 +156,7 @@ export function TcpDump(initialState: InitialState) {
                             </span>
                         )}
                         Delete
-                    </VSCodeButton>
+                    </button>
                 )}
 
                 {state.selectedNode &&
@@ -176,7 +175,7 @@ export function TcpDump(initialState: InitialState) {
 
                 <label className={styles.label}>Capture</label>
                 {hasStatus(NodeStatus.DebugPodRunning, NodeStatus.CaptureStarting) && (
-                    <VSCodeButton
+                    <button
                         onClick={handleStartCapture}
                         disabled={!hasStatus(NodeStatus.DebugPodRunning)}
                         className={styles.controlButton}
@@ -192,10 +191,10 @@ export function TcpDump(initialState: InitialState) {
                             </span>
                         )}
                         Start
-                    </VSCodeButton>
+                    </button>
                 )}
                 {hasStatus(NodeStatus.CaptureRunning, NodeStatus.CaptureStopping) && (
-                    <VSCodeButton
+                    <button
                         onClick={handleStopCapture}
                         disabled={!hasStatus(NodeStatus.CaptureRunning)}
                         className={styles.controlButton}
@@ -211,10 +210,10 @@ export function TcpDump(initialState: InitialState) {
                             </span>
                         )}
                         Stop
-                    </VSCodeButton>
+                    </button>
                 )}
             </div>
-            <VSCodeDivider style={{ marginTop: "1rem" }} />
+            <hr style={{ marginTop: "1rem" }} />
             <h3>Completed Captures</h3>
             {hasStatus(
                 NodeStatus.DebugPodRunning,
@@ -239,10 +238,10 @@ export function TcpDump(initialState: InitialState) {
                                     <td>{c.sizeInKB}</td>
                                     <td>
                                         {!c.downloadedFilePath && (
-                                            <VSCodeButton
+                                            <button
                                                 onClick={() => handleStartDownload(c.name)}
                                                 disabled={c.status !== CaptureStatus.Completed}
-                                                appearance="secondary"
+                                                className="secondary-button"
                                             >
                                                 {c.status === CaptureStatus.Downloading && (
                                                     <span slot="start">
@@ -255,27 +254,27 @@ export function TcpDump(initialState: InitialState) {
                                                     </span>
                                                 )}
                                                 Download
-                                            </VSCodeButton>
+                                            </button>
                                         )}
 
                                         {c.downloadedFilePath && (
                                             <div style={{ display: "flex" }}>
                                                 <span>{c.downloadedFilePath}</span>
                                                 &nbsp;
-                                                <VSCodeButton appearance="icon" title="Copy Path">
+                                                <button className="icon-button" title="Copy Path">
                                                     <FontAwesomeIcon
                                                         icon={faCopy}
                                                         onClick={() =>
                                                             handleCopyDownloadPathClick(c.downloadedFilePath!)
                                                         }
                                                     />
-                                                </VSCodeButton>
-                                                <VSCodeButton appearance="icon" title="Open Folder">
+                                                </button>
+                                                <button className="icon-button" title="Open Folder">
                                                     <FontAwesomeIcon
                                                         icon={faFolderOpen}
                                                         onClick={() => handleOpenFolderClick(c.downloadedFilePath!)}
                                                     />
-                                                </VSCodeButton>
+                                                </button>
                                             </div>
                                         )}
                                     </td>

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -49,7 +49,7 @@ button:hover {
     cursor: pointer;
 }
 
-button:focus {
+button:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 2px;
 }
@@ -74,14 +74,40 @@ button:disabled {
     cursor: pointer;
 }
 
+.secondary-button:disabled {
+    background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
 .secondary-button:hover:disabled {
     opacity: 0.4;
     cursor: not-allowed;
-    background-color: var(--vscode-button-hoverBackground);
+    background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
 .secondary-button code {
     color: var(--vscode-textPreformat-foreground);
+}
+
+.icon-button,
+.choose-location-button {
+    color: inherit;
+    background: none;
+    padding: 0rem 0.3rem 0rem 0.3rem;
+    border-radius: 5px;
+}
+.icon-button:hover,
+.choose-location-button:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.choose-location-button {
+    margin-top: 0.1rem;
+    padding: 0.15rem 0.3rem 0.15rem 0.1rem;
+}
+
+.icon-button:disabled,
+.choose-location-button:disabled {
+    background: none;
 }
 
 blockquote {
@@ -95,22 +121,64 @@ hr {
     margin: 4px 0 4px 0;
 }
 
-input,
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
     height: calc(var(--input-height) * 1px);
     color: var(--input-foreground);
     background-color: var(--input-background);
-    border: 1px solid var(--input-border);
+    border: 1px solid var(--vscode-dropdown-border);
     padding: 0 9px;
     box-sizing: border-box;
     border-radius: 2px;
     font-family: inherit;
 }
 
-option:hover {
-    color: var(--vscode-list-focusForeground);
+input[type="text"]:read-only {
+    cursor: not-allowed;
+}
+
+input[type="checkbox"] {
+    width: 18.25px;
+    height: 18.25px;
     cursor: pointer;
-    background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+input[type="radio"] {
+    box-sizing: border-box;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    margin: 0;
+    border: 2px solid var(--radio-border-color);
+    border-radius: 50%;
+    background-color: none;
+    outline: none;
+    position: relative;
+    top: 0.18rem;
+    color: white;
+}
+
+input[type="radio"] {
+    cursor: pointer;
+}
+
+select {
+    height: calc(var(--input-height) * 1px);
+    color: var(--input-foreground);
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    padding: 0px 0px 0px 4px;
+    box-sizing: border-box;
+    font-family: inherit;
+    border-radius: 2px;
+}
+
+select:hover {
+    cursor: pointer;
+}
+
+option {
+    font-size: var(--vscode-font-size);
 }
 
 option:focus {


### PR DESCRIPTION
This PR specifically removes elements from the  Inspektor Gadget, Retina Capture & TCP Dump commands.

**.vsix for testing:** [vscode-aks-tools-1.6.0-deprecate2.vsix.zip](https://github.com/user-attachments/files/18893162/vscode-aks-tools-1.6.0-deprecate2.vsix.zip)


This is broken up as part of incremental PR's to make review & testing smoother.

For future reference:
- .secondary-button replaces VSCodeButton's appearance="secondary"
- .icon-button replaces VSCodeButton's appearance="icon"
- input[type="text"] replaces VSCodeTextInput
- input[type="checkbox"] replaces VSCodeCheckbox
- input[type="radio"] replaces VSCodeRadio
- Default "< hr >" element now has identical styling to VSCodeDivider
-  Default "< a >" element also has identical styling to VSCodeLink