### PR TITLE
Upgrade Cluster Kubernetes Version

### DIFF
--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -442,6 +442,22 @@ export async function getKubernetesVersionInfo(
     }
 }
 
+export async function getClusterUpgradeProfile(
+    containerClient: azcs.ContainerServiceClient,
+    resourceGroup: string,
+    clusterName: string,
+): Promise<Errorable<azcs.ManagedClusterUpgradeProfile>> {
+    try {
+        const upgradeProfile = await containerClient.managedClusters.getUpgradeProfile(resourceGroup, clusterName);
+        return { succeeded: true, result: upgradeProfile };
+    } catch (e) {
+        return {
+            succeeded: false,
+            error: `Failed to retrieve upgrade profile for cluster ${clusterName}: ${getErrorMessage(e)}`,
+        };
+    }
+}
+
 export async function getWindowsNodePoolKubernetesVersions(
     containerClient: azcs.ContainerServiceClient,
     resourceGroupName: string,

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -447,6 +447,14 @@ export async function getClusterUpgradeProfile(
     resourceGroup: string,
     clusterName: string,
 ): Promise<Errorable<azcs.ManagedClusterUpgradeProfile>> {
+    if (!resourceGroup || resourceGroup.trim() === "") {
+        return { succeeded: false, error: "Resource group name cannot be empty." };
+    }
+
+    if (!clusterName || clusterName.trim() === "") {
+        return { succeeded: false, error: "Cluster name cannot be empty." };
+    }
+
     try {
         const upgradeProfile = await containerClient.managedClusters.getUpgradeProfile(resourceGroup, clusterName);
         return { succeeded: true, result: upgradeProfile };

--- a/src/panels/ClusterPropertiesPanel.ts
+++ b/src/panels/ClusterPropertiesPanel.ts
@@ -16,8 +16,9 @@ import {
     KubernetesVersionListResult,
     ManagedCluster,
     ManagedClusterAgentPoolProfile,
+    ManagedClusterUpgradeProfile,
 } from "@azure/arm-containerservice";
-import { getKubernetesVersionInfo, getManagedCluster } from "../commands/utils/clusters";
+import { getKubernetesVersionInfo, getManagedCluster, getClusterUpgradeProfile } from "../commands/utils/clusters";
 import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { getAksClient } from "../commands/utils/arm";
 import { ReadyAzureSessionProvider } from "../auth/types";
@@ -27,6 +28,7 @@ export class ClusterPropertiesPanel extends BasePanel<"clusterProperties"> {
         super(extensionUri, "clusterProperties", {
             getPropertiesResponse: null,
             errorNotification: null,
+            upgradeClusterVersionResponse: null,
         });
     }
 }
@@ -61,6 +63,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
             abortClusterOperation: true,
             reconcileClusterRequest: true,
             refreshRequest: true,
+            upgradeClusterVersionRequest: true,
         };
     }
 
@@ -74,6 +77,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
             reconcileClusterRequest: () => this.handleReconcileClusterOperation(webview),
             // refreshRequest is just for telemetry, so it will use the same getPropertiesRequest handler.
             refreshRequest: () => this.handleGetPropertiesRequest(webview),
+            upgradeClusterVersionRequest: (version: string) => this.handleUpgradeClusterVersion(webview, version),
         };
     }
 
@@ -213,6 +217,61 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
         await this.readAndPostClusterProperties(webview);
     }
 
