### PR TITLE
Publish release 1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.6.7]
+
+* Add the enable copilot flag for gh copilot feature scenario. (#1408)
+* Dependabot updates and bumps.
+
+Thank you so much to @tejhan, @kejatura-dev, @qpetraroia for review contributions, testing and reviews.
+
 ## [1.6.6]
 
 * Automatically add newly created clusters to user's selected clusters (#1293)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.6",
+    "version": "1.6.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.6",
+            "version": "1.6.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.6",
+    "version": "1.6.7",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "icon": "resources/aks-tools.png",


### PR DESCRIPTION
This PR is open for the release of `1.6.7` this pr contains following:

* Add the enable copilot flag for gh copilot feature scenario. (#1408)
* Dependabot updates and bumps.

Thank you so much to @tejhan, @kejatura-dev, @qpetraroia for review contributions, testing and reviews.

**VSIX for test**

* [vscode-aks-tools-1.6.7-test.vsix.zip](https://github.com/user-attachments/files/20117695/vscode-aks-tools-1.6.7-test.vsix.zip)
