### PR TITLE
Complete removal of webview-ui-toolkit package & elements

### DIFF
--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -13,7 +13,6 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@vscode/codicons": "^0.0.36",
-        "@vscode/webview-ui-toolkit": "^1.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -1037,47 +1036,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
-    },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.4.tgz",
-      "integrity": "sha512-5I2tSPo6bnOfVAIX7XzX+LhilahwvD7h+yzl3jW0t5IYmMX9Lci9VUVyx5f8hHdb1O9a8Y9Atb7Asw7yFO/u+w==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.22.tgz",
-      "integrity": "sha512-XhlX4m6znh7XW92oPvlKoG9USUn9JtF9rP1qtUoIbkaDaFtUS+H8o1Jn6/oK/rS44LbBLJXrvRkInmSWlDiGFw==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1790,20 +1748,6 @@
       "version": "0.0.36",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
       "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
-    },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -2969,11 +2913,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5728,11 +5667,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-    },
     "node_modules/terser": {
       "version": "5.37.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
@@ -5858,11 +5792,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7087,46 +7016,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
-    },
-    "@microsoft/fast-foundation": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.4.tgz",
-      "integrity": "sha512-5I2tSPo6bnOfVAIX7XzX+LhilahwvD7h+yzl3jW0t5IYmMX9Lci9VUVyx5f8hHdb1O9a8Y9Atb7Asw7yFO/u+w==",
-      "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@microsoft/fast-react-wrapper": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.22.tgz",
-      "integrity": "sha512-XhlX4m6znh7XW92oPvlKoG9USUn9JtF9rP1qtUoIbkaDaFtUS+H8o1Jn6/oK/rS44LbBLJXrvRkInmSWlDiGFw==",
-      "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4"
-      }
-    },
-    "@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "requires": {
-        "exenv-es6": "^1.1.1"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7577,17 +7466,6 @@
       "version": "0.0.36",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
       "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