+    private async handleUpgradeClusterVersion(webview: MessageSink<ToWebViewMsgDef>, version: string) {
+        try {
+            const cluster = await getManagedCluster(
+                this.sessionProvider,
+                this.subscriptionId,
+                this.resourceGroup,
+                this.clusterName,
+            );
+
+            if (failed(cluster)) {
+                webview.postErrorNotification(cluster.error);
+                return;
+            }
+
+            // Create update parameters, preserving all other properties
+            const updateParams: ManagedCluster = {
+                ...cluster.result,
+                kubernetesVersion: version,
+            };
+
+            const poller = await this.client.managedClusters.beginCreateOrUpdate(
+                this.resourceGroup,
+                this.clusterName,
+                updateParams,
+            );
+
+            poller.onProgress((state) => {
+                if (state.status === "canceled") {
+                    webview.postErrorNotification(`Upgrade operation on ${this.clusterName} was cancelled.`);
+                    webview.postUpgradeClusterVersionResponse({ success: false });
+                    return;
+                } else if (state.status === "failed") {
+                    const errorMessage = state.error ? getErrorMessage(state.error) : "Unknown error";
+                    webview.postErrorNotification(errorMessage);
+                    webview.postUpgradeClusterVersionResponse({ success: false });
+                    return;
+                }
+            });
+
+            // Update the cluster properties now that the operation has started
+            await this.readAndPostClusterProperties(webview);
+
+            // Wait until operation completes
+            await poller.pollUntilDone();
+            webview.postUpgradeClusterVersionResponse({ success: true });
+
+            // Refresh the cluster properties after operation completes
+            await this.readAndPostClusterProperties(webview);
+        } catch (ex) {
+            const errorMessage = getErrorMessage(ex);
+            webview.postErrorNotification(errorMessage);
+            webview.postUpgradeClusterVersionResponse({ success: false });
+        }
+    }
+
     private async readAndPostClusterProperties(webview: MessageSink<ToWebViewMsgDef>) {
         const cluster = await getManagedCluster(
             this.sessionProvider,
@@ -231,11 +290,23 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
             return;
         }
 
-        webview.postGetPropertiesResponse(asClusterInfo(cluster.result, kubernetesVersion.result));
+        const upgradeProfile = await getClusterUpgradeProfile(this.client, this.resourceGroup, this.clusterName);
+        if (failed(upgradeProfile)) {
+            webview.postErrorNotification(upgradeProfile.error);
+            return;
+        }
+
+        webview.postGetPropertiesResponse(
+            asClusterInfo(cluster.result, kubernetesVersion.result, upgradeProfile.result),
+        );
     }
 }
 
