### PR TITLE
Automatically add newly created clusters to user's selected clusters

### DIFF
--- a/src/commands/aksCreateCluster/aksCreateCluster.ts
+++ b/src/commands/aksCreateCluster/aksCreateCluster.ts
@@ -74,6 +74,7 @@ export default async function aksCreateCluster(_context: IActionContext, target:
         subscriptionName,
         () => vscode.commands.executeCommand("aks.refreshSubscription", target),
         commandId,
+        target,
     );
 
     panel.show(dataProvider);

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -1,6 +1,6 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { ClusterQuickPickItem, getAksClusterSubscriptionNode } from "../utils/clusters";
-import { failed } from "../utils/errorable";
+import { failed, Errorable } from "../utils/errorable";
 import * as vscode from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { getExtension } from "../utils/host";
@@ -10,46 +10,22 @@ import { AksClusterAndFleet, getFilteredClusters, setFilteredClusters } from "./
 import { clusterResourceType, getClusterAndFleetResourcesFromGraphAPI } from "./azureResources";
 
 export default async function aksClusterFilter(_context: IActionContext, target: unknown): Promise<void> {
-    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
-
-    const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
-    if (failed(subscriptionNode)) {
-        vscode.window.showErrorMessage(subscriptionNode.error);
-        return;
-    }
-
     const extension = getExtension();
     if (failed(extension)) {
         vscode.window.showErrorMessage(extension.error);
         return;
     }
 
-    const sessionProvider = await getReadySessionProvider();
-    if (failed(sessionProvider)) {
-        vscode.window.showErrorMessage(sessionProvider.error);
+    // all other usual pre-checks are in this function
+    const filteredClusters = await getUniqueClusters();
+
+    const clusterList = await getClusterList(target);
+    if (failed(clusterList)) {
+        vscode.window.showErrorMessage(clusterList.error);
         return;
     }
 
-    let clusterList: AksClusterAndFleet[] = [];
-
-    await longRunning(`Getting AKS Cluster list for ${subscriptionNode.result.name}`, async () => {
-        const aksClusters = await getClusterAndFleetResourcesFromGraphAPI(
-            sessionProvider.result,
-            subscriptionNode.result.subscriptionId,
-        );
-        if (failed(aksClusters)) {
-            vscode.window.showErrorMessage(aksClusters.error);
-            return;
-        }
-        clusterList = aksClusters.result.filter(
-            // only keep clusters for the cluster filter (remove fleets from the list)
-            (r) => r.type.toLowerCase() === clusterResourceType.toLowerCase(),
-        );
-    });
-
-    const filteredClusters = await getUniqueClusters();
-
-    const quickPickItems: ClusterQuickPickItem[] = clusterList.map((cluster: AksClusterAndFleet) => {
+    const quickPickItems: ClusterQuickPickItem[] = clusterList.result.map((cluster: AksClusterAndFleet) => {
         return {
             label: cluster.name,
             description: cluster.name,
@@ -76,7 +52,58 @@ export default async function aksClusterFilter(_context: IActionContext, target:
           ]
         : [];
 
-    await setFilteredClusters(newFilteredClusters, clusterList);
+    await setFilteredClusters(newFilteredClusters, clusterList.result);
+}
+
+export async function addItemToClusterFilter(target: unknown, clusterName: string, subscriptionId: string) {
+    const clusterList = await getClusterList(target);
+    if (failed(clusterList)) {
+        vscode.window.showErrorMessage(clusterList.error);
+        return;
+    } else {
+        const filteredClusters = await getUniqueClusters();
+        filteredClusters.push({ clusterName, subscriptionId });
+        await setFilteredClusters(filteredClusters, clusterList.result);
+    }
+}
+
+async function getClusterList(target: unknown): Promise<Errorable<AksClusterAndFleet[]>> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
+    if (failed(subscriptionNode)) {
+        return { succeeded: false, error: subscriptionNode.error };
+    }
+
+    const sessionProvider = await getReadySessionProvider();
+    if (failed(sessionProvider)) {
+        return { succeeded: false, error: sessionProvider.error };
+    }
+
+    // Long running that captures errors that necessitate a return out of the function
+    const clusterListResult = await longRunning(
+        `Getting AKS Cluster list for ${subscriptionNode.result.name}`,
+        async (): Promise<Errorable<AksClusterAndFleet[]>> => {
+            let clusterList: AksClusterAndFleet[] = [];
+            const aksClusters = await getClusterAndFleetResourcesFromGraphAPI(
+                sessionProvider.result,
+                subscriptionNode.result.subscriptionId,
+            );
+            if (failed(aksClusters)) {
+                return { succeeded: false, error: aksClusters.error };
+            }
+            clusterList = aksClusters.result.filter(
+                // only keep clusters for the cluster filter (remove fleets from the list)
+                (r) => r.type.toLowerCase() === clusterResourceType.toLowerCase(),
+            );
+            return { succeeded: true, result: clusterList };
+        },
+    );
+
+    if (failed(clusterListResult)) {
+        return { succeeded: false, error: clusterListResult.error };
+    }
+    return { succeeded: true, result: clusterListResult.result };
 }
 
 async function getUniqueClusters() {


### PR DESCRIPTION
This PR addresses a case where if a user has filters enabled, clusters that  they create via the extension wouldn't appear in the tree view.

- The behavior has been changed so that once a cluster has been successfully created, it is automatically added to the list of selected clusters for the user so that it appears in the tree view.

Some code has been extracted into a couple helper functions to reuse some behavior in different scenarios.

(Note: Unexpected fleet behavior might be observed incidentally but this PR doesn't intersect with that functionality)