### PR TITLE
Publish release 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+
+## [1.6.2]
+
+* Feat: Removing components from ASO, Detectors, Kubectl, & Periscope commands (#1261)
+* Feat: Upgrade Cluster Kubernetes Version (#1296)
+* WebviewUI toolkit: deprecation for inspektor, retina, tcpdump (#1259)
+* Quick Refactor: Moving DiagnosticSetting function to common place Cluster.ts. (#1295)
+* [Webview UI toolkit deprecation] AttachAcrToCluster, DraftDeployment/Dockerfile/Workflow Panel component removal (#1260)
+* tcp download fix (#1291)
+* Fix npm warning for build. (#1292)
+* Dependabot updates and bumps.
+
+Thank you so much to @ReinierCC, @bosesuneha @tejhan, @qpetraroia, @gambtho for contributions, testing and reviews.
+
 ## [1.6.1]
 
 * Show Fleet Properties (#1245)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is open for the release of `1.6.2` this pr contains some amazing work like:

* Feat: Removing components from ASO, Detectors, Kubectl, & Periscope commands (#1261)
* Feat: Upgrade Cluster Kubernetes Version (#1296)
* WebviewUI toolkit: deprecation for inspektor, retina, tcpdump (#1259)
* Quick Refactor: Moving DiagnosticSetting function to common place Cluster.ts. (#1295)
* [Webview UI toolkit deprecation] AttachAcrToCluster, DraftDeployment/Dockerfile/Workflow Panel component removal (#1260)
* tcp download fix (#1291)
* Fix npm warning for build. (#1292)
* Dependabot updates and bumps.

Thank you so much to @ReinierCC, @bosesuneha @tejhan, @qpetraroia, @gambtho for contributions, testing and reviews.

VSIX to test:

[vscode-aks-tools-1.6.2-test.vsix.zip](https://github.com/user-attachments/files/19329267/vscode-aks-tools-1.6.2-test.vsix.zip)
