### PR TITLE
Fix: Deploy button not appearing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.34.0",
+                    "default": "v0.36.1",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },

--- a/webview-ui/src/InspektorGadget/Overview.tsx
+++ b/webview-ui/src/InspektorGadget/Overview.tsx
@@ -2,6 +2,7 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEraser, faRocket } from "@fortawesome/free-solid-svg-icons";
 import styles from "./InspektorGadget.module.css";
+import semver from "semver";
 import { GadgetVersion } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
 import { EventHandlers } from "../utilities/state";
 import { EventDef, vscode } from "./helpers/state";
@@ -23,6 +24,12 @@ export function Overview(props: OverviewProps) {
         vscode.postUndeployRequest();
     }
 
+    function isVersionStringOrNull(ver: string | null): boolean {
+        if (ver === null || !ver.startsWith("v")) return false;
+        const version = ver.substring(1);
+        return semver.valid(version) !== null;
+    }
+
     return (
         <>
             {props.status && <p>{props.status}</p>}
@@ -41,12 +48,14 @@ export function Overview(props: OverviewProps) {
                     </VSCodeButton>
                 </>
             )}
-            {props.version && !props.version.server && (
-                <VSCodeButton onClick={handleDeploy}>
-                    <FontAwesomeIcon icon={faRocket} />
-                    &nbsp;Deploy
-                </VSCodeButton>
-            )}
+            <br />
+            {props.version &&
+                (isVersionStringOrNull(props.version.client) || isVersionStringOrNull(props.version.server)) && (
+                    <VSCodeButton onClick={handleDeploy}>
+                        <FontAwesomeIcon icon={faRocket} />
+                        &nbsp;Deploy
+                    </VSCodeButton>
+                )}
         </>
     );
 }


### PR DESCRIPTION
Hiya, following fix is for a bug where `Deploy` button does not appear at-all for the first time and one way to enable that is via manual `kubectl` page deploy. 

* This PR also updates the binary version for inspector gadget tool.

The issue was that for the `server version` if there is no version available the string returns is `not available`

<img width="878" alt="Screenshot 2025-02-28 at 9 20 03 PM" src="https://github.com/user-attachments/assets/5423ee2d-4b4b-4bfb-82b2-100ad01f3cfa" />

**Fix**

This PR now adds the `semver` version check, this is better than regex IMHO because it does strict parsing, battle testes and no need to craft regex.

Thank heaps and gentle fyi to ❤️  @tejhan, @ReinierCC , @bosesuneha and @davidgamero + @qpetraroia

**VSIX Package:**

[vscode-aks-tools-1.6.0-IG-Deploy-fix.vsix.zip](https://github.com/user-attachments/files/19032211/vscode-aks-tools-1.6.0-IG-Deploy-fix.vsix.zip)

