### PR TITLE
Add the enable copilot flag for gh copilot feature scenario.

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
                     "default": "v0.0.26",
                     "title": "Retina repository release tag",
                     "description": "Release tag for the stable Retina tool release."
+                },
+                "vs-kubernetes.enable-gh-copilot": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set to true to enable GH Copilot hook."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
                     "title": "Retina repository release tag",
                     "description": "Release tag for the stable Retina tool release."
                 },
-                "vs-kubernetes.enable-gh-copilot": {
+                "aks.copilotEnabled": {
                     "type": "boolean",
                     "default": true,
                     "description": "Set to true to enable GH Copilot hook."

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -10,11 +10,19 @@ import {
 import { window } from "vscode";
 import { checkExtension, handleExtensionDoesNotExist } from "../utils/ghCopilotHandlers";
 import { logGitHubCopilotPluginEvent } from "../../plugins/shared/telemetry/logger";
+import { getAIRecommendationsInfoState } from "../utils/config";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 
 export async function aksCreateClusterFromCopilot(): Promise<void> {
     const checkGitHubCopilotExtension = checkExtension(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
+
+    const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
+
+    if (!ghcopilotUserSettingsFlag) {
+        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
+        return;
+    }
 
     if (!checkGitHubCopilotExtension) {
         handleExtensionDoesNotExist(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);

--- a/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
+++ b/src/commands/aksCreateCluster/aksCreateClusterFromCopilot.ts
@@ -20,7 +20,9 @@ export async function aksCreateClusterFromCopilot(): Promise<void> {
     const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
 
     if (!ghcopilotUserSettingsFlag) {
-        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
+        vscode.window.showWarningMessage(
+            "The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.",
+        );
         return;
     }
 

--- a/src/commands/aksDeployManifest/aksDeployManifest.ts
+++ b/src/commands/aksDeployManifest/aksDeployManifest.ts
@@ -11,6 +11,7 @@ import { longRunning } from "../utils/host";
 import { invokeKubectlCommand } from "../utils/kubectl";
 import { createTempFile } from "../utils/tempfile";
 import { logGitHubCopilotPluginEvent } from "../../plugins/shared/telemetry/logger";
+import { getAIRecommendationsInfoState } from "../utils/config";
 
 const GITHUBCOPILOT_FOR_AZURE_VSCODE_ID = "ms-azuretools.vscode-azure-github-copilot";
 const YAML_GLOB_PATTERN = "**/*.yaml";
@@ -21,6 +22,13 @@ const BASE_WORKLOADS_PATH = "/workloads";
 export async function aksDeployManifest() {
     // Check if GitHub Copilot for Azure extension is installed
     const checkGitHubCopilotExtension = checkExtension(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
+
+    const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
+    
+    if (!ghcopilotUserSettingsFlag) {
+        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
+        return;
+    }
 
     if (!checkGitHubCopilotExtension) {
         handleExtensionDoesNotExist(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);

--- a/src/commands/aksDeployManifest/aksDeployManifest.ts
+++ b/src/commands/aksDeployManifest/aksDeployManifest.ts
@@ -24,9 +24,11 @@ export async function aksDeployManifest() {
     const checkGitHubCopilotExtension = checkExtension(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
 
     const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
-    
+
     if (!ghcopilotUserSettingsFlag) {
-        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
+        vscode.window.showWarningMessage(
+            "The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.",
+        );
         return;
     }
 

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -4,7 +4,7 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { KubectlDataProvider, KubectlPanel } from "../../panels/KubectlPanel";
 import { CommandResponse } from "../../plugins/shared/pluginResponses";
 import { getExtension } from "../utils/host";
-import { getKubectlCustomCommands } from "../utils/config";
+import { getAIRecommendationsInfoState, getKubectlCustomCommands } from "../utils/config";
 import { failed } from "../utils/errorable";
 import { createTempFile } from "../utils/tempfile";
 import { getReadySessionProvider } from "../../auth/azureAuth";
@@ -20,6 +20,13 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
 
     if (!checkGitHubCopilotExtension) {
         handleExtensionDoesNotExist(GITHUBCOPILOT_FOR_AZURE_VSCODE_ID);
+        return;
+    }
+
+    const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
+    
+    if (!ghcopilotUserSettingsFlag) {
+        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
         return;
     }
 

--- a/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
+++ b/src/commands/aksOpenKubectlPanel/aksOpenKubectlPanel.ts
@@ -24,9 +24,11 @@ export async function aksOpenKubectlPanel(_context: IActionContext, target: unkn
     }
 
     const ghcopilotUserSettingsFlag = getAIRecommendationsInfoState();
-    
+
     if (!ghcopilotUserSettingsFlag) {
-        vscode.window.showWarningMessage("The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.");
+        vscode.window.showWarningMessage(
+            "The AKS extension Copilot flag is currently set to false. Please set this flag to true in order to enable this functionality.",
+        );
         return;
     }
 

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -356,7 +356,10 @@ async function addValueToConfigAtScope(
     createIfNotExist: boolean,
 ): Promise<void> {
     if (!createIfNotExist) {
-        if (!valueAtScope || (typeof valueAtScope === 'object' && valueAtScope !== null && !(configKey in valueAtScope))) {
+        if (
+            !valueAtScope ||
+            (typeof valueAtScope === "object" && valueAtScope !== null && !(configKey in valueAtScope))
+        ) {
             // If the value is not at this scope and we are not creating it, return
             // This means that the value is not set at this scope and we are not allowed to create it
             return;

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -337,7 +337,7 @@ async function atAllConfigScopes<T>(fn: ConfigUpdater<T>, configKey: string, val
 }
 
 export function getAIRecommendationsInfoState(): boolean | undefined {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)["vs-kubernetes.enable-gh-copilot"];
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY).get<boolean>("vs-kubernetes.enable-gh-copilot");
 }
 
 export function setAIRecommendationsInfoState(selectedoption: boolean): void {

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -7,8 +7,6 @@ import { RetinaDownloadConfig } from "../periscope/models/RetinaDownloadConfig";
 import { isObject } from "./runtimeTypes";
 import { Environment, EnvironmentParameters } from "@azure/ms-rest-azure-env";
 
-const EXTENSION_CONFIG_KEY = "vs-kubernetes";
-
 export function getConfiguredAzureEnv(): Environment {
     // See:
     // https://github.com/microsoft/vscode/blob/eac16e9b63a11885b538db3e0b533a02a2fb8143/extensions/microsoft-authentication/package.json#L40-L99
@@ -321,55 +319,6 @@ export async function deleteKubectlCustomCommand(name: string) {
         .update("azure.customkubectl.commands", commands, vscode.ConfigurationTarget.Global, true);
 }
 
-type ConfigUpdater<T> = (
-    configKey: string,
-    value: T,
-    scope: vscode.ConfigurationTarget,
-    valueAtScope: unknown,
-    createIfNotExist: boolean,
-) => Promise<void>;
-
-async function atAllConfigScopes<T>(fn: ConfigUpdater<T>, configKey: string, value: T): Promise<void> {
-    const config = vscode.workspace.getConfiguration().inspect(EXTENSION_CONFIG_KEY)!;
-    await fn(configKey, value, vscode.ConfigurationTarget.Global, config.globalValue, true);
-    await fn(configKey, value, vscode.ConfigurationTarget.Workspace, config.workspaceValue, true);
-    await fn(configKey, value, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, true);
-}
-
 export function getAIRecommendationsInfoState(): boolean | undefined {
-    return vscode.workspace.getConfiguration()["vs-kubernetes.copilotEnabled"];
-}
-
-export function setAIRecommendationsInfoState(selectedoption: boolean): void {
-    setConfigValue("vs-kubernetes.copilotEnabled", selectedoption);
-}
-
-export async function setConfigValue(configKey: string, value: unknown): Promise<void> {
-    await atAllConfigScopes(addValueToConfigAtScope, configKey, value);
-}
-
-async function addValueToConfigAtScope(
-    configKey: string,
-    value: unknown,
-    scope: vscode.ConfigurationTarget,
-    valueAtScope: unknown,
-    createIfNotExist: boolean,
-): Promise<void> {
-    if (!createIfNotExist) {
-        if (
-            !valueAtScope ||
-            (typeof valueAtScope === "object" && valueAtScope !== null && !(configKey in valueAtScope))
-        ) {
-            // If the value is not at this scope and we are not creating it, return
-            // This means that the value is not set at this scope and we are not allowed to create it
-            return;
-        }
-    }
-
-    let newValue: unknown = {};
-    if (valueAtScope) {
-        newValue = Object.assign({}, valueAtScope);
-    }
-    (newValue as Record<string, unknown>)[configKey] = value;
-    await vscode.workspace.getConfiguration().update(EXTENSION_CONFIG_KEY, newValue, scope);
+    return vscode.workspace.getConfiguration("aks")["copilotEnabled"];
 }

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -332,8 +332,8 @@ type ConfigUpdater<T> = (
 async function atAllConfigScopes<T>(fn: ConfigUpdater<T>, configKey: string, value: T): Promise<void> {
     const config = vscode.workspace.getConfiguration().inspect(EXTENSION_CONFIG_KEY)!;
     await fn(configKey, value, vscode.ConfigurationTarget.Global, config.globalValue, true);
-    await fn(configKey, value, vscode.ConfigurationTarget.Workspace, config.workspaceValue, false);
-    await fn(configKey, value, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, false);
+    await fn(configKey, value, vscode.ConfigurationTarget.Workspace, config.workspaceValue, true);
+    await fn(configKey, value, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, true);
 }
 
 export function getAIRecommendationsInfoState(): boolean | undefined {

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -337,11 +337,11 @@ async function atAllConfigScopes<T>(fn: ConfigUpdater<T>, configKey: string, val
 }
 
 export function getAIRecommendationsInfoState(): boolean | undefined {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY).get<boolean>("vs-kubernetes.enable-gh-copilot");
+    return vscode.workspace.getConfiguration()["vs-kubernetes.copilotEnabled"];
 }
 
 export function setAIRecommendationsInfoState(selectedoption: boolean): void {
-    setConfigValue("vs-kubernetes.enable-gh-copilot", selectedoption);
+    setConfigValue("vs-kubernetes.copilotEnabled", selectedoption);
 }
 
 export async function setConfigValue(configKey: string, value: unknown): Promise<void> {


### PR DESCRIPTION
This PR is to add an enable flag which can be set using `setAIRecommendationsInfoState` or get the state by using `getAIRecommendationsInfoState` for the case of enablement, one such way is like this below as sample:

Below is **just sample how this flag could be used**. cc: @tejhan and @kejatura-dev fyi please. ❤️ 

```*.ts
       // Sample user prompt to enable the Azure Kubernetes Service GH CoPilot Feature
        const value = await vscode.window.showInformationMessage(
            `Do you want to enable the Azure Kubernetes Service GH CoPilot Feature?`,
            "Yes",
            "No",
        );
        if (value === "Yes") {
            setAIRecommendationsInfoState(true);
        }
        if (value === "No") {
            setAIRecommendationsInfoState(false);
        }
```

VSIX to test:

* [vscode-aks-tools-1.6.6-copilotEnabled-test11.vsix.zip](https://github.com/user-attachments/files/20113174/vscode-aks-tools-1.6.6-copilotEnabled-test11.vsix.zip)

  

