### PR TITLE
Adding namespace awareness & different runtime support for KAITO models

### DIFF
--- a/src/commands/aksKaito/aksKaitoManage.ts
+++ b/src/commands/aksKaito/aksKaitoManage.ts
@@ -76,7 +76,7 @@ export default async function aksKaitoManage(_context: IActionContext, target: u
     }
 
     // The logic below is to acquire the initial deployment data.
-    const command = `get workspace -o json`;
+    const command = `get workspace -A -o json`;
     const kubectlresult = await invokeKubectlCommand(kubectl, kubeConfigFile.filePath, command);
     if (failed(kubectlresult)) {
         vscode.window.showErrorMessage(`Error retrieving workspaces: ${kubectlresult.error}`);

--- a/src/commands/aksKaito/aksKaitoManage.ts
+++ b/src/commands/aksKaito/aksKaitoManage.ts
@@ -95,6 +95,7 @@ export default async function aksKaitoManage(_context: IActionContext, target: u
             inferenceReady: inferenceReady,
             workspaceReady: workspaceReady,
             age: convertAgeToMinutes(item.metadata?.creationTimestamp),
+            namespace: item.metadata?.namespace,
         });
     }
 

--- a/src/commands/aksKaito/aksKaitoTest.ts
+++ b/src/commands/aksKaito/aksKaitoTest.ts
@@ -11,7 +11,7 @@ import { KaitoTestPanel, KaitoTestPanelDataProvider } from "../../panels/KaitoTe
 
 export default async function aksKaitoTest(
     _context: IActionContext,
-    { target, modelName }: { target: unknown; modelName: string },
+    { target, modelName, namespace }: { target: unknown; modelName: string; namespace: string },
 ): Promise<void> {
     const cloudExplorer = await k8s.extension.cloudExplorer.v1;
     if (!cloudExplorer.available) {
@@ -67,6 +67,7 @@ export default async function aksKaitoTest(
         kubeConfigFile.filePath,
         sessionProvider.result,
         modelName,
+        namespace,
     );
     panel.show(dataProvider, kubeConfigFile);
 }

--- a/src/panels/KaitoManagePanel.ts
+++ b/src/panels/KaitoManagePanel.ts
@@ -154,7 +154,7 @@ export class KaitoManagePanelDataProvider implements PanelDataProvider<"kaitoMan
 
     // Updates the current state of models on the cluster
     private async updateModels(webview: MessageSink<ToWebViewMsgDef>) {
-        const command = `get workspace -o json`;
+        const command = `get workspace -A -o json`;
         const kubectlresult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
         if (failed(kubectlresult)) {
             webview.postMonitorUpdate({

--- a/src/panels/KaitoManagePanel.ts
+++ b/src/panels/KaitoManagePanel.ts
@@ -188,7 +188,7 @@ export class KaitoManagePanelDataProvider implements PanelDataProvider<"kaitoMan
                 inferenceReady: inferenceReady,
                 workspaceReady: workspaceReady,
                 age: convertAgeToMinutes(item.metadata?.creationTimestamp),
-                namespace: item.metadata?.namespace,
+                namespace: item.metadata?.namespace ?? "default",
             });
         }
 

--- a/src/panels/KaitoModelsPanel.ts
+++ b/src/panels/KaitoModelsPanel.ts
@@ -69,6 +69,7 @@ export class KaitoModelsPanelDataProvider implements PanelDataProvider<"kaitoMod
             inferenceReady: null,
             workspaceReady: null,
             age: 0,
+            namespace: "",
         } as InitialState;
     }
     getTelemetryDefinition(): TelemetryDefinition<"kaitoModels"> {
@@ -103,7 +104,11 @@ export class KaitoModelsPanelDataProvider implements PanelDataProvider<"kaitoMod
     private async handleKaitoManageRedirectRequest() {
         vscode.commands.executeCommand("aks.aksKaitoManage", this.newtarget);
     }
-    private async handleGenerateCRDRequest(yaml: string) {
+    private async handleGenerateCRDRequest(yaml: string | undefined) {
+        if (!yaml) {
+            vscode.window.showErrorMessage("Error loading yaml for model");
+            return;
+        }
         const doc = await vscode.workspace.openTextDocument({
             content: yaml,
             language: "yaml",
@@ -198,10 +203,14 @@ export class KaitoModelsPanelDataProvider implements PanelDataProvider<"kaitoMod
     // This function checks quota & existence of workspace, then deploys model
     private async handleDeployKaitoRequest(
         model: string,
-        yaml: string,
+        yaml: string | undefined,
         gpu: string,
         webview: MessageSink<ToWebViewMsgDef>,
     ) {
+        if (!yaml) {
+            vscode.window.showErrorMessage(`Error loading yaml for model: ${model}`);
+            return;
+        }
         this.cancelTokens.set(model, false);
         this.handleResetStateRequest(webview);
         // This prevents the user from redeploying while pre-deployment checks are being performed

--- a/src/panels/KaitoTestPanel.ts
+++ b/src/panels/KaitoTestPanel.ts
@@ -146,7 +146,6 @@ export class KaitoTestPanelDataProvider implements PanelDataProvider<"kaitoTest"
                 // retrieve the logs from the curl pod
                 const logsResult = await this.kubectl.api.invokeCommand(logsCommand);
                 if (logsResult && logsResult.code === 0) {
-                    console.log(logsResult.stdout);
                     const parsedOutput = JSON.parse(logsResult.stdout);
                     let responseText;
                     if (runtime === "transformers") {

--- a/src/panels/KaitoTestPanel.ts
+++ b/src/panels/KaitoTestPanel.ts
@@ -31,6 +31,7 @@ export class KaitoTestPanelDataProvider implements PanelDataProvider<"kaitoTest"
         readonly kubeConfigFilePath: string,
         readonly sessionProvider: ReadyAzureSessionProvider,
         readonly modelName: string,
+        readonly namespace: string,
     ) {
         this.clusterName = clusterName;
         this.subscriptionId = subscriptionId;
@@ -41,6 +42,7 @@ export class KaitoTestPanelDataProvider implements PanelDataProvider<"kaitoTest"
         this.sessionProvider = sessionProvider;
         // corrects for some version naming
         this.modelName = modelName;
+        this.namespace = namespace;
     }
     getTitle(): string {
         return `Test KAITO Model`;
@@ -99,7 +101,12 @@ export class KaitoTestPanelDataProvider implements PanelDataProvider<"kaitoTest"
             const podName = `curl-${Date.now()}`;
             try {
                 // retrieving the cluster IP
-                const clusterIP = await getClusterIP(this.kubeConfigFilePath, this.modelName, this.kubectl);
+                const clusterIP = await getClusterIP(
+                    this.kubeConfigFilePath,
+                    this.modelName,
+                    this.kubectl,
+                    this.namespace,
+                );
                 if (clusterIP === "") {
                     this.isQueryInProgress = false;
                     vscode.window.showErrorMessage(`Error connecting to cluster. Please check pod logs and try again`);

--- a/src/panels/utilities/KaitoHelpers.ts
+++ b/src/panels/utilities/KaitoHelpers.ts
@@ -215,8 +215,11 @@ export async function getClusterIP(
     kubeConfigFilePath: string,
     modelName: string,
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    namespace: string,
 ) {
-    const ipCommand = `--kubeconfig="${kubeConfigFilePath}" get svc ${modelName} -o jsonpath="{.spec.clusterIP}"`;
+    void namespace;
+    const ipCommand = `--kubeconfig="${kubeConfigFilePath}" get svc -n ${namespace} ${modelName} -o jsonpath="{.spec.clusterIP}" `;
+    console.log(ipCommand);
     const ipResult = await kubectl.api.invokeCommand(ipCommand);
     if (ipResult && ipResult.code === 0) {
         return ipResult.stdout;

--- a/src/panels/utilities/KaitoHelpers.ts
+++ b/src/panels/utilities/KaitoHelpers.ts
@@ -158,14 +158,12 @@ export async function createCurlPodCommand(
     if (process.platform === "win32") {
         let windowsCreateCommand;
         if (runtime === "transformers") {
-            console.log("runtime is transformers");
             windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
 --image=curlimages/curl -- curl -X POST http://${clusterIP}/chat -H "accept: application/json" -H \
 "Content-Type: application/json" -d "{\\"model\\":\\"${modelName}\\", \\"prompt\\":\\"${escapeSpecialChars(prompt)}\\", \
 \\"temperature\\":${temperature}, \\"top_p\\":${topP}, \\"top_k\\":${topK}, \
 \\"repetition_penalty\\":${repetitionPenalty}, \\"max_tokens\\":${maxLength}}"`;
         } else {
-            console.log("runtime is not transformers");
             windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
 --image=curlimages/curl -- curl -X POST http://${clusterIP}/v1/completions -H "accept: application/json" -H \
 "Content-Type: application/json" -d "{\\"model\\":\\"${modelName}\\", \\"prompt\\":\\"${escapeSpecialChars(prompt)}\\", \
@@ -226,7 +224,6 @@ export async function getClusterIP(
 ) {
     void namespace;
     const ipCommand = `--kubeconfig="${kubeConfigFilePath}" get svc -n ${namespace} ${modelName} -o jsonpath="{.spec.clusterIP}" `;
-    console.log(ipCommand);
     const ipResult = await kubectl.api.invokeCommand(ipCommand);
     if (ipResult && ipResult.code === 0) {
         return ipResult.stdout;
@@ -245,7 +242,6 @@ export async function getWorkspaceRuntime(
     namespace: string,
 ): Promise<string> {
     const command = `--kubeconfig="${kubeConfigFilePath}" get workspace -n ${namespace} ${modelName} -o json`;
-    console.log(command);
     const kubectlresult = await kubectl.api.invokeCommand(command);
     if (kubectlresult && kubectlresult.code === 0) {
         const json = JSON.parse(kubectlresult.stdout);

--- a/src/panels/utilities/KaitoHelpers.ts
+++ b/src/panels/utilities/KaitoHelpers.ts
@@ -146,6 +146,7 @@ export async function createCurlPodCommand(
     topK: number,
     repetitionPenalty: number,
     maxLength: number,
+    runtime: string = "vllm",
 ) {
     modelName = modelName.startsWith("workspace-") ? modelName.replace("workspace-", "") : modelName;
     if (modelName.startsWith("phi-3-5")) {
@@ -155,33 +156,39 @@ export async function createCurlPodCommand(
     }
     // Command for windows platforms (Needs custom character escaping)
     if (process.platform === "win32") {
-        // v3 command
-        // const windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
-        // --image=curlimages/curl -- curl -X POST http://${clusterIP}/v1/completions -H "accept: application/json" -H \
-        // "Content-Type: application/json" -d "{\\"prompt\\":\\"${escapeSpecialChars(prompt)}\\", \
-        // \\"generate_kwargs\\":{\\"temperature\\":${temperature}, \\"top_p\\":${topP}, \\"top_k\\":${topK}, \
-        // \\"repetition_penalty\\":${repetitionPenalty}, \\"max_length\\":${maxLength}}}"`;
-        // v4 command
-        const windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
+        let windowsCreateCommand;
+        if (runtime === "transformers") {
+            console.log("runtime is transformers");
+            windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
+--image=curlimages/curl -- curl -X POST http://${clusterIP}/chat -H "accept: application/json" -H \
+"Content-Type: application/json" -d "{\\"model\\":\\"${modelName}\\", \\"prompt\\":\\"${escapeSpecialChars(prompt)}\\", \
+\\"temperature\\":${temperature}, \\"top_p\\":${topP}, \\"top_k\\":${topK}, \
+\\"repetition_penalty\\":${repetitionPenalty}, \\"max_tokens\\":${maxLength}}"`;
+        } else {
+            console.log("runtime is not transformers");
+            windowsCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
 --image=curlimages/curl -- curl -X POST http://${clusterIP}/v1/completions -H "accept: application/json" -H \
 "Content-Type: application/json" -d "{\\"model\\":\\"${modelName}\\", \\"prompt\\":\\"${escapeSpecialChars(prompt)}\\", \
 \\"temperature\\":${temperature}, \\"top_p\\":${topP}, \\"top_k\\":${topK}, \
 \\"repetition_penalty\\":${repetitionPenalty}, \\"max_tokens\\":${maxLength}}"`;
+        }
         return windowsCreateCommand;
     } else {
         // Command for UNIX platforms (Should work for all other process.platform return values besides win32)
-        // v3 command
-        //  const unixCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
-        // --image=curlimages/curl -- curl -X POST http://${clusterIP}/v1/completions -H "accept: application/json" -H \
-        // "Content-Type: application/json" -d '{"prompt":"${escapeSpecialChars(prompt)}", \
-        // "generate_kwargs":{"temperature":${temperature}, "top_p":${topP}, "top_k":${topK}, \
-        // "repetition_penalty":${repetitionPenalty}, "max_length":${maxLength}}}'`;
-        // v4 command
-        const unixCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
+        let unixCreateCommand;
+        if (runtime === "transformers") {
+            unixCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
+--image=curlimages/curl -- curl -X POST http://${clusterIP}/chat -H "accept: application/json" -H \
+"Content-Type: application/json" -d '{"model":"${modelName}", "prompt":"${escapeSpecialChars(prompt)}", \
+"temperature":${temperature}, "top_p":${topP}, "top_k":${topK}, "repetition_penalty":${repetitionPenalty}, \
+ "max_tokens":${maxLength}}'`;
+        } else {
+            unixCreateCommand = `--kubeconfig="${kubeConfigFilePath}" run -it --restart=Never ${podName} \
 --image=curlimages/curl -- curl -X POST http://${clusterIP}/v1/completions -H "accept: application/json" -H \
 "Content-Type: application/json" -d '{"model":"${modelName}", "prompt":"${escapeSpecialChars(prompt)}", \
 "temperature":${temperature}, "top_p":${topP}, "top_k":${topK}, "repetition_penalty":${repetitionPenalty}, \
  "max_tokens":${maxLength}}'`;
+        }
         return unixCreateCommand;
     }
 }
@@ -229,6 +236,33 @@ export async function getClusterIP(
         vscode.window.showErrorMessage(`Failed to connect to cluster: ${ipResult.code}\nError: ${ipResult.stderr}`);
     }
     return "";
+}
+
+export async function getWorkspaceRuntime(
+    kubeConfigFilePath: string,
+    modelName: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    namespace: string,
+): Promise<string> {
+    const command = `--kubeconfig="${kubeConfigFilePath}" get workspace -n ${namespace} ${modelName} -o json`;
+    console.log(command);
+    const kubectlresult = await kubectl.api.invokeCommand(command);
+    if (kubectlresult && kubectlresult.code === 0) {
+        const json = JSON.parse(kubectlresult.stdout);
+        const runtime = json.metadata?.annotations?.["kaito.sh/runtime"];
+        if (runtime === "transformers") {
+            return "transformers";
+        } else {
+            return "vllm";
+        }
+    } else if (kubectlresult === undefined) {
+        vscode.window.showErrorMessage(`Failed to get runtime for model ${modelName}`);
+    } else if (kubectlresult.code !== 0) {
+        vscode.window.showErrorMessage(
+            `Failed to connect to cluster: ${kubectlresult.code}\nError: ${kubectlresult.stderr}`,
+        );
+    }
+    return "vllm"; // Default to vllm if runtime is not found
 }
 
 // deploys model with given yaml & returns errorable promise

--- a/src/webview-contract/webviewDefinitions/kaitoManage.ts
+++ b/src/webview-contract/webviewDefinitions/kaitoManage.ts
@@ -12,14 +12,15 @@ export type ModelState = {
     inferenceReady: boolean | null;
     workspaceReady: boolean | null;
     age: number;
+    namespace: string;
 };
 
 export type ToVsCodeMsgDef = {
     monitorUpdateRequest: {};
-    deleteWorkspaceRequest: { model: string };
-    redeployWorkspaceRequest: { modelName: string; modelYaml: string };
+    deleteWorkspaceRequest: { model: string; namespace: string };
+    redeployWorkspaceRequest: { modelName: string; modelYaml: string | undefined; namespace: string };
     getLogsRequest: {};
-    testWorkspaceRequest: { modelName: string };
+    testWorkspaceRequest: { modelName: string; namespace: string };
 };
 
 export type ToWebViewMsgDef = {

--- a/src/webview-contract/webviewDefinitions/kaitoModels.ts
+++ b/src/webview-contract/webviewDefinitions/kaitoModels.ts
@@ -11,8 +11,8 @@ export interface InitialState {
 }
 
 export type ToVsCodeMsgDef = {
-    generateCRDRequest: { model: string };
-    deployKaitoRequest: { model: string; yaml: string; gpu: string };
+    generateCRDRequest: { model: string | undefined };
+    deployKaitoRequest: { model: string; yaml: string | undefined; gpu: string };
     resetStateRequest: {};
     cancelRequest: { model: string };
     kaitoManageRedirectRequest: {};

--- a/webview-ui/src/KaitoManage/KaitoManage.tsx
+++ b/webview-ui/src/KaitoManage/KaitoManage.tsx
@@ -25,15 +25,15 @@ export function KaitoManage(initialState: InitialState) {
         return () => clearInterval(intervalId);
     });
 
-    async function deleteWorkspace(model: string) {
-        vscode.postDeleteWorkspaceRequest({ model: model.replace(".", "-") });
+    async function deleteWorkspace(model: string, namespace: string) {
+        vscode.postDeleteWorkspaceRequest({ model: model.replace(".", "-"), namespace: namespace });
     }
-    async function redeployWorkspace(modelName: string, modelYaml: string) {
-        vscode.postRedeployWorkspaceRequest({ modelName: modelName, modelYaml: modelYaml });
+    async function redeployWorkspace(modelName: string, modelYaml: string | undefined, namespace: string) {
+        vscode.postRedeployWorkspaceRequest({ modelName: modelName, modelYaml: modelYaml, namespace: namespace });
     }
 
-    function testWorkspace(modelName: string) {
-        vscode.postTestWorkspaceRequest({ modelName: modelName });
+    function testWorkspace(modelName: string, namespace: string) {
+        vscode.postTestWorkspaceRequest({ modelName: modelName, namespace: namespace });
     }
 
     return (
@@ -61,7 +61,7 @@ export function KaitoManage(initialState: InitialState) {
                                             <>
                                                 <div className={styles.buttonDiv}>
                                                     <button
-                                                        onClick={() => deleteWorkspace(model.name)}
+                                                        onClick={() => deleteWorkspace(model.name, model.namespace)}
                                                         className={styles.button}
                                                     >
                                                         Cancel
@@ -86,6 +86,7 @@ export function KaitoManage(initialState: InitialState) {
                                                         redeployWorkspace(
                                                             model.name,
                                                             generateKaitoYAML(model.name).yaml,
+                                                            model.namespace,
                                                         )
                                                     }
                                                     className={`${styles.button} ${styles.redeployButton}`}
@@ -93,7 +94,7 @@ export function KaitoManage(initialState: InitialState) {
                                                     Re-deploy default CRD
                                                 </button>
                                                 <button
-                                                    onClick={() => deleteWorkspace(model.name)}
+                                                    onClick={() => deleteWorkspace(model.name, model.namespace)}
                                                     className={styles.button}
                                                 >
                                                     Delete Workspace
@@ -122,7 +123,7 @@ export function KaitoManage(initialState: InitialState) {
                                                 <div className={styles.buttonDiv}>
                                                     <button
                                                         className={styles.button}
-                                                        onClick={() => deleteWorkspace(model.name)}
+                                                        onClick={() => deleteWorkspace(model.name, model.namespace)}
                                                     >
                                                         Delete Workspace
                                                     </button>
@@ -134,7 +135,7 @@ export function KaitoManage(initialState: InitialState) {
                                                     </button>
                                                     <button
                                                         className={`${styles.button} ${styles.testButton}`}
-                                                        onClick={() => testWorkspace(model.name)}
+                                                        onClick={() => testWorkspace(model.name, model.namespace)}
                                                     >
                                                         Test
                                                     </button>

--- a/webview-ui/src/KaitoModels/KaitoModels.tsx
+++ b/webview-ui/src/KaitoModels/KaitoModels.tsx
@@ -365,7 +365,7 @@ export function KaitoModels(initialState: InitialState) {
 }
 
 // exported function to be shared in other kaito-related webviews
-export function generateKaitoYAML(model: string): { yaml: string; gpu: string | undefined } {
+export function generateKaitoYAML(model: string): { yaml: string | undefined; gpu: string | undefined } {
     model = model.startsWith("workspace-") ? model.replace("workspace-", "") : model;
     const allModelDetails = kaitoSupporterModel.modelDetails;
     // Helper function to fetch model details by name
@@ -375,6 +375,9 @@ export function generateKaitoYAML(model: string): { yaml: string; gpu: string | 
     const getStringOrEmpty = (value?: string): string => value ?? "";
 
     const modelDetails = getModelDetails(model);
+    if (!modelDetails) {
+        return { yaml: undefined, gpu: undefined };
+    }
     const name = getStringOrEmpty(modelDetails?.modelName);
     const gpu = getStringOrEmpty(modelDetails?.minimumGpu);
 

--- a/webview-ui/src/manualTest/kaitoManageTests.tsx
+++ b/webview-ui/src/manualTest/kaitoManageTests.tsx
@@ -16,6 +16,7 @@ export function getKaitoManageScenarios() {
                 inferenceReady: null,
                 workspaceReady: null,
                 age: 4,
+                namespace: "default",
             },
             {
                 name: "phi-2",
@@ -24,6 +25,7 @@ export function getKaitoManageScenarios() {
                 inferenceReady: true,
                 workspaceReady: true,
                 age: 43,
+                namespace: "default",
             },
             {
                 name: "phi-3-medium-128k-instruct",
@@ -32,6 +34,7 @@ export function getKaitoManageScenarios() {
                 inferenceReady: false,
                 workspaceReady: false,
                 age: 381,
+                namespace: "default",
             },
         ],
     };
@@ -50,8 +53,8 @@ export function getKaitoManageScenarios() {
             getLogsRequest: () => {
                 console.log("getLogsRequest");
             },
-            testWorkspaceRequest: ({ modelName }) => {
-                console.log("testWorkspaceRequest", modelName);
+            testWorkspaceRequest: ({ modelName, namespace }) => {
+                console.log("testWorkspaceRequest", modelName, namespace);
             },
         };
     }


### PR DESCRIPTION
This PR enables namespace awareness amongst KAITO features, allowing workspaces deployed in non-standard namespaces to be recognized & used for deleting models, viewing them, and querying the inference server properly. 

Additionally, I've added a check for the runtime of the KAITO model, which allows selection of a proper query to the inference server based on the runtime that's being utilized. 

.vsix for testing: [Uploading vscode-aks-tools-1.6.8-runtimefix.vsix.zip…]()

Thank you to @Tatsinnit and @lyantovski or contributions & insights.