-function asClusterInfo(cluster: ManagedCluster, kubernetesVersionList: KubernetesVersionListResult): ClusterInfo {
+function asClusterInfo(
+    cluster: ManagedCluster,
+    kubernetesVersionList: KubernetesVersionListResult,
+    upgradeProfile: ManagedClusterUpgradeProfile,
+): ClusterInfo {
     return {
         provisioningState: cluster.provisioningState!,
         fqdn: cluster.fqdn!,
@@ -243,6 +314,9 @@ function asClusterInfo(cluster: ManagedCluster, kubernetesVersionList: Kubernete
         powerStateCode: cluster.powerState!.code!,
         agentPoolProfiles: (cluster.agentPoolProfiles || []).map(asPoolProfileInfo),
         supportedVersions: (kubernetesVersionList.values || []).map(asKubernetesVersionInfo),
+        availableUpgradeVersions: (upgradeProfile.controlPlaneProfile?.upgrades || [])
+            .map((upgrade) => upgrade.kubernetesVersion!)
+            .filter((version): version is string => version !== undefined),
     };
 }
 

--- a/src/webview-contract/webviewDefinitions/clusterProperties.ts
+++ b/src/webview-contract/webviewDefinitions/clusterProperties.ts
@@ -40,13 +40,13 @@ export type ToVsCodeMsgDef = {
     abortClusterOperation: void;
     reconcileClusterRequest: void;
     refreshRequest: void;
-    getUpgradeClusterVersionRequest: string;
+    upgradeClusterVersionRequest: string;
 };
 
 export type ToWebViewMsgDef = {
     getPropertiesResponse: ClusterInfo;
     errorNotification: string;
-    upgradeClusterVersionResponse: string[];
+    upgradeClusterVersionResponse: boolean;
 };
 
 export type ClusterPropertiesDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/src/webview-contract/webviewDefinitions/clusterProperties.ts
+++ b/src/webview-contract/webviewDefinitions/clusterProperties.ts
@@ -11,6 +11,7 @@ export type ClusterInfo = {
     powerStateCode: string;
     agentPoolProfiles: AgentPoolProfileInfo[];
     supportedVersions: KubernetesVersionInfo[];
+    availableUpgradeVersions: string[];
 };
 
 export type AgentPoolProfileInfo = {
@@ -39,11 +40,13 @@ export type ToVsCodeMsgDef = {
     abortClusterOperation: void;
     reconcileClusterRequest: void;
     refreshRequest: void;
+    getUpgradeClusterVersionRequest: string;
 };
 
 export type ToWebViewMsgDef = {
     getPropertiesResponse: ClusterInfo;
     errorNotification: string;
+    upgradeClusterVersionResponse: string[];
 };
 
 export type ClusterPropertiesDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
@@ -70,7 +70,7 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
     const supportedPatchVersions = props.clusterInfo.supportedVersions.flatMap((v) => v.patchVersions);
     const isSupported = supportedPatchVersions.includes(props.clusterInfo.kubernetesVersion);
 
-    const isUpgrading = props.clusterInfo.provisioningState === "Upgrading";
+    const isUpgrading = props.clusterInfo.provisioningState.toLowerCase() === "upgrading";
 
     return (
         <dl className={styles.propertyList}>

--- a/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
@@ -3,6 +3,7 @@ import { EventHandlers } from "../utilities/state";
 import styles from "./ClusterProperties.module.css";
 import { EventDef, vscode } from "./state";
 import { ClusterDisplayToolTip } from "./ClusterDisplayToolTip";
+import { ClusterUpgrade } from "./ClusterUpgrade";
 
 export interface ClusterDisplayProps {
     clusterInfo: ClusterInfo;
@@ -55,6 +56,12 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
         props.eventHandlers.onSetClusterOperationRequested();
     }
 
+    function handleUpgradeVersion(version: string) {
+        // Update UI state immediately to show upgrading state
+        props.eventHandlers.onUpgradeVersionSelected(version);
+        props.eventHandlers.onSetClusterOperationRequested();
+    }
+
     const startStopState = determineStartStopState(props.clusterInfo);
     const showAbortButton = !unabortableProvisioningStates.includes(props.clusterInfo.provisioningState);
     const showReconcileButton =
@@ -62,6 +69,8 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
 
     const supportedPatchVersions = props.clusterInfo.supportedVersions.flatMap((v) => v.patchVersions);
     const isSupported = supportedPatchVersions.includes(props.clusterInfo.kubernetesVersion);
+
+    const isUpgrading = props.clusterInfo.provisioningState === "Upgrading";
 
     return (
         <dl className={styles.propertyList}>
@@ -142,11 +151,21 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
 
             <dt>FQDN</dt>
             <dd>{props.clusterInfo.fqdn}</dd>
+
             <dt>Kubernetes Version</dt>
             <dd>
-                {props.clusterInfo.kubernetesVersion} {isSupported ? "" : "(Out of support)"}
-                &nbsp;
-                <ClusterDisplayToolTip clusterInfo={props.clusterInfo}></ClusterDisplayToolTip>
+                <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
+                    <span>
+                        {props.clusterInfo.kubernetesVersion} {isSupported ? "" : "(Out of support)"}
+                        {isUpgrading && <span className={styles.upgradeIndicator}>&nbsp;(Upgrading)</span>}
+                    </span>
+                    <ClusterDisplayToolTip clusterInfo={props.clusterInfo} />
+                    <ClusterUpgrade
+                        clusterInfo={props.clusterInfo}
+                        clusterOperationRequested={props.clusterOperationRequested}
+                        onUpgrade={handleUpgradeVersion}
+                    />
+                </div>
             </dd>
         </dl>
     );

--- a/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplay.tsx
@@ -157,7 +157,7 @@ export function ClusterDisplay(props: ClusterDisplayProps) {
                 <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
                     <span>
                         {props.clusterInfo.kubernetesVersion} {isSupported ? "" : "(Out of support)"}
-                        {isUpgrading && <span className={styles.upgradeIndicator}>&nbsp;(Upgrading)</span>}
+                        {isUpgrading && <span className={styles.upgradeIndicator}>(Upgrading)</span>}
                     </span>
                     <ClusterDisplayToolTip clusterInfo={props.clusterInfo} />
                     <ClusterUpgrade

--- a/webview-ui/src/ClusterProperties/ClusterDisplayToolTip.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterDisplayToolTip.tsx
@@ -7,13 +7,16 @@ export interface ClusterDisplayToolTipProps {
 
 export function ClusterDisplayToolTip(props: ClusterDisplayToolTipProps) {
     return (
-        <span className={styles.tooltip}>
-            <span className={styles.infoIndicator}>
+        <span className={styles.tooltip} style={{ display: "inline-block", verticalAlign: "middle", margin: "0 8px" }}>
+            <span
+                className={styles.infoIndicator}
+                style={{ position: "relative", display: "inline-block", height: "auto", width: "auto" }}
+            >
                 <div className="icon">
                     <i className="codicon codicon-info" aria-label="info icon using vscode icons"></i>
                 </div>
             </span>
-            <span className={styles.tooltiptext}>
+            <span className={styles.tooltiptext} style={{ top: "100%", left: "-120px", marginTop: "5px" }}>
                 <table>
                     <caption className={styles.tableHeader}>Current Versions Available</caption>
                     <tr>

--- a/webview-ui/src/ClusterProperties/ClusterProperties.module.css
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.module.css
@@ -27,7 +27,7 @@
 }
 
 .tooltip {
-    position: absolute;
+    position: relative;
     display: inline-block;
 }
 
@@ -109,4 +109,88 @@ th {
     top: 0.06rem;
     left: 0.03rem;
     font-weight: bold;
+}
+
+.kubernetesVersionContainer {
+    display: flex;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.versionLabel {
+    margin-right: 16px;
+    font-weight: 500;
+}
+
+.upgradeVersionDropdown {
+    display: flex;
+    align-items: center;
+}
+
+.upgradeVersionDropdown span {
+    margin-right: 8px;
+}
+
+.upgradeIndicator {
+    color: var(--vscode-statusBarItem-warningForeground, #ff8c00);
+    font-weight: bold;
+    animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+    0% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.6;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+.dialogOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dialogContainer {
+    background-color: var(--vscode-editorWidget-background);
+    border: 1px solid var(--vscode-editorWidget-border);
+    padding: 16px;
+    border-radius: 4px;
+    min-width: 320px;
+    max-width: 480px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.dialogTitle {
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: var(--vscode-editor-foreground);
+}
+
+.dialogContent {
+    margin-bottom: 24px;
+    color: var(--vscode-editor-foreground);
+    line-height: 1.5;
+}
+
+.dialogActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.warningIcon {
+    color: var(--vscode-editorWarning-foreground, #fc0);
+    margin-right: 8px;
 }

--- a/webview-ui/src/ClusterProperties/ClusterProperties.module.css
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.module.css
@@ -132,8 +132,12 @@ th {
 }
 
 .upgradeIndicator {
-    color: var(--vscode-statusBarItem-warningForeground, #ff8c00);
-    font-weight: bold;
+    background-color: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    margin-left: 6px;
     animation: pulse 1.5s infinite;
 }
 

--- a/webview-ui/src/ClusterProperties/ClusterProperties.module.css
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.module.css
@@ -136,7 +136,7 @@ th {
     color: var(--vscode-badge-foreground);
     padding: 2px 6px;
     border-radius: 3px;
-    font-size: 0.85em;
+    font-size: 0.95em;
     margin-left: 6px;
     animation: pulse 1.5s infinite;
 }

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -18,9 +18,6 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
     const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
     const isUpgrading = props.clusterInfo.provisioningState === "Upgrading";
 
-    // Track which version is currently being upgraded
-    const [upgradeVersion, setUpgradeVersion] = useState<string | null>(null);
-
     function handleUpgradeVersionChange(event: Event) {
         const target = event.target as HTMLSelectElement;
         const version = target.value;
@@ -33,9 +30,6 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
 
     function handleConfirmUpgrade() {
         if (selectedVersion) {
-            // Store which version is being upgraded
-            setUpgradeVersion(selectedVersion);
-
             // Set clusterOperationRequested first so UI updates immediately
             props.onUpgrade(selectedVersion);
 
@@ -53,10 +47,7 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
     }
 
     function resetDropdown() {
-        const dropdown = document.querySelector("vscode-dropdown") as HTMLSelectElement | null;
-        if (dropdown) {
-            dropdown.value = "";
-        }
+        setSelectedVersion(null);
     }
 
     // Only render if upgrade versions are available
@@ -82,8 +73,8 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
         </div>
     );
 
-    // Determine which version to display (either the version being upgraded to or none)
-    const displayVersion = isUpgrading || props.clusterOperationRequested ? upgradeVersion : selectedVersion;
+    // Show default (empty) value when upgrading is in progress
+    const displayVersion = isUpgrading || props.clusterOperationRequested ? "" : selectedVersion;
     const readyToUpgrade =
         props.clusterInfo.powerStateCode === "Running" && props.clusterInfo.provisioningState === "Succeeded";
 

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -42,23 +42,25 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
             // Then post the request to the extension
             vscode.postUpgradeClusterVersionRequest(selectedVersion);
             setShowConfirmation(false);
+            resetDropdown();
         }
     }
 
     function handleCancelUpgrade() {
         setShowConfirmation(false);
         setSelectedVersion(null);
-        // Reset the dropdown
-        const dropdown = document.querySelector("vscode-dropdown") as HTMLSelectElement;
+        resetDropdown();
+    }
+
+    function resetDropdown() {
+        const dropdown = document.querySelector("vscode-dropdown") as HTMLSelectElement | null;
         if (dropdown) {
             dropdown.value = "";
         }
     }
 
     // Only render if upgrade versions are available
-    if (!props.clusterInfo.availableUpgradeVersions || props.clusterInfo.availableUpgradeVersions.length === 0) {
-        return null;
-    }
+    if (!props.clusterInfo.availableUpgradeVersions?.length) return null;
 
     const warningMessage = (
         <div>

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { ClusterInfo } from "../../../src/webview-contract/webviewDefinitions/clusterProperties";
+import styles from "./ClusterProperties.module.css";
+import { vscode } from "./state";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { ConfirmationDialog } from "./ConfirmationDialog";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+
+export interface ClusterUpgradeProps {
+    clusterInfo: ClusterInfo;
+    clusterOperationRequested: boolean;
+    onUpgrade: (version: string) => void;
+}
+
+export function ClusterUpgrade(props: ClusterUpgradeProps) {
+    const [showConfirmation, setShowConfirmation] = useState(false);
+    const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+    const isUpgrading = props.clusterInfo.provisioningState === "Upgrading";
+
+    // Track which version is currently being upgraded
+    const [upgradeVersion, setUpgradeVersion] = useState<string | null>(null);
+
+    function handleUpgradeVersionChange(event: Event) {
+        const target = event.target as HTMLSelectElement;
+        const version = target.value;
+
+        if (version && version !== "Select version") {
+            setSelectedVersion(version);
+            setShowConfirmation(true);
+        }
+    }
+
+    function handleConfirmUpgrade() {
+        if (selectedVersion) {
+            // Store which version is being upgraded
+            setUpgradeVersion(selectedVersion);
+
+            // Set clusterOperationRequested first so UI updates immediately
+            props.onUpgrade(selectedVersion);
+
+            // Then post the request to the extension
+            vscode.postUpgradeClusterVersionRequest(selectedVersion);
+            setShowConfirmation(false);
+        }
+    }
+
+    function handleCancelUpgrade() {
+        setShowConfirmation(false);
+        setSelectedVersion(null);
+        // Reset the dropdown
+        const dropdown = document.querySelector("vscode-dropdown") as HTMLSelectElement;
+        if (dropdown) {
+            dropdown.value = "";
+        }
+    }
+
+    // Only render if upgrade versions are available
+    if (!props.clusterInfo.availableUpgradeVersions || props.clusterInfo.availableUpgradeVersions.length === 0) {
+        return null;
+    }
+
+    const warningMessage = (
+        <div>
+            <p>
+                You are about to upgrade your AKS cluster from version{" "}
+                <strong>{props.clusterInfo.kubernetesVersion}</strong> to <strong>{selectedVersion}</strong>.
+            </p>
+            <FontAwesomeIcon icon={faExclamationTriangle} className={styles.warningIcon} />
+            An AKS cluster upgrade triggers a cordon and drain of your nodes. If you have a low compute quota available,
+            the upgrade might fail. For more information, see{" "}
+            <a
+                href="https://learn.microsoft.com/en-us/azure/quotas/regional-quota-requests"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                increase quotas
+            </a>
+            .<p>Are you sure you want to proceed with the upgrade?</p>
+        </div>
+    );
+
+    // Determine which version to display (either the version being upgraded to or none)
+    const displayVersion = isUpgrading || props.clusterOperationRequested ? upgradeVersion : selectedVersion;
+    const readyToUpgrade =
+        props.clusterInfo.powerStateCode === "Running" && props.clusterInfo.provisioningState === "Succeeded";
+
+    return (
+        <>
+            <div className={styles.upgradeVersionDropdown} style={{ marginLeft: "10px" }}>
+                <span>Upgrade:</span>
+                <VSCodeDropdown
+                    onchange={handleUpgradeVersionChange}
+                    disabled={props.clusterOperationRequested || !readyToUpgrade}
+                    style={{ minWidth: "120px", maxWidth: "150px" }}
+                    value={displayVersion || ""}
+                >
+                    <VSCodeOption selected={!displayVersion} value="">
+                        Select version
+                    </VSCodeOption>
+                    {props.clusterInfo.availableUpgradeVersions.map((version: string) => (
+                        <VSCodeOption key={version} value={version} selected={version === displayVersion}>
+                            {version}
+                        </VSCodeOption>
+                    ))}
+                </VSCodeDropdown>
+            </div>
+            <ConfirmationDialog
+                title="Confirm Kubernetes Version Upgrade"
+                message={warningMessage}
+                confirmLabel="Upgrade"
+                cancelLabel="Cancel"
+                isOpen={showConfirmation}
+                onConfirm={handleConfirmUpgrade}
+                onCancel={handleCancelUpgrade}
+            />
+        </>
+    );
+}

--- a/webview-ui/src/ClusterProperties/ConfirmationDialog.tsx
+++ b/webview-ui/src/ClusterProperties/ConfirmationDialog.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import styles from "./ClusterProperties.module.css";
+
+export interface ConfirmationDialogProps {
+    title: string;
+    message: React.ReactNode;
+    confirmLabel: string;
+    cancelLabel: string;
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export function ConfirmationDialog(props: ConfirmationDialogProps) {
+    if (!props.isOpen) {
+        return null;
+    }
+
+    return (
+        <div className={styles.dialogOverlay}>
+            <div className={styles.dialogContainer}>
+                <h3 className={styles.dialogTitle}>{props.title}</h3>
+                <div className={styles.dialogContent}>{props.message}</div>
+                <div className={styles.dialogActions}>
+                    <button className="secondary-button" onClick={props.onCancel}>
+                        {props.cancelLabel}
+                    </button>
+                    <button className="primary-button" onClick={props.onConfirm}>
+                        {props.confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/webview-ui/src/ClusterProperties/state.ts
+++ b/webview-ui/src/ClusterProperties/state.ts
@@ -7,11 +7,13 @@ export type CreateClusterState = InitialState & {
     clusterInfo: Lazy<ClusterInfo>;
     clusterOperationRequested: boolean;
     errorMessage: string | null;
+    selectedUpgradeVersion: string | null;
 };
 
 export type EventDef = {
     setPropertiesLoading: void;
     setClusterOperationRequested: void;
+    upgradeVersionSelected: string;
 };
 
 export const stateUpdater: WebviewStateUpdater<"clusterProperties", EventDef, CreateClusterState> = {
@@ -20,6 +22,7 @@ export const stateUpdater: WebviewStateUpdater<"clusterProperties", EventDef, Cr
         clusterInfo: newNotLoaded(),
         clusterOperationRequested: false,
         errorMessage: null,
+        selectedUpgradeVersion: null,
     }),
     vscodeMessageHandler: {
         getPropertiesResponse: (state, clusterInfo) => ({
@@ -27,11 +30,16 @@ export const stateUpdater: WebviewStateUpdater<"clusterProperties", EventDef, Cr
             clusterInfo: newLoaded(clusterInfo),
             clusterOperationRequested: false,
         }),
+        upgradeClusterVersionResponse: (state) => ({
+            ...state,
+            clusterOperationRequested: false,
+        }),
         errorNotification: (state, err) => ({ ...state, errorMessage: err }),
     },
     eventHandler: {
         setPropertiesLoading: (state) => ({ ...state, clusterInfo: newLoading() }),
         setClusterOperationRequested: (state) => ({ ...state, clusterOperationRequested: true }),
+        upgradeVersionSelected: (state, version) => ({ ...state, selectedUpgradeVersion: version }),
     },
 };
 
@@ -43,4 +51,5 @@ export const vscode = getWebviewMessageContext<"clusterProperties">({
     abortClusterOperation: null,
     reconcileClusterRequest: null,
     refreshRequest: null,
+    upgradeClusterVersionRequest: null,
 });

--- a/webview-ui/src/manualTest/clusterPropertiesTests.tsx
+++ b/webview-ui/src/manualTest/clusterPropertiesTests.tsx
@@ -51,13 +51,13 @@ const testWindows2022Pool: AgentPoolProfileInfo = {
 const supportedVersions: KubernetesVersionInfo[] = [
     {
         version: "1.24",
-        patchVersions: ["1.24.6"],
+        patchVersions: ["1.24.6", "1.24.7"],
         supportPlan: ["KubernetesOfficial"],
         isPreview: false,
     },
     {
         version: "1.25",
-        patchVersions: ["1.25.3"],
+        patchVersions: ["1.25.3", "1.25.4"],
         supportPlan: ["AKSLongTermSupport", "KubernetesOfficial"],
         isPreview: false,
     },
@@ -94,6 +94,7 @@ const runningClusterInfo: ClusterInfo = {
     powerStateCode: "Running",
     agentPoolProfiles: [testSystemPool, testWindows2019Pool, testWindows2022Pool],
     supportedVersions: supportedVersions,
+    availableUpgradeVersions: ["1.24.7", "1.25.3", "1.25.4"],
 };
 
 const abortedClusterInfo: ClusterInfo = {
@@ -124,6 +125,8 @@ export function getClusterPropertiesScenarios() {
             abortClusterOperation: () => handleAbortClusterOperation(withErrors && sometimes()),
             reconcileClusterRequest: () => handleReconcileClusterRequest(withErrors && sometimes()),
             refreshRequest: () => handleGetPropertiesRequest(),
+            upgradeClusterVersionRequest: (version: string) =>
+                handleUpgradeClusterVersionRequest(version, withErrors && sometimes()),
         };
 
         async function handleGetPropertiesRequest() {
@@ -233,6 +236,27 @@ export function getClusterPropertiesScenarios() {
                 p.provisioningState = "Succeeded";
                 p.powerStateCode = "Running";
             });
+            webview.postGetPropertiesResponse(testClusterInfo);
+        }
+
+        async function handleUpgradeClusterVersionRequest(version: string, hasError: boolean) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            if (hasError) {
+                webview.postErrorNotification("Sorry, I wasn't quite able to upgrade the cluster.");
+                return;
+            }
+
+            // Begin upgrade operation
+            testClusterInfo.provisioningState = "Upgrading";
+            webview.postGetPropertiesResponse(testClusterInfo);
+
+            // Simulate time for upgrade
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+
+            // Finish upgrade
+            testClusterInfo.kubernetesVersion = version;
+            testClusterInfo.provisioningState = "Succeeded";
+            webview.postUpgradeClusterVersionResponse(true);
             webview.postGetPropertiesResponse(testClusterInfo);
         }
     }


### PR DESCRIPTION
This PR adds the requested user functionality to easily upgrade an AKS cluster's kubernetes version.

If a cluster is elegible for upgrade, a dropdown next kubernetes version will appear on the 'Cluster Properties' page.
![Screenshot 2025-03-11 at 9 58 47 AM](https://github.com/user-attachments/assets/5dd9f239-854a-45b3-b97f-f66335ab8f8d)

Created two additional frontend components: `ClusterUpgrade.tsx` and `ConfirmationDialog` to handle the upgrade process.

A similar warning message from the upgrade documentation is placed on a confirmation screen displayed to the user before the upgrade process begins:

![Screenshot 2025-03-11 at 10 04 02 AM](https://github.com/user-attachments/assets/f67eb437-1967-46be-b227-385fc632445d)

Upgrading:
![Screenshot 2025-03-17 at 11 11 15 AM](https://github.com/user-attachments/assets/80b19270-3c4f-47da-91b2-f2116c80b379)

I've done testing on what I believe are the possible states the upgrade but please do give the vsix additional testing (Upgrading, aborting, closing page, ...).

 Latest:
[vscode-aks-tools-1.6.1-upgrade-cluster-3.vsix.zip](https://github.com/user-attachments/files/19289781/vscode-aks-tools-1.6.1-upgrade-cluster-3.vsix.zip)


⛹️‍♂️ 