### PR TITLE
Publish release 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.6.5]
+
+* Update/detector upgrade scenario (#1348)
+* Update retina doc (#1364)
+* Fixing folder open for wsl (#1349)
+* Custom elements docs (#1331)
+* All webview-ui-toolkit content removed (#1330)
+* Dependabot updates and bumps.
+
+Thank you so much to @ReinierCC, @bosesuneha, @tejhan for contributions, testing and reviews.
+
+
 ## [1.6.4]
 
 * Reverting @azure/identity update to fix windows issue (#1345) Fix for [this bug](https://github.com/Azure/vscode-aks-tools/issues/1344)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
@@ -39,6 +39,7 @@
                 "node-fetch": "^3.3.2",
                 "rxjs": "^7.8.2",
                 "semver": "^7.7.1",
+                "sinon": "^20.0.0",
                 "tmp": "^0.2.3",
                 "uuid": "^11.1.0",
                 "vscode-kubernetes-tools-api": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is open for the release of `1.6.5` this pr contains a key fix/features/updates and detail as below:

* Update/detector upgrade scenario (#1348)
* Update retina doc (#1364)
* Fixing folder open for wsl (#1349)
* Custom elements docs (#1331)
* All webview-ui-toolkit content removed (#1330)
* Dependabot updates and bumps.

Thank you so much to @tejhan, @bosesuneha, @ReinierCC, @davidgamero, @qpetraroia, @gambtho for contributions, testing and reviews.

### VSIX to test:

[vscode-aks-tools-1.6.5-test.vsix.zip](https://github.com/user-attachments/files/19659185/vscode-aks-tools-1.6.5-test.vsix.zip)
