### PR TITLE
[Webview UI toolkit deprecation] AttachAcrToCluster, DraftDeployment/Dockerfile/Workflow Panel component removal

### DIFF
--- a/webview-ui/src/AttachAcrToCluster/AttachAcrToCluster.tsx
+++ b/webview-ui/src/AttachAcrToCluster/AttachAcrToCluster.tsx
@@ -18,7 +18,6 @@ import {
 import { AttachAcrToClusterState, stateUpdater, vscode } from "./state/state";
 import { distinct } from "../utilities/array";
 import { ResourceSelector } from "../components/ResourceSelector";
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { faLink, faLinkSlash } from "@fortawesome/free-solid-svg-icons";
 import { AcrRoleState } from "./state/stateTypes";
 import { InlineAction, InlineActionProps, makeFixAction, makeInlineActionProps } from "../components/InlineAction";
@@ -96,16 +95,16 @@ export function AttachAcrToCluster(initialState: InitialState) {
                 <p className={styles.fullWidth}>
                     Select a cluster and Azure Container Registry (ACR) to attach. For more information on attaching an
                     ACR to a cluster, see{" "}
-                    <VSCodeLink href="https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?tabs=azure-cli#configure-acr-integration-for-an-existing-aks-cluster">
+                    <a href="https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?tabs=azure-cli#configure-acr-integration-for-an-existing-aks-cluster">
                         Configure ACR integration for an existing AKS cluster
-                    </VSCodeLink>
+                    </a>
                     .
                 </p>
                 <p className={styles.fullWidth}>
                     This operation assigns the{" "}
-                    <VSCodeLink href="https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#acrpull">
+                    <a href="https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#acrpull">
                         AcrPull
-                    </VSCodeLink>{" "}
+                    </a>{" "}
                     role to the Microsoft Entra ID managed identity associated with your AKS cluster.
                 </p>
 

--- a/webview-ui/src/AutomatedDeployments/AutomatedDeployments.tsx
+++ b/webview-ui/src/AutomatedDeployments/AutomatedDeployments.tsx
@@ -1,6 +1,5 @@
 //import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/automatedDeployments";
-//import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 //import { faFolder } from "@fortawesome/free-regular-svg-icons";
 
 import {
@@ -26,16 +25,6 @@ import {
     valid,
 } from "../utilities/validation";
 import { ResourceSelector } from "../components/ResourceSelector";
-import {
-    VSCodeButton,
-    //VSCodeButton,
-    //VSCodeLink,
-    //VSCodeRadio,
-    //VSCodeRadioGroup,
-    VSCodeTextField,
-    //VSCodeDropdown,
-    //VSCodeOption,
-} from "@vscode/webview-ui-toolkit/react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -152,7 +141,8 @@ export function AutomatedDeployments(initialState: InitialState) {
                         Workflow name *
                     </label>
 
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="workflow-name-input"
                         value={orDefault(state.selectedWorkflowName, "")}
                         className={styles.control}
@@ -218,12 +208,12 @@ export function AutomatedDeployments(initialState: InitialState) {
                         onSelect={(g) => console.log("Selected Resource Group:", g)}
                     />
 
-                    <VSCodeButton
+                    <button
                         className={styles.sideControl}
                         onClick={() => eventHandlers.onSetIsNewResourceGroupDialogShown(true)}
                     >
                         Create New Resource Group
-                    </VSCodeButton>
+                    </button>
 
                     {state.isNewResourceGroupDialogShown && (
                         <CreateResourceGroupDialog
@@ -253,9 +243,9 @@ export function AutomatedDeployments(initialState: InitialState) {
             </form>
 
             <div className={styles.buttonContainer}>
-                <VSCodeButton type="submit" onClick={handleCreateWorkflowClick}>
+                <button type="submit" onClick={handleCreateWorkflowClick}>
                     Create DevHub Workflow
-                </VSCodeButton>
+                </button>
             </div>
         </>
     );

--- a/webview-ui/src/Draft/Draft.module.css
+++ b/webview-ui/src/Draft/Draft.module.css
@@ -47,6 +47,10 @@
     color: var(--vscode-textLink-foreground);
 }
 
+.linkColor {
+    color: var(--vscode-textLink-foreground);
+}
+
 .buttonContainer {
     margin-top: 1rem;
     margin-bottom: 1rem;
@@ -101,4 +105,12 @@ ul.existingFileList > li.removable {
 
 .nextStepsContainer h3 {
     margin-top: 0;
+}
+
+.radioLabel {
+    margin-left: 0.62rem;
+}
+
+.radioLine {
+    margin-bottom: 0.5rem;
 }

--- a/webview-ui/src/Draft/DraftDeployment/DraftDeployment.tsx
+++ b/webview-ui/src/Draft/DraftDeployment/DraftDeployment.tsx
@@ -32,13 +32,6 @@ import { Lazy, map as lazyMap } from "../../utilities/lazy";
 import { ResourceSelector } from "../../components/ResourceSelector";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
-import {
-    VSCodeButton,
-    VSCodeLink,
-    VSCodeRadio,
-    VSCodeRadioGroup,
-    VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
 import { faFolder } from "@fortawesome/free-regular-svg-icons";
 import { distinct } from "../../utilities/array";
 import { TextWithDropdown } from "../../components/TextWithDropdown";
@@ -231,7 +224,6 @@ export function DraftDeployment(initialState: InitialState) {
         });
     }
 
-    const [manifests, helm, kustomize]: DeploymentSpecType[] = ["manifests", "helm", "kustomize"];
     const existingFiles = getExistingPaths(state.selectedDeploymentSpecType, state.existingFiles);
 
     const acrImageTooltipMessage =
@@ -372,7 +364,8 @@ export function DraftDeployment(initialState: InitialState) {
                             )}
 
                             {state.selectedAcrRepository.value.isNew && (
-                                <VSCodeTextField
+                                <input
+                                    type="text"
                                     id="acr-image-tag-input"
                                     className={styles.control}
                                     value={
@@ -436,19 +429,20 @@ export function DraftDeployment(initialState: InitialState) {
                     <label htmlFor="location-input" className={styles.label}>
                         Location *
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="location-input"
                         readOnly
                         value={`.${state.workspaceConfig.pathSeparator}${state.selectedLocation.value}`}
                         className={styles.control}
                     />
                     <div className={styles.controlSupplement}>
-                        <VSCodeButton appearance="icon" onClick={handleChooseLocationClick}>
+                        <button className="choose-location-button" onClick={handleChooseLocationClick}>
                             <span className={styles.iconButton}>
                                 <FontAwesomeIcon icon={faFolder} />
                                 &nbsp;Choose location
                             </span>
-                        </VSCodeButton>
+                        </button>
                     </div>
                     {hasMessage(state.selectedLocation) && (
                         <span className={styles.validationMessage}>
@@ -460,22 +454,45 @@ export function DraftDeployment(initialState: InitialState) {
                     <label htmlFor="deployment-type-input" className={styles.label}>
                         Deployment options *
                     </label>
-                    <VSCodeRadioGroup
-                        id="deployment-type-input"
-                        className={styles.control}
-                        value={state.selectedDeploymentSpecType}
-                        orientation="vertical"
-                        onChange={handleDeploymentSpecTypeChange}
-                    >
-                        <VSCodeRadio value={manifests}>Manifests</VSCodeRadio>
-                        <VSCodeRadio value={helm}>Helm</VSCodeRadio>
-                        <VSCodeRadio value={kustomize}>Kustomize</VSCodeRadio>
-                    </VSCodeRadioGroup>
+                    <div id="deployment-type-input" className={styles.control}>
+                        <div className={styles.radioLine}>
+                            <input
+                                type="radio"
+                                name="deployment-type"
+                                value="manifests"
+                                checked={state.selectedDeploymentSpecType === "manifests"}
+                                onChange={handleDeploymentSpecTypeChange}
+                            />
+
+                            <label className={styles.radioLabel}>Manifests</label>
+                        </div>
+                        <div className={styles.radioLine}>
+                            <input
+                                type="radio"
+                                name="deployment-type"
+                                value="helm"
+                                checked={state.selectedDeploymentSpecType === "helm"}
+                                onChange={handleDeploymentSpecTypeChange}
+                            />
+                            <label className={styles.radioLabel}>Helm</label>
+                        </div>
+                        <div className={styles.radioLine}>
+                            <input
+                                type="radio"
+                                name="deployment-type"
+                                value="kustomize"
+                                checked={state.selectedDeploymentSpecType === "kustomize"}
+                                onChange={handleDeploymentSpecTypeChange}
+                            />
+                            <label className={styles.radioLabel}>Kustomize</label>
+                        </div>
+                    </div>
 
                     <label htmlFor="app-name-input" className={styles.label}>
                         Application name *
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="app-name-input"
                         value={orDefault(state.selectedApplicationName, "")}
                         className={styles.control}
@@ -554,9 +571,9 @@ export function DraftDeployment(initialState: InitialState) {
                 </fieldset>
 
                 <div className={styles.buttonContainer}>
-                    <VSCodeButton type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
+                    <button type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
                         Create
-                    </VSCodeButton>
+                    </button>
                 </div>
 
                 {existingFiles.length > 0 && (
@@ -565,7 +582,7 @@ export function DraftDeployment(initialState: InitialState) {
                         <ul className={styles.existingFileList}>
                             {existingFiles.map((path, i) => (
                                 <li key={i}>
-                                    <VSCodeLink
+                                    <a
                                         href="#"
                                         onClick={(e) => {
                                             e.preventDefault();
@@ -573,7 +590,7 @@ export function DraftDeployment(initialState: InitialState) {
                                         }}
                                     >
                                         {path}
-                                    </VSCodeLink>
+                                    </a>
                                 </li>
                             ))}
                         </ul>
@@ -588,9 +605,9 @@ export function DraftDeployment(initialState: InitialState) {
 
                             <p>
                                 To generate a GitHub Action, you can run{" "}
-                                <VSCodeLink href="#" onClick={handleDraftWorkflowClick}>
+                                <a href="#" onClick={handleDraftWorkflowClick}>
                                     Automated Deployments: Create a GitHub workflow
-                                </VSCodeLink>
+                                </a>
                                 .
                             </p>
                         </div>

--- a/webview-ui/src/Draft/DraftDockerfile/DraftDockerfile.tsx
+++ b/webview-ui/src/Draft/DraftDockerfile/DraftDockerfile.tsx
@@ -4,7 +4,6 @@ import { ResourceSelector } from "../../components/ResourceSelector";
 import { useStateManagement } from "../../utilities/state";
 import styles from "../Draft.module.css";
 import { stateUpdater, vscode } from "./state";
-import { VSCodeButton, VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFolder } from "@fortawesome/free-regular-svg-icons";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
@@ -146,19 +145,20 @@ export function DraftDockerfile(initialState: InitialState) {
                         <i className={`${styles.inlineIcon} codicon codicon-info`} />
                     </span>
                 </label>
-                <VSCodeTextField
+                <input
+                    type="text"
                     id="location-input"
                     readOnly
                     value={`.${state.workspaceConfig.pathSeparator}${state.selectedLocation.value}`}
                     className={styles.control}
                 />
                 <div className={styles.controlSupplement}>
-                    <VSCodeButton appearance="icon" onClick={handleChooseLocationClick}>
+                    <button className="choose-location-button" onClick={handleChooseLocationClick}>
                         <span className={styles.iconButton}>
                             <FontAwesomeIcon icon={faFolder} />
                             &nbsp;Choose location
                         </span>
-                    </VSCodeButton>
+                    </button>
                 </div>
                 {hasMessage(state.selectedLocation) && (
                     <span className={styles.validationMessage}>
@@ -243,15 +243,15 @@ export function DraftDockerfile(initialState: InitialState) {
 
             <div className={styles.buttonContainer}>
                 {state.status !== "Created" && (
-                    <VSCodeButton type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
+                    <button type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
                         Create
-                    </VSCodeButton>
+                    </button>
                 )}
 
                 {state.existingFiles.map((path, i) => (
-                    <VSCodeButton key={i} appearance="secondary" onClick={() => vscode.postOpenFileRequest(path)}>
+                    <button key={i} className="secondary-button" onClick={() => vscode.postOpenFileRequest(path)}>
                         Open {path}
-                    </VSCodeButton>
+                    </button>
                 ))}
             </div>
 
@@ -263,18 +263,18 @@ export function DraftDockerfile(initialState: InitialState) {
 
                         <p>
                             If you still need to generate the appropriate deployment files, you can run{" "}
-                            <VSCodeLink href="#" onClick={handleDraftDeploymentClick}>
+                            <a href="#" onClick={handleDraftDeploymentClick}>
                                 Automated Deployments: Create a deployment
-                            </VSCodeLink>{" "}
+                            </a>{" "}
                             to easily create the appropriate files.
                         </p>
 
                         <p>
                             If you already have all the files you need to deploy and would like to generate a GitHub
                             Action, you can run{" "}
-                            <VSCodeLink href="#" onClick={handleDraftWorkflowClick}>
+                            <a href="#" onClick={handleDraftWorkflowClick}>
                                 Automated Deployments: Create a GitHub workflow
-                            </VSCodeLink>
+                            </a>
                             .
                         </p>
                     </div>

--- a/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
+++ b/webview-ui/src/Draft/DraftWorkflow/DraftWorkflow.tsx
@@ -40,13 +40,6 @@ import { useStateManagement } from "../../utilities/state";
 import styles from "../Draft.module.css";
 import { Maybe, isNothing, just, nothing } from "../../utilities/maybe";
 import { ResourceSelector } from "../../components/ResourceSelector";
-import {
-    VSCodeButton,
-    VSCodeLink,
-    VSCodeRadio,
-    VSCodeRadioGroup,
-    VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faTimesCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { faFolder } from "@fortawesome/free-regular-svg-icons";
@@ -385,7 +378,6 @@ export function DraftWorkflow(initialState: InitialState) {
         vscode.postCreateWorkflowRequest(createParams.value);
     }
 
-    const [manifests, helm]: DeploymentSpecType[] = ["manifests", "helm"];
     const existingFile = getExistingFile(state, state.selectedWorkflowName);
 
     const gitHubRepoTooltipMessage =
@@ -401,13 +393,13 @@ export function DraftWorkflow(initialState: InitialState) {
                 <p className={styles.fullWidth}>
                     Generate a workflow to deploy to Azure Kubernetes Service (AKS). Before running this command, make
                     sure you have created a Dockerfile and Deployment. You can do this using the{" "}
-                    <VSCodeLink href="#" onClick={handleDraftDockerfileClick}>
+                    <a href="#" onClick={handleDraftDockerfileClick}>
                         Automated Deployments: Create a Dockerfile
-                    </VSCodeLink>{" "}
+                    </a>{" "}
                     and{" "}
-                    <VSCodeLink href="#" onClick={handleDraftDeploymentClick}>
+                    <a href="#" onClick={handleDraftDeploymentClick}>
                         Automated Deployments: Create a Deployment
-                    </VSCodeLink>{" "}
+                    </a>{" "}
                     commands.
                 </p>
 
@@ -416,7 +408,8 @@ export function DraftWorkflow(initialState: InitialState) {
                     <label htmlFor="workflow-name-input" className={styles.label}>
                         Workflow name *
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="workflow-name-input"
                         value={orDefault(state.selectedWorkflowName, "")}
                         className={styles.control}
@@ -493,7 +486,8 @@ export function DraftWorkflow(initialState: InitialState) {
                     <label htmlFor="dockerfile-input" className={styles.label}>
                         Dockerfile *
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="dockerfile-input"
                         value={
                             isValueSet(state.selectedDockerfilePath)
@@ -504,12 +498,12 @@ export function DraftWorkflow(initialState: InitialState) {
                         className={styles.control}
                     />
                     <div className={styles.controlSupplement}>
-                        <VSCodeButton appearance="icon" onClick={handleChooseDockerfileClick}>
+                        <button className="choose-location-button" onClick={handleChooseDockerfileClick}>
                             <span className={styles.iconButton}>
                                 <FontAwesomeIcon icon={faFolder} />
                                 &nbsp;Choose Dockerfile
                             </span>
-                        </VSCodeButton>
+                        </button>
                     </div>
                     {hasMessage(state.selectedDockerfilePath) && (
                         <span className={styles.validationMessage}>
@@ -521,19 +515,20 @@ export function DraftWorkflow(initialState: InitialState) {
                     <label htmlFor="build-context-input" className={styles.label}>
                         Build context *
                     </label>
-                    <VSCodeTextField
+                    <input
+                        type="text"
                         id="build-context-input"
                         value={`.${state.workspaceConfig.pathSeparator}${state.selectedBuildContextPath}`}
                         readOnly
                         className={styles.control}
                     />
                     <div className={styles.controlSupplement}>
-                        <VSCodeButton appearance="icon" onClick={handleChooseBuildContextClick}>
+                        <button className="choose-location-button" onClick={handleChooseBuildContextClick}>
                             <span className={styles.iconButton}>
                                 <FontAwesomeIcon icon={faFolder} />
                                 &nbsp;Choose build context
                             </span>
-                        </VSCodeButton>
+                        </button>
                     </div>
 
                     {isValid(state.selectedSubscription) && (
@@ -685,16 +680,30 @@ export function DraftWorkflow(initialState: InitialState) {
                     <label htmlFor="deployment-type-input" className={styles.label}>
                         Type
                     </label>
-                    <VSCodeRadioGroup
-                        id="deployment-type-input"
-                        className={styles.control}
-                        value={state.selectedDeploymentSpecType}
-                        orientation="vertical"
-                        onChange={handleDeploymentSpecTypeChange}
-                    >
-                        <VSCodeRadio value={manifests}>Manifests</VSCodeRadio>
-                        <VSCodeRadio value={helm}>Helm</VSCodeRadio>
-                    </VSCodeRadioGroup>
+
+                    <div id="deployment-type-input" className={styles.control}>
+                        <div className={styles.radioLine}>
+                            <input
+                                type="radio"
+                                name="deployment-type"
+                                value="manifests"
+                                checked={state.selectedDeploymentSpecType === "manifests"}
+                                onChange={handleDeploymentSpecTypeChange}
+                            />
+
+                            <label className={styles.radioLabel}>Manifests</label>
+                        </div>
+                        <div className={styles.radioLine}>
+                            <input
+                                type="radio"
+                                name="deployment-type"
+                                value="helm"
+                                checked={state.selectedDeploymentSpecType === "helm"}
+                                onChange={handleDeploymentSpecTypeChange}
+                            />
+                            <label className={styles.radioLabel}>Helm</label>
+                        </div>
+                    </div>
 
                     {state.selectedDeploymentSpecType === "manifests" && (
                         <>
@@ -702,18 +711,18 @@ export function DraftWorkflow(initialState: InitialState) {
                                 Manifest file paths *
                             </label>
                             <div className={styles.control}>
-                                <VSCodeButton appearance="icon" onClick={handleChooseManifestPathsClick}>
+                                <button className="choose-location-button" onClick={handleChooseManifestPathsClick}>
                                     <span className={styles.iconButton}>
                                         <FontAwesomeIcon icon={faFolder} />
                                         &nbsp;Choose manifest file paths
                                     </span>
-                                </VSCodeButton>
+                                </button>
                             </div>
                             {isValid(state.manifestsParamsState.selectedManifestPaths) && (
                                 <ul className={`${styles.existingFileList} ${styles.control}`} id="manifest-paths">
                                     {state.manifestsParamsState.selectedManifestPaths.value.map((path, i) => (
                                         <li key={i} className={styles.removable}>
-                                            <VSCodeLink
+                                            <a
                                                 href="#"
                                                 onClick={(e) => {
                                                     e.preventDefault();
@@ -721,17 +730,15 @@ export function DraftWorkflow(initialState: InitialState) {
                                                 }}
                                             >
                                                 {path}
-                                            </VSCodeLink>
-                                            <VSCodeButton
-                                                appearance="icon"
+                                            </a>
+                                            <button
+                                                className="icon-button"
                                                 onClick={() => handleDeleteManifestPathClick(path)}
                                                 aria-label="Remove"
                                                 title="Remove"
                                             >
-                                                <span className={styles.iconButton}>
-                                                    <FontAwesomeIcon icon={faTrash} />
-                                                </span>
-                                            </VSCodeButton>
+                                                <FontAwesomeIcon className={styles.linkColor} icon={faTrash} />
+                                            </button>
                                         </li>
                                     ))}
                                 </ul>
@@ -750,7 +757,8 @@ export function DraftWorkflow(initialState: InitialState) {
                             <label htmlFor="chart-path-input" className={styles.label}>
                                 Chart path *
                             </label>
-                            <VSCodeTextField
+                            <input
+                                type="text"
                                 id="chart-path-input"
                                 value={
                                     isValid(state.helmParamsState.selectedChartPath)
@@ -761,12 +769,12 @@ export function DraftWorkflow(initialState: InitialState) {
                                 className={styles.control}
                             />
                             <div className={styles.controlSupplement}>
-                                <VSCodeButton appearance="icon" onClick={handleChooseHelmChartFolderClick}>
+                                <button className="choose-location-button" onClick={handleChooseHelmChartFolderClick}>
                                     <span className={styles.iconButton}>
                                         <FontAwesomeIcon icon={faFolder} />
                                         &nbsp;Choose Helm chart folder
                                     </span>
-                                </VSCodeButton>
+                                </button>
                             </div>
                             {hasMessage(state.helmParamsState.selectedChartPath) && (
                                 <span className={styles.validationMessage}>
@@ -778,7 +786,8 @@ export function DraftWorkflow(initialState: InitialState) {
                             <label htmlFor="values-path-input" className={styles.label}>
                                 Values.yaml path *
                             </label>
-                            <VSCodeTextField
+                            <input
+                                type="text"
                                 id="values-path-input"
                                 value={
                                     isValid(state.helmParamsState.selectedValuesYamlPath)
@@ -789,12 +798,12 @@ export function DraftWorkflow(initialState: InitialState) {
                                 className={styles.control}
                             />
                             <div className={styles.controlSupplement}>
-                                <VSCodeButton appearance="icon" onClick={handleChooseHelmValuesFileClick}>
+                                <button className="choose-location-button" onClick={handleChooseHelmValuesFileClick}>
                                     <span className={styles.iconButton}>
                                         <FontAwesomeIcon icon={faFolder} />
                                         &nbsp;Choose values.yaml file
                                     </span>
-                                </VSCodeButton>
+                                </button>
                             </div>
                             {hasMessage(state.helmParamsState.selectedValuesYamlPath) && (
                                 <span className={styles.validationMessage}>
@@ -807,7 +816,8 @@ export function DraftWorkflow(initialState: InitialState) {
                             {state.helmParamsState.selectedOverrides.map((o, i) => (
                                 <>
                                     <div key={i} className={styles.control} style={{ display: "flex" }}>
-                                        <VSCodeTextField
+                                        <input
+                                            type="text"
                                             id={`override-key-input-${i}`}
                                             className={`${styles.longControl} ${styles.validatable}`}
                                             onBlur={(e) => handleOverrideKeyChange(e, o)}
@@ -815,23 +825,22 @@ export function DraftWorkflow(initialState: InitialState) {
                                             value={orDefault(o.key, "")}
                                         />
                                         =
-                                        <VSCodeTextField
+                                        <input
+                                            type="text"
                                             id={`override-value-input-${i}`}
                                             className={`${styles.longControl} ${styles.validatable}`}
                                             onBlur={(e) => handleOverrideValueChange(e, o)}
                                             onInput={(e) => handleOverrideValueChange(e, o)}
                                             value={orDefault(o.value, "")}
                                         />
-                                        <VSCodeButton
-                                            appearance="icon"
+                                        <button
+                                            className="icon-button"
                                             onClick={() => handleDeleteOverrideClick(o)}
                                             aria-label="Remove"
                                             title="Remove"
                                         >
-                                            <span className={styles.iconButton}>
-                                                <FontAwesomeIcon icon={faTrash} />
-                                            </span>
-                                        </VSCodeButton>
+                                            <FontAwesomeIcon className={styles.linkColor} icon={faTrash} />
+                                        </button>
                                     </div>
                                     {hasMessage(o.key) && (
                                         <span className={styles.validationMessage}>
@@ -854,12 +863,12 @@ export function DraftWorkflow(initialState: InitialState) {
                                         : styles.controlSupplement
                                 }
                             >
-                                <VSCodeButton appearance="icon" onClick={handleAddHelmOverrideClick}>
+                                <button className="choose-location-button" onClick={handleAddHelmOverrideClick}>
                                     <span className={styles.iconButton}>
                                         <FontAwesomeIcon icon={faPlus} />
                                         &nbsp;Add override
                                     </span>
-                                </VSCodeButton>
+                                </button>
                             </div>
                         </>
                     )}
@@ -867,15 +876,15 @@ export function DraftWorkflow(initialState: InitialState) {
 
                 <div className={styles.buttonContainer}>
                     {state.status !== "Created" && (
-                        <VSCodeButton type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
+                        <button type="submit" disabled={state.status !== "Editing" || isNothing(validate())}>
                             Create
-                        </VSCodeButton>
+                        </button>
                     )}
 
                     {existingFile && (
-                        <VSCodeButton appearance="secondary" onClick={() => vscode.postOpenFileRequest(existingFile)}>
+                        <button className="secondary-button" onClick={() => vscode.postOpenFileRequest(existingFile)}>
                             Open Workflow File
-                        </VSCodeButton>
+                        </button>
                     )}
                 </div>
 
@@ -890,9 +899,9 @@ export function DraftWorkflow(initialState: InitialState) {
                                 <ul>
                                     <li>
                                         The ACR {isValueSet(state.selectedAcr) ? `(${state.selectedAcr.value})` : ""}{" "}
-                                        <VSCodeLink href="#" onClick={handleLaunchAttachAcrToClusterClick}>
+                                        <a href="#" onClick={handleLaunchAttachAcrToClusterClick}>
                                             is attached
-                                        </VSCodeLink>{" "}
+                                        </a>{" "}
                                         to the cluster{" "}
                                         {isValueSet(state.selectedCluster) ? `(${state.selectedCluster.value})` : ""}.
                                         You can follow for guidance.
@@ -902,9 +911,9 @@ export function DraftWorkflow(initialState: InitialState) {
                                         {isValueSet(state.selectedGitHubRepo)
                                             ? `(${state.selectedGitHubRepo.value.gitHubRepoOwner}/${state.selectedGitHubRepo.value.gitHubRepoName})`
                                             : ""}{" "}
-                                        <VSCodeLink href="https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure">
+                                        <a href="https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure">
                                             is configured
-                                        </VSCodeLink>{" "}
+                                        </a>{" "}
                                         to access the ACR and cluster.
                                     </li>
                                 </ul>

--- a/webview-ui/src/components/InlineAction.tsx
+++ b/webview-ui/src/components/InlineAction.tsx
@@ -1,7 +1,6 @@
 import { IconDefinition, faCheckCircle, faClock } from "@fortawesome/free-solid-svg-icons";
 import styles from "./InlineAction.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 
 export function makeFixAction(
     icon: IconDefinition,
@@ -60,9 +59,9 @@ export function InlineAction(props: InlineActionProps) {
             </div>
             <div className={styles.actionButtons}>
                 {props.actions.map((action, i) => (
-                    <VSCodeButton
+                    <button
                         key={i}
-                        appearance={action.isPrimary ? "primary" : "secondary"}
+                        className={action.isPrimary ? "" : "secondary-button"}
                         onClick={action.action}
                         disabled={!action.canPerformAction}
                     >
@@ -70,7 +69,7 @@ export function InlineAction(props: InlineActionProps) {
                             <FontAwesomeIcon icon={action.icon} />
                         </span>{" "}
                         {action.name}
-                    </VSCodeButton>
+                    </button>
                 ))}
             </div>
         </div>

--- a/webview-ui/src/components/TextWithDropdown.module.css
+++ b/webview-ui/src/components/TextWithDropdown.module.css
@@ -1,8 +1,3 @@
-.selectedValue {
-    display: inline; /* Prevents a small gap between text input and listbox options */
-    width: 100%;
-}
-
 .indicator {
     cursor: pointer;
     margin-right: -2px;
@@ -41,4 +36,26 @@
 
 .listboxItem.selected {
     background: var(--vscode-list-activeSelectionBackground);
+}
+
+.inputField {
+    position: relative;
+    width: 100%;
+}
+
+.selectedValue {
+    width: 100%;
+    padding-right: 1.8rem !important;
+    box-sizing: border-box;
+}
+.selectedValue:hover {
+    cursor: pointer;
+}
+
+.dropDownButton {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
 }

--- a/webview-ui/src/components/TextWithDropdown.tsx
+++ b/webview-ui/src/components/TextWithDropdown.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, HTMLAttributes, useEffect, useRef, useState } from "react";
 import styles from "./TextWithDropdown.module.css";
-import { VSCodeProgressRing, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { Lazy, asLazy, isLoaded, isLoading, isNotLoaded, orDefault } from "../utilities/lazy";
 
 type AvailableHtmlAttributes = Pick<HTMLAttributes<HTMLElement>, "className" | "id">;
@@ -59,7 +59,9 @@ function TextOnly(props: TextOnlyProps) {
         props.onSelect(newText, true);
     }
 
-    return <VSCodeTextField className={props.className} onInput={handleTextChange} value={props.selectedItem || ""} />;
+    return (
+        <input type="text" className={props.className} onInput={handleTextChange} value={props.selectedItem || ""} />
+    );
 }
 
 type NonLazyTextWithDropdownProps = Omit<TextWithDropdownProps, "items"> & { items: string[] };
@@ -97,13 +99,6 @@ function NonLazyTextWithDropdown(props: NonLazyTextWithDropdownProps) {
 
     function handleTextFieldClick() {
         // For consistency with the VS Code dropdown, we toggle the dropdown when the text field is clicked.
-        setIsExpanded(!isExpanded);
-    }
-
-    function handleDropDownButtonClick(e: React.MouseEvent) {
-        // Don't propagate because the containing element (the text field) has its own click handler
-        // which will itself toggle the expanded state.
-        e.stopPropagation();
         setIsExpanded(!isExpanded);
     }
 
@@ -204,32 +199,29 @@ function NonLazyTextWithDropdown(props: NonLazyTextWithDropdownProps) {
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
         >
-            <VSCodeTextField
-                className={styles.selectedValue}
-                onInput={handleTextChange}
-                value={inputText}
-                onClick={handleTextFieldClick}
-            >
-                <span slot="end" className={styles.indicator} onClick={handleDropDownButtonClick} tabIndex={-1}>
-                    {/* 
-                    See: 
-                    https://github.com/microsoft/vscode-webview-ui-toolkit/blob/a1f078e963969ad3f6d5932f96874f1a41cda919/src/dropdown/index.ts#L43-L57
-                    */}
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="currentColor"
-                    >
-                        <path
-                            fillRule="evenodd"
-                            clipRule="evenodd"
-                            d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"
-                        ></path>
-                    </svg>
-                </span>
-            </VSCodeTextField>
+            <div className={styles.inputField}>
+                <input
+                    type="text"
+                    className={styles.selectedValue}
+                    onInput={handleTextChange}
+                    value={inputText}
+                    onClick={handleTextFieldClick}
+                ></input>
+                <svg
+                    className={styles.dropDownButton}
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="currentColor"
+                >
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"
+                    ></path>
+                </svg>
+            </div>
 
             <ol
                 className={`${styles.listbox} ${displayListbox ? "" : styles.hidden}`}

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -137,6 +137,11 @@ input[type="text"]:read-only {
     cursor: not-allowed;
 }
 
+input[type="text"]:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+}
+
 input[type="checkbox"] {
     width: 18.25px;
     height: 18.25px;
@@ -144,22 +149,49 @@ input[type="checkbox"] {
 }
 
 input[type="radio"] {
-    box-sizing: border-box;
-    width: 16px;
-    height: 16px;
-    padding: 0;
-    margin: 0;
-    border: 2px solid var(--radio-border-color);
+    -webkit-appearance: none;
+    appearance: none;
+    width: 17px;
+    height: 17px;
+    background-color: var(--vscode-checkbox-background, none);
+    border: 1px solid var(--vscode-checkbox-border, --radio-border-color);
     border-radius: 50%;
-    background-color: none;
+    cursor: pointer;
     outline: none;
+    color: var(--vscode-checkbox-foreground, white);
+    margin: 0px;
+    padding: 0px;
     position: relative;
     top: 0.18rem;
-    color: white;
 }
 
-input[type="radio"] {
-    cursor: pointer;
+input[type="radio"]:checked::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 8px;
+    height: 8px;
+    background-color: var(--vscode-checkbox-foreground, white);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+}
+
+input[type="radio"]:focus-visible {
+    border: 1px solid var(--vscode-focusBorder, #007acc);
+}
+
+input[type="radio"]:active {
+    border: 1px solid var(--vscode-focusBorder, #007acc);
+}
+
+input[type="radio"]:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+}
+
+fieldset:disabled label {
+    opacity: 0.4;
 }
 
 select {

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -49,7 +49,7 @@ button:hover {
     cursor: pointer;
 }
 
-button:focus {
+button:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 2px;
 }
@@ -74,14 +74,40 @@ button:disabled {
     cursor: pointer;
 }
 
+.secondary-button:disabled {
+    background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
 .secondary-button:hover:disabled {
     opacity: 0.4;
     cursor: not-allowed;
-    background-color: var(--vscode-button-hoverBackground);
+    background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
 .secondary-button code {
     color: var(--vscode-textPreformat-foreground);
+}
+
+.icon-button,
+.choose-location-button {
+    color: inherit;
+    background: none;
+    padding: 0rem 0.3rem 0rem 0.3rem;
+    border-radius: 5px;
+}
+.icon-button:hover,
+.choose-location-button:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.choose-location-button {
+    margin-top: 0.1rem;
+    padding: 0.15rem 0.3rem 0.15rem 0.1rem;
+}
+
+.icon-button:disabled,
+.choose-location-button:disabled {
+    background: none;
 }
 
 blockquote {
@@ -95,22 +121,64 @@ hr {
     margin: 4px 0 4px 0;
 }
 
-input,
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
     height: calc(var(--input-height) * 1px);
     color: var(--input-foreground);
     background-color: var(--input-background);
-    border: 1px solid var(--input-border);
+    border: 1px solid var(--vscode-dropdown-border);
     padding: 0 9px;
     box-sizing: border-box;
     border-radius: 2px;
     font-family: inherit;
 }
 
-option:hover {
-    color: var(--vscode-list-focusForeground);
+input[type="text"]:read-only {
+    cursor: not-allowed;
+}
+
+input[type="checkbox"] {
+    width: 18.25px;
+    height: 18.25px;
     cursor: pointer;
-    background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+input[type="radio"] {
+    box-sizing: border-box;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    margin: 0;
+    border: 2px solid var(--radio-border-color);
+    border-radius: 50%;
+    background-color: none;
+    outline: none;
+    position: relative;
+    top: 0.18rem;
+    color: white;
+}
+
+input[type="radio"] {
+    cursor: pointer;
+}
+
+select {
+    height: calc(var(--input-height) * 1px);
+    color: var(--input-foreground);
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    padding: 0px 0px 0px 4px;
+    box-sizing: border-box;
+    font-family: inherit;
+    border-radius: 2px;
+}
+
+select:hover {
+    cursor: pointer;
+}
+
+option {
+    font-size: var(--vscode-font-size);
 }
 
 option:focus {

--- a/webview-ui/src/manualTest/components/FilePicker.module.css
+++ b/webview-ui/src/manualTest/components/FilePicker.module.css
@@ -57,3 +57,12 @@ ul.nodeList > li > .item:hover {
     flex-direction: row;
     column-gap: 0.5rem;
 }
+
+.title {
+    margin: 0rem 0 0.5rem 0;
+}
+
+.itemSpan {
+    position: relative;
+    top: -0.1rem;
+}

--- a/webview-ui/src/manualTest/components/FilePicker.tsx
+++ b/webview-ui/src/manualTest/components/FilePicker.tsx
@@ -1,6 +1,5 @@
 import { FormEvent, useState } from "react";
 import { Dialog } from "../../components/Dialog";
-import { VSCodeButton, VSCodeCheckbox, VSCodeDivider, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import styles from "./FilePicker.module.css";
@@ -113,10 +112,10 @@ export function FilePicker(props: FilePickerProps) {
 
     return (
         <Dialog isShown={props.shown} onCancel={() => props.closeRequested(null)}>
-            <h2>{props.options.title}</h2>
+            <h2 className={styles.title}>{props.options.title}</h2>
 
             <form onSubmit={handleSubmit}>
-                <VSCodeDivider />
+                <hr style={{ marginBottom: "0.5rem" }} />
                 <FileSystemNodes
                     items={[props.rootDir]}
                     filters={props.options.filters || {}}
@@ -131,7 +130,8 @@ export function FilePicker(props: FilePickerProps) {
                         {isDirectory ? "Directory:" : "File:"}
                     </label>
                     {(!canSelectMany || selectedItems.length <= 1) && (
-                        <VSCodeTextField
+                        <input
+                            type="text"
                             id="filename-input"
                             className={styles.control}
                             value={selectedItems.length === 1 ? selectedItems[0].name : ""}
@@ -142,12 +142,12 @@ export function FilePicker(props: FilePickerProps) {
                 </div>
 
                 <div className={styles.buttonContainer}>
-                    <VSCodeButton type="submit" disabled={isNothing(validate())}>
+                    <button type="submit" disabled={isNothing(validate())}>
                         {props.options.buttonLabel || "Select"}
-                    </VSCodeButton>
-                    <VSCodeButton appearance="secondary" onClick={() => props.closeRequested(null)}>
+                    </button>
+                    <button className="secondary-button" onClick={() => props.closeRequested(null)}>
                         Cancel
-                    </VSCodeButton>
+                    </button>
                 </div>
             </form>
         </Dialog>
@@ -235,12 +235,10 @@ function FileSystemNode(props: FileSystemNodeProps) {
     }
 
     function ignoreClick(e: Event | FormEvent<HTMLElement>) {
-        e.preventDefault();
         e.stopPropagation();
     }
 
     const isSelected = props.selectedItems.includes(props.item);
-    const itemClassNames = [styles.item, isSelected ? styles.selected : ""].filter((n) => !!n).join(" ");
 
     return (
         <>
@@ -253,14 +251,20 @@ function FileSystemNode(props: FileSystemNodeProps) {
                     />
                 )}
                 {props.canSelectMany && !isDirectory(props.item) && (
-                    <VSCodeCheckbox
+                    <input
+                        type="checkbox"
                         checked={isSelected}
                         onClick={ignoreClick}
                         onChange={() => props.handleItemSelectionChange(props.item)}
-                        style={{ margin: "0", paddingRight: "0.5rem" }}
+                        style={{
+                            margin: "0rem 0.5rem 0rem .5rem",
+                            position: "relative",
+                            top: ".125rem",
+                            display: "inline",
+                        }}
                     />
                 )}
-                <span onClick={() => props.handleItemSelectionChange(props.item)} className={itemClassNames}>
+                <span onClick={() => props.handleItemSelectionChange(props.item)} className={styles.itemSpan}>
                     {props.item.name}
                 </span>
                 {expanded && isDirectory(props.item) && (


### PR DESCRIPTION
This PR specifically removes elements from the AttachAcrToCluster & DraftDeployment/Dockerfile/Workflow commands.

**.vsix for testing:** [vscode-aks-tools-1.6.0-dep3-2.vsix.zip](https://github.com/user-attachments/files/19069996/vscode-aks-tools-1.6.0-dep3-2.vsix.zip)


This is broken up as part of incremental PR's to make review & testing smoother.

For future reference:
- .secondary-button replaces VSCodeButton's appearance="secondary"
- .icon-button replaces VSCodeButton's appearance="icon"
- input[type="text"] replaces VSCodeTextInput
- input[type="checkbox"] replaces VSCodeCheckbox
- input[type="radio"] replaces VSCodeRadio
- Default "< hr >" element now has identical styling to VSCodeDivider
-  Default "< a >" element also has identical styling to VSCodeLink