### PR TITLE
[Kaito] Fix for v4 node pool deletion issue

### DIFF
--- a/src/commands/aksKaito/aksKaitoManage.ts
+++ b/src/commands/aksKaito/aksKaitoManage.ts
@@ -108,6 +108,7 @@ export default async function aksKaitoManage(_context: IActionContext, target: u
         kubeConfigFile.filePath,
         models,
         target,
+        sessionProvider.result,
     );
     panel.show(dataProvider, kubeConfigFile);
 }


### PR DESCRIPTION
This PR introduces a fix for issue #1262. 
- When deleting a workspace in v4.4, the associated gpu node pool will also be manually deleted.
- #1262 

(This should be merged in tandem with #1318 once v4.4 is pushed to the add-on as well)
