### PR TITLE
packages: Update Inspektor Gadget to v0.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.36.1",
+                    "default": "v0.38.0",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },


### PR DESCRIPTION
The newest version of Inspektor Gadget was released today: https://github.com/inspektor-gadget/inspektor-gadget/releases/tag/v0.38.0

This PR updates the `kubectl-gadget` binary to be pulled from the latest release `v0.38.0`