### PR TITLE
Update/detector upgrade sceanrio

### DIFF
--- a/src/commands/aksClusterProperties/aksClusterProperties.ts
+++ b/src/commands/aksClusterProperties/aksClusterProperties.ts
@@ -32,6 +32,7 @@ export default async function aksClusterProperties(_context: IActionContext, tar
         clusterNode.result.subscriptionId,
         clusterNode.result.resourceGroupName,
         clusterNode.result.name,
+        target
     );
     const panel = new ClusterPropertiesPanel(extension.result.extensionUri);
 

--- a/src/commands/aksClusterProperties/aksClusterProperties.ts
+++ b/src/commands/aksClusterProperties/aksClusterProperties.ts
@@ -32,7 +32,7 @@ export default async function aksClusterProperties(_context: IActionContext, tar
         clusterNode.result.subscriptionId,
         clusterNode.result.resourceGroupName,
         clusterNode.result.name,
-        target
+        target,
     );
     const panel = new ClusterPropertiesPanel(extension.result.extensionUri);
 

--- a/src/panels/ClusterPropertiesPanel.ts
+++ b/src/panels/ClusterPropertiesPanel.ts
@@ -22,6 +22,8 @@ import { getKubernetesVersionInfo, getManagedCluster, getClusterUpgradeProfile }
 import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { getAksClient } from "../commands/utils/arm";
 import { ReadyAzureSessionProvider } from "../auth/types";
+import { aksCRUDDiagnostics } from "../commands/detectors/detectors";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
 
 export class ClusterPropertiesPanel extends BasePanel<"clusterProperties"> {
     constructor(extensionUri: Uri) {
@@ -40,6 +42,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
         readonly subscriptionId: string,
         readonly resourceGroup: string,
         readonly clusterName: string,
+        readonly target: unknown
     ) {
         this.client = getAksClient(sessionProvider, subscriptionId);
     }
@@ -64,6 +67,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
             reconcileClusterRequest: true,
             refreshRequest: true,
             upgradeClusterVersionRequest: true,
+            detectorCRUDRequest: true,
         };
     }
 
@@ -78,6 +82,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
             // refreshRequest is just for telemetry, so it will use the same getPropertiesRequest handler.
             refreshRequest: () => this.handleGetPropertiesRequest(webview),
             upgradeClusterVersionRequest: (version: string) => this.handleUpgradeClusterVersion(webview, version),
+            detectorCRUDRequest: () => this.handleDetectorCRUDRequest(this.target),
         };
     }
 
@@ -270,6 +275,13 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
 
         // Refresh the cluster properties after operation completes
         await this.readAndPostClusterProperties(webview);
+    }
+
+    private handleDetectorCRUDRequest(commandTarget: unknown) { 
+        // This is a placeholder for the CRUD operation
+        // Implement the CRUD logic here
+        return aksCRUDDiagnostics({} as IActionContext, commandTarget);
+       
     }
 
     private async readAndPostClusterProperties(webview: MessageSink<ToWebViewMsgDef>) {

--- a/src/panels/ClusterPropertiesPanel.ts
+++ b/src/panels/ClusterPropertiesPanel.ts
@@ -42,7 +42,7 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
         readonly subscriptionId: string,
         readonly resourceGroup: string,
         readonly clusterName: string,
-        readonly target: unknown
+        readonly target: unknown,
     ) {
         this.client = getAksClient(sessionProvider, subscriptionId);
     }
@@ -277,11 +277,10 @@ export class ClusterPropertiesDataProvider implements PanelDataProvider<"cluster
         await this.readAndPostClusterProperties(webview);
     }
 
