### PR TITLE
Fix for viewing downloaded files when using WSL

### DIFF
--- a/src/panels/RetinaCapturePanel.ts
+++ b/src/panels/RetinaCapturePanel.ts
@@ -12,6 +12,7 @@ import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { getLocalKubectlCpPath } from "./utilities/KubectlNetworkHelper";
 import * as semver from "semver";
+import { commands, env } from "vscode";
 
 export class RetinaCapturePanel extends BasePanel<"retinaCapture"> {
     constructor(extensionUri: Uri) {
@@ -198,7 +199,12 @@ spec:
             )
             .then((selection) => {
                 if (selection === goToFolder) {
-                    open(captureHostFolderName);
+                    if (env.remoteName === "wsl") {
+                        commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(captureHostFolderName));
+                    } else {
+                        // opening relative file path doesn't work in WSL
+                        open(captureHostFolderName);
+                    }
                 }
             });
     }

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -1,6 +1,6 @@
 import { platform } from "os";
 import { relative } from "path";
-import { Uri, commands, window, workspace } from "vscode";
+import { Uri, commands, window, workspace, env } from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import * as semver from "semver";
 import { failed, map as errmap, Errorable } from "../commands/utils/errorable";
@@ -464,7 +464,13 @@ spec:
     }
 
     private handleOpenFolder(path: string) {
-        commands.executeCommand("revealFileInOS", Uri.file(path));
+        // Open the folder in the respective file explorer
+        if (env.remoteName === "wsl") {
+            commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(path));
+        } else {
+            // revealFileInOS doesn't work in WSL
+            commands.executeCommand("revealFileInOS", Uri.file(path));
+        }
     }
 
     private async handleGetInterfaces(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {


### PR DESCRIPTION
Observed small issue where attempting to view downloaded files didn't work in TCP Dump & Retina panels - specifically in WSL.

It seems that the `revealFileInOS` & `open` functions both don't appear to work in WSL, so this PR implements a small fix to check for WSL environments & if detected, use the `remote-wsl.revealInExplorer` command instead.

.vsix for testing: 
[vscode-aks-tools-1.6.4-wslfolderfix.vsix.zip](https://github.com/user-attachments/files/19635675/vscode-aks-tools-1.6.4-wslfolderfix.vsix.zip)

