### PR TITLE
Changes to publish 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.6.3]
+
+* Add upload logs feature for Retina Capture (#1306)
+* Full replacement of VSCodeDropdown & VSCodeOption with custom react elements [Webview-UI-toolkit deprecation] (#1276)
+* Dependabot updates and bumps.
+
+Thank you so much to @ReinierCC, @bosesuneha @tejhan for contributions, testing and reviews.
+
 
 ## [1.6.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 * Full replacement of VSCodeDropdown & VSCodeOption with custom react elements [Webview-UI-toolkit deprecation] (#1276)
 * Dependabot updates and bumps.
 
-Thank you so much to @ReinierCC, @bosesuneha @tejhan for contributions, testing and reviews.
-
+Thank you so much to @ReinierCC, @bosesuneha, @tejhan for contributions, testing and reviews.
 
 ## [1.6.2]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is open for the release of `1.6.3` this pr contains some amazing work like:

* Add upload logs feature for Retina Capture (#1306)
* Full replacement of VSCodeDropdown & VSCodeOption with custom react elements [Webview-UI-toolkit deprecation] (#1276)
* Dependabot updates and bumps.

Thank you so much to @tejhan, @bosesuneha, @ReinierCC, @davidgamero, @qpetraroia, @gambtho for contributions, testing and reviews.

VSIX to test:

[vscode-aks-tools-1.6.3-test.vsix.zip](https://github.com/user-attachments/files/19558697/vscode-aks-tools-1.6.3-test.vsix.zip)

