### PR TITLE
Fix the runner break as the version is deprecated.

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
ubuntu-20.04 is fully deprecated by GitHub and can no longer be used: https://github.com/actions/runner-images/issues/11101 

Thanks.