-    private handleDetectorCRUDRequest(commandTarget: unknown) { 
+    private handleDetectorCRUDRequest(commandTarget: unknown) {
         // This is a placeholder for the CRUD operation
         // Implement the CRUD logic here
         return aksCRUDDiagnostics({} as IActionContext, commandTarget);
-       
     }
 
     private async readAndPostClusterProperties(webview: MessageSink<ToWebViewMsgDef>) {

--- a/src/webview-contract/webviewDefinitions/clusterProperties.ts
+++ b/src/webview-contract/webviewDefinitions/clusterProperties.ts
@@ -41,6 +41,7 @@ export type ToVsCodeMsgDef = {
     reconcileClusterRequest: void;
     refreshRequest: void;
     upgradeClusterVersionRequest: string;
+    detectorCRUDRequest: void;
 };
 
 export type ToWebViewMsgDef = {

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -101,7 +101,10 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
                     href="#"
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={handleCRUDDetectorCall}
+                    onClick={(event) => {
+                        event.preventDefault();
+                        handleCRUDDetectorCall();
+                    }}
                     style={{ minWidth: "120px", maxWidth: "250px" }}
                 >
                     <FontAwesomeIcon icon={faExclamationTriangle} className={styles.InformationIcon} />

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -4,7 +4,7 @@ import styles from "./ClusterProperties.module.css";
 import { vscode } from "./state";
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faCircleInfo, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { CustomDropdown } from "../components/CustomDropdown";
 import { CustomDropdownOption } from "../components/CustomDropdownOption";
 
@@ -107,7 +107,9 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
                     }}
                     style={{ minWidth: "120px", maxWidth: "250px" }}
                 >
-                    <FontAwesomeIcon icon={faExclamationTriangle} className={styles.InformationIcon} />
+                    &nbsp;
+                    <FontAwesomeIcon icon={faCircleInfo} className={styles.InformationIcon} />
+                    &nbsp;
                     <strong>Run CRUD Validations</strong>
                     <br />
                 </a>

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -105,7 +105,7 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
                     style={{ minWidth: "120px", maxWidth: "150px" }}
                 >
                     <FontAwesomeIcon icon={faExclamationTriangle} className={styles.warningIcon} />
-                    <strong>Run CRUD Detector For any potential issues </strong>
+                    <strong>Run CRUD Validations</strong>
                     <br />
                 </a>
             </div>

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -26,6 +26,11 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
         }
     }
 
+    function handleCRUDDetectorCall() {
+        // Then post the request to the extension
+        vscode.postDetectorCRUDRequest();
+    }
+
     function handleConfirmUpgrade() {
         if (selectedVersion) {
             // Set clusterOperationRequested first so UI updates immediately
@@ -90,6 +95,19 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
                         <CustomDropdownOption key={version} value={version} label={version} />
                     ))}
                 </CustomDropdown>
+            </div>
+            <div className={styles.upgradeVersionLink}>
+                <a
+                    href="#"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={handleCRUDDetectorCall}
+                    style={{ minWidth: "120px", maxWidth: "150px" }}
+                >
+                    <FontAwesomeIcon icon={faExclamationTriangle} className={styles.warningIcon} />
+                    <strong>Run CRUD Detector For any potential issues </strong>
+                    <br />
+                </a>
             </div>
             <ConfirmationDialog
                 title="Confirm Kubernetes Version Upgrade"

--- a/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
+++ b/webview-ui/src/ClusterProperties/ClusterUpgrade.tsx
@@ -102,9 +102,9 @@ export function ClusterUpgrade(props: ClusterUpgradeProps) {
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={handleCRUDDetectorCall}
-                    style={{ minWidth: "120px", maxWidth: "150px" }}
+                    style={{ minWidth: "120px", maxWidth: "250px" }}
                 >
-                    <FontAwesomeIcon icon={faExclamationTriangle} className={styles.warningIcon} />
+                    <FontAwesomeIcon icon={faExclamationTriangle} className={styles.InformationIcon} />
                     <strong>Run CRUD Validations</strong>
                     <br />
                 </a>

--- a/webview-ui/src/ClusterProperties/state.ts
+++ b/webview-ui/src/ClusterProperties/state.ts
@@ -52,4 +52,5 @@ export const vscode = getWebviewMessageContext<"clusterProperties">({
     reconcileClusterRequest: null,
     refreshRequest: null,
     upgradeClusterVersionRequest: null,
+    detectorCRUDRequest: null,
 });

--- a/webview-ui/src/manualTest/clusterPropertiesTests.tsx
+++ b/webview-ui/src/manualTest/clusterPropertiesTests.tsx
@@ -127,6 +127,9 @@ export function getClusterPropertiesScenarios() {
             refreshRequest: () => handleGetPropertiesRequest(),
             upgradeClusterVersionRequest: (version: string) =>
                 handleUpgradeClusterVersionRequest(version, withErrors && sometimes()),
+            detectorCRUDRequest: () => {
+                webview.postErrorNotification("Sorry, I wasn't quite able to perform the CRUD operation.");
+            },
         };
 
         async function handleGetPropertiesRequest() {


### PR DESCRIPTION
This PR is to enable a scenario where user can run their CRUD detectors for the pre-flight or post-flight check themselves.

Key intent of this work is to get the functionality step closer and close the loop of what user can check in case of upgrade failures.

The Screen looks like this. ❤️  Thanks heaps, @sprab (for the idae-ask/share), @ReinierCC , @tejhan , @bosesuneha , @davidgamero + @qpetraroia and fyi @gambtho 

<img width="920" alt="Screenshot 2025-04-07 at 10 29 52 AM" src="https://github.com/user-attachments/assets/e6efa67c-b866-4df5-8ef3-9a7e25156a5f" />

### VSIX to test: 

[vscode-aks-tools-1.6.4-test-crud-upgrade-link.vsix.zip](https://github.com/user-attachments/files/19625288/vscode-aks-tools-1.6.4-test-crud-upgrade-link.vsix.zip)