-    },
-    "@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      }
     },
     "acorn": {
       "version": "8.14.0",
@@ -8376,11 +8254,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
     },
     "extend": {
       "version": "3.0.2",
@@ -10123,11 +9996,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-    },
     "terser": {
       "version": "5.37.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
@@ -10208,11 +10076,6 @@
       "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
       "dev": true,
       "requires": {}
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -16,7 +16,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@vscode/codicons": "^0.0.36",
-    "@vscode/webview-ui-toolkit": "^1.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/webview-ui/src/AzureServiceOperator/ProgressStep.tsx
+++ b/webview-ui/src/AzureServiceOperator/ProgressStep.tsx
@@ -1,9 +1,9 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./AzureServiceOperator.module.css";
 import { InstallStepStatus } from "./helpers/state";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheckCircle, faClock, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { InstallStepResult } from "../../../src/webview-contract/webviewDefinitions/azureServiceOperator";
+import { ProgressRing } from "../components/ProgressRing";
 
 export interface ProgressStepProps {
     description: string;
@@ -15,9 +15,7 @@ export function ProgressStep(props: ProgressStepProps) {
     return (
         <div className={styles.progressStep}>
             {props.status === InstallStepStatus.NotStarted && <FontAwesomeIcon icon={faClock} />}
-            {props.status === InstallStepStatus.InProgress && (
-                <VSCodeProgressRing className={styles.progressIndicator} />
-            )}
+            {props.status === InstallStepStatus.InProgress && <ProgressRing className={styles.progressIndicator} />}
             {props.status === InstallStepStatus.Succeeded && (
                 <FontAwesomeIcon className={styles.successIndicator} icon={faCheckCircle} />
             )}

--- a/webview-ui/src/ClusterProperties/ClusterProperties.module.css
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.module.css
@@ -198,3 +198,9 @@ th {
     color: var(--vscode-editorWarning-foreground, #fc0);
     margin-right: 8px;
 }
+
+.inie {
+    display: inline-block;
+    top: 0.2rem;
+    position: relative;
+}

--- a/webview-ui/src/ClusterProperties/ClusterProperties.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterProperties.tsx
@@ -4,11 +4,11 @@ import { useStateManagement } from "../utilities/state";
 import { stateUpdater, vscode } from "./state";
 import { ClusterDisplay } from "./ClusterDisplay";
 import { isLoaded, isNotLoaded } from "../utilities/lazy";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { AgentPoolDisplay } from "./AgentPoolDisplay";
 import styles from "./ClusterProperties.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedoAlt } from "@fortawesome/free-solid-svg-icons";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function ClusterProperties(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -48,7 +48,9 @@ export function ClusterProperties(initialState: InitialState) {
                     eventHandlers={eventHandlers}
                 />
             ) : (
-                <VSCodeProgressRing />
+                <>
+                    <ProgressRing />
+                </>
             )}
 
             {clusterInfo &&

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -2,10 +2,11 @@ import { useState } from "react";
 import { ClusterInfo } from "../../../src/webview-contract/webviewDefinitions/clusterProperties";
 import styles from "./ClusterProperties.module.css";
 import { vscode } from "./state";
-import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { CustomDropdown } from "../components/CustomDropdown";
+import { CustomDropdownOption } from "../components/CustomDropdownOption";
 
 export interface ClusterUpgradeProps {
     clusterInfo: ClusterInfo;
@@ -18,10 +19,7 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
     const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
     const isUpgrading = props.clusterInfo.provisioningState === "Upgrading";
 
-    function handleUpgradeVersionChange(event: Event) {
-        const target = event.target as HTMLSelectElement;
-        const version = target.value;
-
+    function handleUpgradeVersionChange(version: string) {
         if (version && version !== "Select version") {
             setSelectedVersion(version);
             setShowConfirmation(true);
@@ -82,21 +80,16 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
         <>
             <div className={styles.upgradeVersionDropdown} style={{ marginLeft: "10px" }}>
                 <span>Upgrade:</span>
-                <VSCodeDropdown
-                    onchange={handleUpgradeVersionChange}
+                <CustomDropdown
+                    onChange={handleUpgradeVersionChange}
                     disabled={props.clusterOperationRequested || !readyToUpgrade}
-                    style={{ minWidth: "120px", maxWidth: "150px" }}
                     value={displayVersion || ""}
                 >
-                    <VSCodeOption selected={!displayVersion} value="">
-                        Select version
-                    </VSCodeOption>
+                    <CustomDropdownOption value="" label="Select version" />
                     {props.clusterInfo.availableUpgradeVersions.map((version: string) => (
-                        <VSCodeOption key={version} value={version} selected={version === displayVersion}>
-                            {version}
-                        </VSCodeOption>
+                        <CustomDropdownOption key={version} value={version} label={version} />
                     ))}
-                </VSCodeDropdown>
+                </CustomDropdown>
             </div>
             <ConfirmationDialog
                 title="Confirm Kubernetes Version Upgrade"

--- a/webview-ui/src/CreateCluster/CreateCluster.tsx
+++ b/webview-ui/src/CreateCluster/CreateCluster.tsx
@@ -3,8 +3,8 @@ import { CreateClusterInput } from "./CreateClusterInput";
 import { Success } from "./Success";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/createCluster";
 import { Stage, stateUpdater, vscode } from "./helpers/state";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useStateManagement } from "../utilities/state";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function CreateCluster(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -51,7 +51,7 @@ export function CreateCluster(initialState: InitialState) {
                             </p>
                         )}
 
-                        <VSCodeProgressRing />
+                        <ProgressRing />
                     </>
                 );
             case Stage.Failed:

--- a/webview-ui/src/CreateCluster/CreateClusterInput.tsx
+++ b/webview-ui/src/CreateCluster/CreateClusterInput.tsx
@@ -1,6 +1,5 @@
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-// import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
 import { FormEvent, useState } from "react";
 import { MessageSink } from "../../../src/webview-contract/messaging";
 import {

--- a/webview-ui/src/CreateFleet/CreateFleet.tsx
+++ b/webview-ui/src/CreateFleet/CreateFleet.tsx
@@ -3,7 +3,7 @@ import { InitialState } from "../../../src/webview-contract/webviewDefinitions/c
 import { CreateFleetInput } from "./CreateFleetInput";
 import { useStateManagement } from "../utilities/state";
 import { Stage, stateUpdater, vscode } from "./helpers/state";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function CreateFleet(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -45,7 +45,7 @@ export function CreateFleet(initialState: InitialState) {
                         <h3>
                             Creating Fleet {state.createParams!.name} in {state.createParams!.location}
                         </h3>
-                        <VSCodeProgressRing />
+                        <ProgressRing />
                     </>
                 );
             case Stage.Failed:

--- a/webview-ui/src/FleetProperties/FleetProperties.tsx
+++ b/webview-ui/src/FleetProperties/FleetProperties.tsx
@@ -9,7 +9,7 @@ import styles from "../ClusterProperties/ClusterProperties.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedoAlt } from "@fortawesome/free-solid-svg-icons";
 import { HubMode } from "../../../src/webview-contract/webviewDefinitions/createFleet";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function FleetProperties(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -59,7 +59,7 @@ export function FleetProperties(initialState: InitialState) {
                 </dl>
             ) : (
                 <>
-                    <VSCodeProgressRing />
+                    <ProgressRing />
                     <h3>If loading takes too long, please ensure the Treeview is up-to-date by refreshing it.</h3>
                 </>
             )}

--- a/webview-ui/src/InspektorGadget/InspektorGadget.module.css
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.module.css
@@ -12,7 +12,6 @@
     clear: left;
     padding: 2px 4px;
     font-weight: bold;
-    width: 10rem;
 }
 
 .propertyList dd {
@@ -155,4 +154,38 @@ ul.hierarchyList li * {
 
 .radioLine {
     margin-bottom: 0.3rem;
+}
+
+.tabContainer {
+    display: flex;
+    flex-direction: column;
+    margin-top: 1rem;
+}
+.tabHeader {
+    display: flex;
+    margin-bottom: 0.5rem;
+}
+.tabItem {
+    padding: 0.3rem 0.3rem;
+    cursor: pointer;
+    position: relative;
+    margin: 0 1.5rem 0 0;
+    color: var(--vscode-editor-foreground, #fff);
+    opacity: 0.7;
+}
+.tabItem:hover {
+    opacity: 1;
+}
+.tabItem.active {
+    opacity: 1;
+}
+.tabItem.active::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -1px;
+    height: 2px;
+    width: 100%;
+    background-color: var(--vscode-editor-foreground, #007acc);
+    border-radius: 1px;
 }

--- a/webview-ui/src/InspektorGadget/InspektorGadget.tsx
+++ b/webview-ui/src/InspektorGadget/InspektorGadget.tsx
@@ -1,8 +1,7 @@
-import { VSCodePanelTab, VSCodePanelView, VSCodePanels } from "@vscode/webview-ui-toolkit/react";
 import { Overview } from "./Overview";
 import { Traces, TracesProps } from "./Traces";
 import styles from "./InspektorGadget.module.css";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { GadgetCategory } from "./helpers/gadgets/types";
 import { isNotLoaded } from "../utilities/lazy";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
@@ -48,6 +47,9 @@ export function InspektorGadget(initialState: InitialState) {
 
     const isDeployed = state.version && state.version.server !== null;
 
+    // used to track active tab
+    const [activeTab, setActiveTab] = useState("overview");
+
     return (
         <>
             <h2>Inspektor Gadget</h2>
@@ -56,37 +58,61 @@ export function InspektorGadget(initialState: InitialState) {
                 <a href="https://www.inspektor-gadget.io/">&nbsp;Learn more</a>
             </p>
 
-            <VSCodePanels aria-label="Inspektory Gadget functions">
-                <VSCodePanelTab>OVERVIEW</VSCodePanelTab>
-                {isDeployed && <VSCodePanelTab>TRACES</VSCodePanelTab>}
-                {isDeployed && <VSCodePanelTab>TOP</VSCodePanelTab>}
-                {isDeployed && <VSCodePanelTab>SNAPSHOTS</VSCodePanelTab>}
-                {isDeployed && <VSCodePanelTab>PROFILE</VSCodePanelTab>}
+            {/* implementation of tabs */}
+            <div className={styles.tabContainer}>
+                <div className={styles.tabHeader}>
+                    <div
+                        className={`${styles.tabItem} ${activeTab === "overview" ? styles.active : ""}`}
+                        onClick={() => setActiveTab("overview")}
+                    >
+                        OVERVIEW
+                    </div>
+                    {isDeployed && (
+                        <>
+                            <div
+                                className={`${styles.tabItem} ${activeTab === "trace" ? styles.active : ""}`}
+                                onClick={() => setActiveTab("trace")}
+                            >
+                                TRACES
+                            </div>
+                            <div
+                                className={`${styles.tabItem} ${activeTab === "top" ? styles.active : ""}`}
+                                onClick={() => setActiveTab("top")}
+                            >
+                                TOP
+                            </div>
+                            <div
+                                className={`${styles.tabItem} ${activeTab === "snapshot" ? styles.active : ""}`}
+                                onClick={() => setActiveTab("snapshot")}
+                            >
+                                SNAPSHOTS
+                            </div>
+                            <div
+                                className={`${styles.tabItem} ${activeTab === "profile" ? styles.active : ""}`}
+                                onClick={() => setActiveTab("profile")}
+                            >
+                                PROFILE
+                            </div>
+                        </>
+                    )}
+                </div>
 
-                <VSCodePanelView className={styles.tab}>
-                    <Overview status={state.overviewStatus} version={state.version} eventHandlers={eventHandlers} />
-                </VSCodePanelView>
-                {isDeployed && (
-                    <VSCodePanelView className={styles.tab}>
-                        <Traces {...getTracesProps("trace")} />
-                    </VSCodePanelView>
-                )}
-                {isDeployed && (
-                    <VSCodePanelView className={styles.tab}>
-                        <Traces {...getTracesProps("top")} />
-                    </VSCodePanelView>
-                )}
-                {isDeployed && (
-                    <VSCodePanelView className={styles.tab}>
-                        <Traces {...getTracesProps("snapshot")} />
-                    </VSCodePanelView>
-                )}
-                {isDeployed && (
-                    <VSCodePanelView className={styles.tab}>
-                        <Traces {...getTracesProps("profile")} />
-                    </VSCodePanelView>
-                )}
-            </VSCodePanels>
+                <div>
+                    {activeTab === "overview" && (
+                        <>
+                            <Overview
+                                status={state.overviewStatus}
+                                version={state.version}
+                                eventHandlers={eventHandlers}
+                            />
+                        </>
+                    )}
+                    {isDeployed && activeTab === "trace" && <Traces {...getTracesProps("trace")} />}
+                    {isDeployed && activeTab === "top" && <Traces {...getTracesProps("top")} />}
+                    {isDeployed && activeTab === "snapshot" && <Traces {...getTracesProps("snapshot")} />}
+                    {isDeployed && activeTab === "profile" && <Traces {...getTracesProps("profile")} />}
+                </div>
+            </div>
         </>
     );
 }

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -1,4 +1,3 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./InspektorGadget.module.css";
 import { Dialog } from "../components/Dialog";
 import { FormEvent, useEffect, useState, ChangeEvent as InputChangeEvent } from "react";
@@ -13,6 +12,7 @@ import { GadgetCategory, GadgetExtraProperties, SortSpecifier, toExtraPropertyOb
 import { NamespaceSelection } from "../../../src/webview-contract/webviewDefinitions/inspektorGadget";
 import { EventHandlers } from "../utilities/state";
 import { EventDef, vscode } from "./helpers/state";
+import { ProgressRing } from "../components/ProgressRing";
 
 const defaultTimeoutInSeconds = 30;
 const defaultMaxItemCount = 20;
@@ -171,7 +171,7 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
                             className={styles.control}
                         />
                     ) : (
-                        <VSCodeProgressRing />
+                        <ProgressRing />
                     )}
 
                     {!extraProperties.noK8sResourceFiltering && (
@@ -187,7 +187,7 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
                                     userMessageHandlers={props.eventHandlers}
                                 />
                             ) : (
-                                <VSCodeProgressRing />
+                                <ProgressRing />
                             )}
                         </>
                     )}

--- a/webview-ui/src/InspektorGadget/Overview.tsx
+++ b/webview-ui/src/InspektorGadget/Overview.tsx
@@ -35,16 +35,16 @@ export function Overview(props: OverviewProps) {
             {props.version && props.version.server && (
                 <>
                     <dl className={styles.propertyList}>
-                        <dt>Client Version</dt>
+                        <dt>Client Version:&nbsp;</dt>
                         <dd>{props.version.client}</dd>
-                        <dt>Server Version</dt>
+                        <dt>Server Version:&nbsp;</dt>
                         <dd>{props.version.server}</dd>
                     </dl>
-                    <br />
-                    <button onClick={handleUndeploy}>
+                    <button className="secondary-button" onClick={handleUndeploy}>
                         <FontAwesomeIcon icon={faEraser} />
                         &nbsp;Undeploy
                     </button>
+                    &nbsp;&nbsp;&nbsp;
                 </>
             )}
             {props.version &&

--- a/webview-ui/src/InspektorGadget/ResourceSelector.tsx
+++ b/webview-ui/src/InspektorGadget/ResourceSelector.tsx
@@ -4,10 +4,10 @@ import { faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons
 import styles from "./InspektorGadget.module.css";
 import { NamespaceResources, PodResources } from "./helpers/clusterResources";
 import { Lazy, isLoaded, isNotLoaded, map as lazyMap, orDefault } from "../utilities/lazy";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { Lookup, asLookup, exclude, intersection } from "../utilities/array";
 import { EventHandlers } from "../utilities/state";
 import { EventDef, vscode } from "./helpers/state";
+import { ProgressRing } from "../components/ProgressRing";
 
 type ChangeEvent = Event | FormEvent<HTMLElement>;
 
@@ -144,7 +144,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
                         {isLoaded(item.children) ? (
                             renderPodItems(item.name, item.children.value, status[item.name].podStatuses)
                         ) : (
-                            <VSCodeProgressRing />
+                            <ProgressRing />
                         )}
                     </ul>
                 )}
@@ -178,7 +178,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
                         {isLoaded(item.children) ? (
                             renderContainerItems(namespace, item.name, item.children.value)
                         ) : (
-                            <VSCodeProgressRing />
+                            <ProgressRing />
                         )}
                     </ul>
                 )}

--- a/webview-ui/src/InspektorGadget/TraceOutput.tsx
+++ b/webview-ui/src/InspektorGadget/TraceOutput.tsx
@@ -1,8 +1,8 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./InspektorGadget.module.css";
 import { TraceGadget } from "./helpers/gadgets";
 import { ProcessSnapshotKey } from "./helpers/gadgets/snapshot";
 import { ItemProperty, ValueType } from "./helpers/gadgets/types";
+import { ProgressRing } from "../components/ProgressRing";
 
 export interface TraceOutputProps {
     trace: TraceGadget;
@@ -19,7 +19,7 @@ export function TraceOutput(props: TraceOutputProps) {
     if (props.trace.output === null) {
         return (
             <>
-                <VSCodeProgressRing></VSCodeProgressRing>
+                <ProgressRing />
                 Running Gadget...
             </>
         );

--- a/webview-ui/src/Kaito/Kaito.tsx
+++ b/webview-ui/src/Kaito/Kaito.tsx
@@ -1,4 +1,3 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { InitialState, ProgressEventType } from "../../../src/webview-contract/webviewDefinitions/kaito";
 import { useStateManagement } from "../utilities/state";
 import styles from "./Kaito.module.css";
@@ -6,6 +5,7 @@ import kaitoimage from "./kaito-image.png";
 import { useState } from "react";
 
 import { stateUpdater, vscode } from "./state";
+import { ProgressRing } from "../components/ProgressRing";
 export function Kaito(initialState: InitialState) {
     const { state } = useStateManagement(stateUpdater, initialState, vscode);
     const [isDisabled, setIsDisabled] = useState(false);
@@ -78,7 +78,7 @@ export function Kaito(initialState: InitialState) {
                                     display: "flex",
                                 }}
                             >
-                                <VSCodeProgressRing />
+                                <ProgressRing />
                                 <p className={styles.installingMessage}>
                                     Installing KAITO, this may take a few minutes...
                                 </p>
@@ -92,7 +92,7 @@ export function Kaito(initialState: InitialState) {
                                     display: "flex",
                                 }}
                             >
-                                <VSCodeProgressRing />
+                                <ProgressRing />
                                 <p className={styles.installingMessage}>
                                     Enabling Role assignments and Federated Credentails for KAITO, this may take a few
                                     minutes...

--- a/webview-ui/src/KaitoManage/KaitoManage.tsx
+++ b/webview-ui/src/KaitoManage/KaitoManage.tsx
@@ -2,10 +2,10 @@ import { useStateManagement } from "../utilities/state";
 import styles from "./KaitoManage.module.css";
 import { stateUpdater, vscode } from "./state";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/kaitoManage";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { generateKaitoYAML } from "../KaitoModels/KaitoModels";
 import { useEffect } from "react";
 import { convertMinutesToFormattedAge } from "../KaitoModels/KaitoModels";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function KaitoManage(initialState: InitialState) {
     const { state } = useStateManagement(stateUpdater, initialState, vscode);
@@ -73,7 +73,7 @@ export function KaitoManage(initialState: InitialState) {
                                                         Get Logs
                                                     </button>
                                                 </div>
-                                                <VSCodeProgressRing className={styles.progress} />
+                                                <ProgressRing className={styles.progress} />
                                                 <span className={styles.bold}>Deployment in progress</span>
                                             </>
                                         );

--- a/webview-ui/src/KaitoModels/KaitoModels.tsx
+++ b/webview-ui/src/KaitoModels/KaitoModels.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import styles from "./KaitoModels.module.css";
 import kaitoSupporterModel from "../../../resources/kaitollmconfig/kaitollmconfig.json";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { stateUpdater, vscode } from "./state";
 import { useStateManagement } from "../utilities/state";
 import { ArrowIcon } from "../icons/ArrowIcon";
 import { InitialState } from "../../../src/webview-contract/webviewDefinitions/kaitoModels";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function KaitoModels(initialState: InitialState) {
     const { state } = useStateManagement(stateUpdater, initialState, vscode);
@@ -191,7 +191,7 @@ export function KaitoModels(initialState: InitialState) {
                                                     return (
                                                         <>
                                                             <div className={styles.progressDiv}>
-                                                                <VSCodeProgressRing className={styles.progress} />
+                                                                <ProgressRing className={styles.progress} />
                                                                 <span className={styles.bold}>
                                                                     Deployment in progress
                                                                 </span>

--- a/webview-ui/src/Kubectl/CommandOutput.tsx
+++ b/webview-ui/src/Kubectl/CommandOutput.tsx
@@ -1,7 +1,7 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./Kubectl.module.css";
 import { EventHandlers } from "../utilities/state";
 import { EventDef } from "./helpers/state";
+import { ProgressRing } from "../components/ProgressRing";
 
 export interface CommandOutputProps {
     isCommandRunning: boolean;
@@ -16,7 +16,7 @@ export function CommandOutput(props: CommandOutputProps) {
 
     return (
         <>
-            {props.isCommandRunning && <VSCodeProgressRing />}
+            {props.isCommandRunning && <ProgressRing />}
             {hasOutput && <pre>{props.output}</pre>}
             {hasError && <pre className={styles.error}>{props.errorMessage}</pre>}
         </>

--- a/webview-ui/src/Periscope/SuccessView.tsx
+++ b/webview-ui/src/Periscope/SuccessView.tsx
@@ -1,4 +1,3 @@
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useEffect } from "react";
 import { NodeUploadStatus, PodLogs } from "../../../src/webview-contract/webviewDefinitions/periscope";
 import { NodeActions } from "./NodeActions";
@@ -6,6 +5,7 @@ import { NodeLogs } from "./NodeLogs";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
 import styles from "./Periscope.module.css";
+import { ProgressRing } from "../components/ProgressRing";
 
 export interface SuccessViewProps {
     runId: string;
@@ -69,7 +69,7 @@ export function SuccessView(props: SuccessViewProps) {
                                         Uploaded
                                     </>
                                 ) : (
-                                    <VSCodeProgressRing />
+                                    <ProgressRing />
                                 )}
                             </td>
                             <td>{status.nodeName}</td>

--- a/webview-ui/src/RetinaCapture/RetinaCapture.module.css
+++ b/webview-ui/src/RetinaCapture/RetinaCapture.module.css
@@ -17,3 +17,18 @@
     flex-direction: row;
     column-gap: 0.5rem;
 }
+
+.checkboxLabel {
+    position: relative;
+    top: -0.25rem;
+    left: 0.2rem;
+}
+
+.checkboxLabel:hover {
+    cursor: pointer;
+}
+
+.buttonDiv {
+    margin-top: 1rem;
+    display: flex;
+}

--- a/webview-ui/src/RetinaCapture/RetinaCapture.tsx
+++ b/webview-ui/src/RetinaCapture/RetinaCapture.tsx
@@ -6,8 +6,6 @@ import { useStateManagement } from "../utilities/state";
 import { DeleteNodeExplorerDialog } from "./DeleteNodeExplorerDialog";
 import styles from "./RetinaCapture.module.css";
 import { stateUpdater, vscode } from "./state";
-import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react";
-
 type ChangeEvent = Event | FormEvent<HTMLElement>;
 
 export function RetinaCapture(initialState: InitialState) {
@@ -42,7 +40,6 @@ export function RetinaCapture(initialState: InitialState) {
             <header>
                 <h2>Retina Distributed Capture for {state.clusterName}</h2>
             </header>
-
             <hr style={{ marginBottom: "1rem" }} />
             <div>
                 <FontAwesomeIcon icon={faInfoCircle} /> Retina capture command allows the user to capture network
@@ -62,26 +59,32 @@ export function RetinaCapture(initialState: InitialState) {
                     <div style={{ flexDirection: "row", width: "31.25rem" }}>
                         {state.allNodes.map((node) => (
                             <div key={node}>
-                                <VSCodeCheckbox onChange={(e) => onSelectNode(e, node)} checked={isNodeSelected(node)}>
+                                <input
+                                    id={`checkbox-${node}`}
+                                    onChange={(e) => onSelectNode(e, node)}
+                                    checked={isNodeSelected(node)}
+                                    type="checkbox"
+                                ></input>
+                                <label className={styles.checkboxLabel} htmlFor={`checkbox-${node}`}>
                                     {node}
-                                </VSCodeCheckbox>
+                                </label>
                             </div>
                         ))}
-                        <div style={{ display: "flex" }}>
-                            <VSCodeButton
+                        <div className={styles.buttonDiv}>
+                            <button
                                 type="submit"
                                 style={{ marginRight: "0.625rem" }}
                                 onClick={() => handleCaptureFileDownload()}
                             >
                                 Download Retina Logs to Host Machine.
-                            </VSCodeButton>
+                            </button>
                             {state.isNodeExplorerPodExists && (
-                                <VSCodeButton appearance="secondary" onClick={() => handleDeleteExplorerPod()}>
+                                <button className="secondary-button" onClick={() => handleDeleteExplorerPod()}>
                                     <span slot="start">
                                         <FontAwesomeIcon icon={faTrash} />
                                     </span>
                                     Delete Node Explorer Pod
-                                </VSCodeButton>
+                                </button>
                             )}
                         </div>
                     </div>

--- a/webview-ui/src/TCPDump/TcpDump.tsx
+++ b/webview-ui/src/TCPDump/TcpDump.tsx
@@ -1,7 +1,6 @@
 import { CaptureName, InitialState } from "../../../src/webview-contract/webviewDefinitions/tcpDump";
 import styles from "./TcpDump.module.css";
 import { useEffect } from "react";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { useStateManagement } from "../utilities/state";
 import { CaptureStatus, NodeState, NodeStatus, TcpDumpState, stateUpdater, vscode } from "./state";
 import { NodeSelector } from "../components/NodeSelector";
@@ -18,6 +17,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { CaptureFilters } from "./CaptureFilters";
 import { EventHandlerFunc } from "./state/dataLoading";
+import { ProgressRing } from "../components/ProgressRing";
 
 export function TcpDump(initialState: InitialState) {
     const { state, eventHandlers } = useStateManagement(stateUpdater, initialState, vscode);
@@ -108,7 +108,7 @@ export function TcpDump(initialState: InitialState) {
 
                 {hasStatus(NodeStatus.Checking) && (
                     <div className={styles.control} style={{ display: "flex" }}>
-                        <VSCodeProgressRing style={{ height: "1rem" }} />
+                        <ProgressRing />
                         Checking Node
                     </div>
                 )}

--- a/webview-ui/src/components/ProgressRing.module.css
+++ b/webview-ui/src/components/ProgressRing.module.css
@@ -1,0 +1,13 @@
+.spinner {
+    border: 3px solid var(--vscode-progressBar-background);
+    border-top: 3px solid transparent;
+    border-left: 3px solid transparent;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/webview-ui/src/components/ProgressRing.tsx
+++ b/webview-ui/src/components/ProgressRing.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import styles from "./ProgressRing.module.css";
+
+interface ProgressRingProps {
+    size?: number;
+    className?: string;
+}
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const ProgressRing: React.FC<ProgressRingProps> = ({ size = "1rem", className }) => {
+    return <div className={`${styles.spinner} ${className || ""}`} style={{ width: size, height: size }} />;
+};

--- a/webview-ui/src/components/ResourceSelector.tsx
+++ b/webview-ui/src/components/ResourceSelector.tsx
@@ -1,7 +1,7 @@
 import { Lazy, asLazy, isLoaded, isLoading, isNotLoaded } from "../utilities/lazy";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { CustomDropdown } from "./CustomDropdown";
 import { CustomDropdownOption } from "./CustomDropdownOption";
+import { ProgressRing } from "./ProgressRing";
 
 export interface ResourceSelectorProps<TResource> {
     resources: Lazy<TResource[]> | TResource[];
@@ -26,7 +26,7 @@ export function ResourceSelector<TResource>(props: ResourceSelectorProps<TResour
 
     return (
         <>
-            {isLoading(resources) && <VSCodeProgressRing style={{ height: "1rem" }} />}
+            {isLoading(resources) && <ProgressRing />}
             {isNotLoaded(resources) && (
                 <CustomDropdown
                     className={props.className}

--- a/webview-ui/src/components/TextWithDropdown.tsx
+++ b/webview-ui/src/components/TextWithDropdown.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, HTMLAttributes, useEffect, useRef, useState } from "react";
 import styles from "./TextWithDropdown.module.css";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { Lazy, asLazy, isLoaded, isLoading, isNotLoaded, orDefault } from "../utilities/lazy";
+import { ProgressRing } from "./ProgressRing";
 
 type AvailableHtmlAttributes = Pick<HTMLAttributes<HTMLElement>, "className" | "id">;
 type ChangeEvent = Event | FormEvent<HTMLElement>;
@@ -43,7 +43,7 @@ export function TextWithDropdown(props: TextWithDropdownProps) {
     return (
         <>
             {displayMode === DisplayMode.TextField && <TextOnly {...props} />}
-            {displayMode === DisplayMode.Loader && <VSCodeProgressRing style={{ height: "1rem" }} />}
+            {displayMode === DisplayMode.Loader && <ProgressRing />}
             {displayMode === DisplayMode.Dropdown && (
                 <NonLazyTextWithDropdown {...{ ...props, items: orDefault(lazyItems, []) }} />
             )}


### PR DESCRIPTION
This PR finalizes the removal of the webview-ui-toolkit package and all remaining usages from the repo. 
- Removed & replaced all instances of `<VSCodePanels>`, `<VSCodePanelTab>`, `<VSCodePanelView>`, `<VSCodeDropdownButton>`, and `<VSCodeProgressRing>` elements
- Custom `<ProgressRing>` element added
- Closes out issue #1207 

(An addition to the documentation briefly describing our new options for custom element & future development will be posted in a PR shortly after this).

(I've decided to include a couple clips below to reduce testing & demonstrate functionality- mainly showing the page that was changed the most in this PR which is the InspektorGadget panel. Several other files were changed but in this PR they are mostly non-interactable elements, so there shouldn't be much worry of broken functionality.)

Of course still here is the .vsix and any additional testing would be appreciated! 
[vscode-aks-tools-1.6.2-deprecationtest.vsix.zip](https://github.com/user-attachments/files/19512662/vscode-aks-tools-1.6.2-deprecationtest.vsix.zip)

Inspektor Gadget Before Changes:

https://github.com/user-attachments/assets/d6fe082a-e941-43f6-8031-44db70f075aa

After Changes:

https://github.com/user-attachments/assets/8a090695-378e-4c14-a2dd-0eeb7bd2685c

Progress Ring:

https://github.com/user-attachments/assets/fb252d24-0a28-468a-a95f-77ecd729cdad

These clips are just to demonstrate that the visual/functionality is almost identical as intended.

