### PR TITLE
TCP Dump Bug Fix

### DIFF
--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -419,6 +419,14 @@ spec:
         });
 
         if (!localCaptureUri) {
+            //  Reset download state with error message if no file path was selected
+            webview.postDownloadCaptureFileResponse({
+                node,
+                captureName,
+                localCapturePath: "",
+                succeeded: false,
+                errorMessage: `Failed to download capture '${captureName}'. No file path was selected, please try again.`,
+            });
             return;
         }
 


### PR DESCRIPTION
Slight bug observed where if a user escapes the file selection menu after clicking the button to download a TCP dump capture, the button stays stuck in the disabled downloading state.
![image](https://github.com/user-attachments/assets/690b5c87-7548-4f1b-881b-b9ed8e53e735)
This PR adds an error response to correct for that.

(To reproduce, select Troubleshoot Network Health > Collect TCP Dumps, select a node, start & stop a capture, then click the download button that appears next to completed capture item)

.vsix: [vscode-aks-tools-1.6.1-tcpfix.vsix.zip](https://github.com/user-attachments/files/19071081/vscode-aks-tools-1.6.1-tcpfix.vsix.zip)
