### PR TITLE
Reverting @azure/identity update to fix issues in non-wsl Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@azure/arm-subscriptions": "^5.1.0",
                 "@azure/container-registry": "^1.1.0",
                 "@azure/core-auth": "^1.8.0",
-                "@azure/identity": "^4.8.0",
+                "@azure/identity": "4.6",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/storage-blob": "^12.26.0",
                 "@eslint/compat": "^1.2.7",
@@ -577,9 +577,9 @@
             }
         },
         "node_modules/@azure/identity": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.8.0.tgz",
-            "integrity": "sha512-l9ALUGHtFB/JfsqmA+9iYAp2a+cCwdNO/cyIr2y7nJLJsz1aae6qVP8XxT7Kbudg0IQRSIMXj0+iivFdbD1xPA==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.6.0.tgz",
+            "integrity": "sha512-ANpO1iAvcZmpD4QY7/kaE/P2n66pRXsDp3nMUC6Ow3c9KfXOZF7qMU9VgqPw8m7adP7TVIbVyrCEmD9cth3KQQ==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
@@ -589,11 +589,11 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^4.2.0",
-                "@azure/msal-node": "^3.2.3",
+                "@azure/msal-browser": "^4.0.1",
+                "@azure/msal-node": "^2.15.0",
                 "events": "^3.0.0",
                 "jws": "^4.0.0",
-                "open": "^10.1.0",
+                "open": "^8.0.0",
                 "stoppable": "^1.1.0",
                 "tslib": "^2.2.0"
             },
@@ -733,21 +733,21 @@
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "15.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.2.1.tgz",
-            "integrity": "sha512-eZHtYE5OHDN0o2NahCENkczQ6ffGc0MoUSAI3hpwGpZBHJXaEQMMZPWtIx86da2L9w7uT+Tr/xgJbGwIkvTZTQ==",
+            "version": "14.16.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
+            "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.3.0.tgz",
-            "integrity": "sha512-ulsT3EHF1RQ29X55cxBLgKsIKWni9JdbUqG7sipGVP4uhWcBpmm/vhKOMH340+27Acm9+kHGnN/5XmQ5LrIDgA==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
+            "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.2.1",
+                "@azure/msal-common": "14.16.0",
                 "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
@@ -2777,21 +2777,6 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
-        "node_modules/bundle-name": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-            "license": "MIT",
-            "dependencies": {
-                "run-applescript": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -3425,34 +3410,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/default-browser": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-            "license": "MIT",
-            "dependencies": {
-                "bundle-name": "^4.1.0",
-                "default-browser-id": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3471,15 +3428,12 @@
             }
         },
         "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/delayed-stream": {
@@ -4811,15 +4765,15 @@
             }
         },
         "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4853,24 +4807,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-interactive": {
@@ -4941,18 +4877,15 @@
             }
         },
         "node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "license": "MIT",
             "dependencies": {
-                "is-inside-container": "^1.0.0"
+                "is-docker": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -6034,18 +5967,17 @@
             }
         },
         "node_modules/open": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.2.1",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6831,18 +6763,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/run-applescript": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -715,7 +715,7 @@
         "@azure/arm-subscriptions": "^5.1.0",
         "@azure/container-registry": "^1.1.0",
         "@azure/core-auth": "^1.8.0",
-        "@azure/identity": "^4.8.0",
+        "@azure/identity": "4.6",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/storage-blob": "^12.26.0",
         "@eslint/compat": "^1.2.7",


### PR DESCRIPTION
This pull request reverts recent updates to the `@azure/identity` package and its dependency `open`, due to critical issues affecting Windows users. The updates introduced breaking changes that prevented Windows users from loading and viewing subscriptions or clusters within the VSCode AKS Tools extension.

- Addresses issue https://github.com/Azure/vscode-aks-tools/issues/1344
- Reverted update from `@azure/identity` from 4.8 back to 4.6
- Reverted `open` from 10.1 to 8.0 (This package specifically or (it's depdendencies)) are what introduced the breaking changes.

For a bit of detail - it seems to be that the update to  the open package included some new dependencies such as `default-browser` & `is-inside-container` package, which also came along with additional subdependencies of `bundle-name` & `run-applescript` alongside updates to other OS-related packages like `is-wsl` & removal of previous sub dependency `is-docker`. One of these packages caused the issue & since they all mutually need eachother for this update, we will have to exclude them all for now to provide functionality for windows users. 

All of these packages are required for version 10 of `open`, which is required for version 4.8 of `@azure/identity`, so for now we can revert this major change & prevent dependabot from auto-updating the `@azure/identity` or `open` package as of now.

.vsix for testing -> [vscode-aks-tools-1.6.3-windowsfix.vsix.zip](https://github.com/user-attachments/files/19591011/vscode-aks-tools-1.6.3-windowsfix.vsix.zip)

We can do further investigation to pin down the specific individual package causing the issue for further decisions, but for now this serves to fix the issue by reverting the major upgrades to the parent packages while maintaining full functionality.


