### PR TITLE
Fix for similarly named clusters showing in adjacent subscription nodes

### DIFF
--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -53,7 +53,10 @@ export default async function aksClusterFilter(_context: IActionContext, target:
         return {
             label: cluster.name,
             description: cluster.name,
-            picked: filteredClusters.some((filtered) => filtered.clusterName === cluster.name),
+            picked: filteredClusters.some(
+                (filtered) =>
+                    filtered.clusterName === cluster.name && filtered.subscriptionId === cluster.subscriptionId,
+            ),
             Cluster: {
                 clusterName: cluster.name,
                 subscriptionId: cluster.subscriptionId,

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -144,7 +144,9 @@ export async function setFilteredClusters(filters: ClusterFilter[], allClusters:
     // Check if filters have changed
     const filtersChanged =
         existingFilters.length !== finalFilters.length ||
-        !existingFilters.every(({ clusterName }) => finalFilters.some((f) => f.clusterName === clusterName));
+        !existingFilters.every(({ clusterName, subscriptionId }) =>
+            finalFilters.some((f) => f.clusterName === clusterName && f.subscriptionId === subscriptionId),
+        );
 
     if (filtersChanged) {
         await vscode.workspace

--- a/src/tree/fleetTreeItem.ts
+++ b/src/tree/fleetTreeItem.ts
@@ -66,6 +66,11 @@ class FleetTreeItem extends AzExtParentTreeItem implements FleetTreeNode {
 
     private readonly members: Map<string, DefinedFleetMemberWithGroup> = new Map<string, DefinedFleetMemberWithGroup>();
 
+    // utility func for future use
+    public hasChildren() {
+        return this.members.size > 0;
+    }
+
     public addCluster(members: DefinedFleetMemberWithGroup[]): void {
         members.forEach((m) => {
             this.members.set(m.id, m);

--- a/src/tree/subscriptionTreeItem.ts
+++ b/src/tree/subscriptionTreeItem.ts
@@ -168,8 +168,12 @@ class SubscriptionTreeItem extends AzExtParentTreeItem implements SubscriptionTr
         const clusterTreeItems = new Map<string, AzExtTreeItem>();
         fleetResources.concat(clusterResources).forEach((r) => {
             if (r.type?.toLocaleLowerCase() === fleetResourceType.toLowerCase()) {
+                const children = fleetToMembersMap.get(r.id) || [];
+                // If fleet has no children, it will still show in tree
+                // This means that fleets show even with clusters filters that do not match any of their children
+                // This can be changed in the future if needed, potentially adding fleets as a quickpick option for the filters
                 const fleetTreeItem = createFleetTreeNode(this, this.subscriptionId, r);
-                fleetTreeItem.addCluster(fleetToMembersMap.get(r.id) || []);
+                fleetTreeItem.addCluster(children);
                 fleetTreeNodes.set(r.id, fleetTreeItem);
                 return fleetTreeItem;
             } else if (r.type?.toLocaleLowerCase() === clusterResourceType.toLowerCase()) {
@@ -179,7 +183,9 @@ class SubscriptionTreeItem extends AzExtParentTreeItem implements SubscriptionTr
                 );
 
                 if (isSubIdExistInClusterFilter) {
-                    const matchedCluster = filteredClusters.find((filter) => filter.clusterName === r.name);
+                    const matchedCluster = filteredClusters.find(
+                        (filter) => filter.clusterName === r.name && filter.subscriptionId === this.subscriptionId,
+                    );
                     if (matchedCluster) {
                         const cluster = createClusterTreeNode(this, this.subscriptionId, r);
                         clusterTreeItems.set(r.id, cluster);


### PR DESCRIPTION
There was an issue where clusters who share names in different subscription nodes would always be selected for both subscriptions, despite removing it from the filters. It seems when matching values across subscriptions in the filter logic, we checked for name but didn't verify if the subscriptionID's matched.

(This scenario is most easily observed with fleet hub clusters, since you can very easily have clusters named "hub" across multiple subscriptions you have selected in your configuration.)

- This PR fixes the logic for that, ensuring a selected cluster from 1 sub doesn't populate the others. 
- This fixes issue #1294 

(This scenario is most easily observed with fleet hub clusters, since you can very easily have clusters named "hub" across multiple subscriptions you have selected in your configuration.)

.vsix: [vscode-aks-tools-1.6.1-filter5.vsix.zip](https://github.com/user-attachments/files/19214637/vscode-aks-tools-1.6.1-filter5.vsix.zip)

Note: Default behavior of fleet is to appear even when there are no member clusters, so it can show in the tree upon creation. But for future, maybe a toggle to show fleets or adding fleets to the clusterfilter can be considered, as currently no matter what your filters are, the fleets will always appear. Thoughts?