### PR TITLE
Publish release 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.6.4]
+
+* Reverting @azure/identity update to fix windows issue (#1345) Fix for [this bug](https://github.com/Azure/vscode-aks-tools/issues/1344)
+* Update retina doc (#1334)
+
+Thank you so much to @tejhan for identitify culprit package and @bosesuneha for retina docs, also to   kejatura-dev for contributions, testing and reviews.
+
 ## [1.6.3]
 
 * Add upload logs feature for Retina Capture (#1306)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.3",
+            "version": "1.6.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is open for the release of `1.6.4` this pr contains a key fix and detail is below:

* Reverting @azure/identity update to fix windows issue (#1345) Fix for [this bug](https://github.com/Azure/vscode-aks-tools/issues/1344)
* Update retina doc (#1334)

This release will fix : #1344 

Thank you so much to @tejhan for identitify culprit package and @bosesuneha for retina docs, also to   kejatura-dev for contributions, testing and reviews.

Thank you so much to @tejhan, @bosesuneha, @ReinierCC, @davidgamero, @qpetraroia, @gambtho for contributions, testing and reviews.

VSIX to test:

[vscode-aks-tools-1.6.4-test.vsix.zip](https://github.com/user-attachments/files/19592280/vscode-aks-tools-1.6.4-test.vsix.zip)
