### PR TITLE
Updating vscode styling variables

### DIFF
--- a/src/panels/RetinaCapturePanel.ts
+++ b/src/panels/RetinaCapturePanel.ts
@@ -12,6 +12,7 @@ import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { getLocalKubectlCpPath } from "./utilities/KubectlNetworkHelper";
 import * as semver from "semver";
+import { commands, env } from "vscode";
 
 export class RetinaCapturePanel extends BasePanel<"retinaCapture"> {
     constructor(extensionUri: Uri) {
@@ -198,7 +199,12 @@ spec:
             )
             .then((selection) => {
                 if (selection === goToFolder) {
-                    open(captureHostFolderName);
+                    if (env.remoteName === "wsl") {
+                        commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(captureHostFolderName));
+                    } else {
+                        // opening relative file path doesn't work in WSL
+                        open(captureHostFolderName);
+                    }
                 }
             });
     }

--- a/src/panels/TcpDumpPanel.ts
+++ b/src/panels/TcpDumpPanel.ts
@@ -1,6 +1,6 @@
 import { platform } from "os";
 import { relative } from "path";
-import { Uri, commands, window, workspace } from "vscode";
+import { Uri, commands, window, workspace, env } from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import * as semver from "semver";
 import { failed, map as errmap, Errorable } from "../commands/utils/errorable";
@@ -464,7 +464,13 @@ spec:
     }
 
     private handleOpenFolder(path: string) {
-        commands.executeCommand("revealFileInOS", Uri.file(path));
+        // Open the folder in the respective file explorer
+        if (env.remoteName === "wsl") {
+            commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(path));
+        } else {
+            // revealFileInOS doesn't work in WSL
+            commands.executeCommand("revealFileInOS", Uri.file(path));
+        }
     }
 
     private async handleGetInterfaces(node: NodeName, webview: MessageSink<ToWebViewMsgDef>) {

--- a/webview-ui/src/components/CustomDropdown.module.css
+++ b/webview-ui/src/components/CustomDropdown.module.css
@@ -14,9 +14,9 @@
     width: 100%;
     cursor: pointer;
     text-align: left;
-    height: calc(var(--input-height) * 1px);
-    color: var(--input-foreground);
-    background-color: var(--input-background);
+    height: 1.5rem;
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-input-background);
     padding: 0px 2.2rem 0px 9px;
     box-sizing: border-box;
     border-radius: 2px;
@@ -28,13 +28,13 @@
 }
 
 .dropdownButton:hover {
-    background-color: var(--input-background);
+    background-color: var(--vscode-input-background);
     border: 1px solid var(--vscode-dropdown-border);
 }
 
 .dropdownButton:disabled {
     cursor: not-allowed;
-    background-color: var(--input-background);
+    background-color: var(--vscode-input-background);
 }
 
 .dropdownButton:focus {
@@ -44,7 +44,7 @@
 .dropdownMenu {
     position: absolute;
     width: 100%;
-    background-color: var(--input-background);
+    background-color: var(--vscode-input-background);
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
     z-index: 1;
     max-height: 10rem;
@@ -66,7 +66,7 @@
 
 .dropdownOption {
     cursor: pointer;
-    background-color: var(--input-background);
+    background-color: var(--vscode-input-background);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -123,9 +123,9 @@ hr {
 
 input[type="text"],
 input[type="password"] {
-    height: calc(var(--input-height) * 1px);
-    color: var(--input-foreground);
-    background-color: var(--input-background);
+    height: 1.5rem;
+    color: var(--vscode-foreground);
+    background-color: var(--vscode-input-background);
     border: 1px solid var(--vscode-dropdown-border);
     padding: 0 9px;
     box-sizing: border-box;
@@ -195,10 +195,10 @@ fieldset:disabled label {
 }
 
 select {
-    height: calc(var(--input-height) * 1px);
-    color: var(--input-foreground);
-    background-color: var(--input-background);
-    border: 1px solid var(--input-border);
+    height: 1.5rem;
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border);
     padding: 0px 0px 0px 4px;
     box-sizing: border-box;
     font-family: inherit;
@@ -281,9 +281,9 @@ fieldset {
 }
 
 input[type="number"] {
-    height: calc(var(--input-height) * 1px);
-    color: var(--input-foreground);
-    background-color: var(--input-background);
+    height: 1.5rem;
+    color: var(--vscode-foreground);
+    background-color: var(--vscode-input-background);
     border: 0;
     padding: 0 calc(var(--design-unit) * 2px + 1px);
     box-sizing: border-box;


### PR DESCRIPTION
It appears that some of the variable names used to access vscode global variables are no longer recognized, resulting in missing background colors & incorrect sizing. The live version hasn't been affected, and the relevant css files haven't been changed in 2+ releases, which leads me to believe it's likely that an update to VSCode caused this. When debugging the extension with the live repo code, (even code prior to 1.6.4 update), the error is observed.

This PR makes slight change for the variables to fix this.
- Added vscode prefix to identifiers that no longer work. 

This is what was observed : (missing colors & misalignments)
<!-- Second Image -->
<img src="https://github.com/user-attachments/assets/7730b126-6cb1-4f7a-9dd2-5ba47fded289" alt="Description of image" height="150" width="300">

<!-- Third Image -->
<img src="https://github.com/user-attachments/assets/e1c60b98-44c8-4e29-aa52-698e44bdeced" alt="Description of image" height="150" width="300">

What it should be:
<!-- First Image -->
<img src="https://github.com/user-attachments/assets/b00426f7-1c12-4011-8bb5-11416c1fe52c" alt="Description of image" height="150" width="300">

Note: This would need to be merged for next release to ensure proper input styling.

.vsix for testing: [vscode-aks-tools-1.6.4-inputstylingfix.vsix.zip](https://github.com/user-attachments/files/19636082/vscode-aks-tools-1.6.4-inputstylingfix.vsix.zip)


