### PR TITLE
Updating supported models for v0.4.6 of KAITO

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -33,7 +33,6 @@
   "Repetition Penalty": "Repetition Penalty",
   "Max Length": "Max Length",
   "Please note deployment time can vary from 10 minutes to 1hr+.": "Please note deployment time can vary from 10 minutes to 1hr+.",
-  "Llama2 models require privately referenced images for deployment. You must create a CRD and specify the location of your privately hosted image. Learn more": "Llama2 models require privately referenced images for deployment. You must create a CRD and specify the location of your privately hosted image. Learn more",
   "here.": "here.",
   "Next steps": "Next steps",
   "If this is your preferred model for deployment in your application, proceed to:": "If this is your preferred model for deployment in your application, proceed to:",

--- a/resources/kaitollmconfig/kaitollmconfig.json
+++ b/resources/kaitollmconfig/kaitollmconfig.json
@@ -8,16 +8,6 @@
             "falcon-40b-instruct",
             "falcon-40b"
         ],
-        "llama2": [
-            "llama-2-7b",
-            "llama-2-13b",
-            "llama-2-70b"
-        ],
-        "llama2chat": [
-            "llama-2-7b-chat",
-            "llama-2-13b-chat",
-            "llama-2-70b-chat"
-        ],
         "mistral": [
             "mistral-7b-instruct",
             "mistral-7b"
@@ -33,7 +23,11 @@
             "phi-3-5-mini-instruct"
         ],
         "qwen" : [
-            "qwen-2-5-coder-7b-instruct"
+            "qwen-2-5-coder-7b-instruct",
+            "qwen-2-5-coder-32b-instruct"
+        ],
+        "llama3": [
+            "llama-3-1-8b-instruct"
         ]
     },
     "modelDetails": [
@@ -41,14 +35,14 @@
             "family": "falcon",
             "modelName": "falcon-7b-instruct",
             "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/tiiuae/falcon-7b-instruct"
         },
         {
             "family": "falcon",
             "modelName": "falcon-7b",
             "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/tiiuae/falcon-7b"
         },
         {
@@ -66,80 +60,38 @@
             "modelSource": "https://huggingface.co/tiiuae/falcon-40b"
         },
         {
-            "family": "llama2",
-            "modelName": "llama-2-7b",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-7b"
-        },
-        {
-            "family": "llama2",
-            "modelName": "llama-2-13b",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-13b"
-        },
-        {
-            "family": "llama2",
-            "modelName": "llama-2-70b",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC96ads_A100_v4",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-70b"
-        },
-        {
-            "family": "llama2chat",
-            "modelName": "llama-2-7b-chat",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-7b-chat"
-        },
-        {
-            "family": "llama2chat",
-            "modelName": "llama-2-13b-chat",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC12s_v3",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-13b-chat"
-        },
-        {
-            "family": "llama2chat",
-            "modelName": "llama-2-70b-chat",
-            "kaitoVersion": "v0.0.1+",
-            "minimumGpu": "Standard_NC96ads_A100_v4",
-            "modelSource": "https://huggingface.co/meta-llama/Llama-2-70b-chat"
-        },
-        {
             "family": "mistral",
             "modelName": "mistral-7b-instruct",
             "kaitoVersion": "v0.2.0+",
-            "minimumGpu": "Standard_NC12s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3"
         },
         {
             "family": "mistral",
             "modelName": "mistral-7b",
             "kaitoVersion": "v0.2.0+",
-            "minimumGpu": "Standard_NC12s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/mistralai/Mistral-7B-v0.3"
         },
         {
             "family": "phi-2",
             "modelName": "phi-2",
             "kaitoVersion": "v0.2.0+",
-            "minimumGpu": "Standard_NC6s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/microsoft/phi-2"
         },
         {
             "family": "phi-3",  
             "modelName": "phi-3-mini-4k-instruct",
             "kaitoVersion": "v0.3.0+",
-            "minimumGpu": "Standard_NC6s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/microsoft/Phi-3-mini-4k-instruct"
         },
         {
             "family": "phi-3",
             "modelName": "phi-3-mini-128k-instruct",
             "kaitoVersion": "v0.3.0+",
-            "minimumGpu": "Standard_NC6s_v3",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/microsoft/Phi-3-mini-128k-instruct"
         },
         {
@@ -169,6 +121,20 @@
             "kaitoVersion": "v0.4.1+",
             "minimumGpu": "Standard_NC24ads_A100_v4",
             "modelSource": "https://huggingface.co/Qwen/Qwen2.5-coder-7b-instruct"
+        },
+        {
+            "family": "qwen",
+            "modelName": "qwen-2-5-coder-32b-instruct",
+            "kaitoVersion": "v0.4.5+",
+            "minimumGpu": "Standard_NC24ads_A100_v4",
+            "modelSource": "https://huggingface.co/Qwen/Qwen2.5-coder-32b-instruct"
+        },
+         {
+            "family": "llama3",
+            "modelName": "llama-3-1-8b-instruct",
+            "kaitoVersion": "v0.4.6+",
+            "minimumGpu": "Standard_NC96ads_A100_v4",
+            "modelSource": "https://huggingface.co/meta-llama/Llama-3.1-8b-instruct"
         }
     ],
     "docref": "https://github.com/Azure/kaito/blob/main/presets/models/supported_models.yaml"

--- a/resources/yaml/kaitoworkspace.yaml
+++ b/resources/yaml/kaitoworkspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: kaito.sh/v1alpha1
+apiVersion: kaito.sh/v1beta1
 kind: Workspace
 metadata:
   name: workspace-<APP_ID>

--- a/src/commands/aksKaito/akskaitoGenerateYaml.ts
+++ b/src/commands/aksKaito/akskaitoGenerateYaml.ts
@@ -102,8 +102,6 @@ export default async function aksKaitoGenerateYaml(_context: IActionContext, tar
 function listKaitoSUpportedModel() {
     const modelList = [
         kaitoSupporterModel.modelsupported.falcon,
-        kaitoSupporterModel.modelsupported.llama2,
-        kaitoSupporterModel.modelsupported.llama2chat,
         kaitoSupporterModel.modelsupported.mistral,
         kaitoSupporterModel.modelsupported["phi-2"],
         kaitoSupporterModel.modelsupported["phi-3"],

--- a/webview-ui/src/KaitoModels/KaitoModels.tsx
+++ b/webview-ui/src/KaitoModels/KaitoModels.tsx
@@ -54,29 +54,8 @@ export function KaitoModels(initialState: InitialState) {
         setSelectedModel(model);
     };
 
-    // Returns true if model cannot be deployed with one click
-    function undeployable(model: string) {
-        return model.substring(0, 7) === "llama-2";
-    }
-
     const defaultMessage = <>{l10n.t("Please note deployment time can vary from 10 minutes to 1hr+.")}</>;
-    function tooltipMessage(model: string) {
-        if (model.substring(0, 7) === "llama-2") {
-            return (
-                <>
-                    {l10n.t(
-                        "Llama2 models require privately referenced images for deployment. You must create a CRD and specify the location of your privately hosted image. Learn more",
-                    )}{" "}
-                    <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href="https://github.com/Azure/kaito/tree/main/presets/models/llama2"
-                    >
-                        {l10n.t("here.")}
-                    </a>
-                </>
-            );
-        }
+    function tooltipMessage() {
         return defaultMessage;
     }
     function generateCRD(model: string) {
@@ -148,7 +127,6 @@ export function KaitoModels(initialState: InitialState) {
                                                     <div>
                                                         <button
                                                             className={styles.button}
-                                                            disabled={undeployable(selectedModel)}
                                                             onClick={() => onClickDeployKaito(selectedModel)}
                                                         >
                                                             {l10n.t("Deploy default workspace CRD")}
@@ -163,7 +141,7 @@ export function KaitoModels(initialState: InitialState) {
                                                                 </div>
                                                             </span>
                                                             <span className={styles.tooltiptext}>
-                                                                {tooltipMessage(selectedModel)}
+                                                                {tooltipMessage()}
                                                             </span>
                                                         </span>
                                                     </div>
@@ -408,17 +386,11 @@ export function generateKaitoYAML(model: string): { yaml: string | undefined; gp
         }
     } else if (name.startsWith("qwen-2-5")) {
         inferenceName = inferenceName.replace("qwen-2-5", "qwen2.5");
+    } else if (name.startsWith("llama-3")) {
+        inferenceName = inferenceName.replace("llama-3-1", "llama3.1");
     }
 
-    // Adds private configuration template for llama-2 models
-    const privateConfig = name.startsWith("llama-2")
-        ? `
-accessMode: private
-presetOptions:
-  image: <YOUR IMAGE URL>`
-        : "";
-
-    const yaml = `apiVersion: kaito.sh/v1alpha1
+    const yaml = `apiVersion: kaito.sh/v1beta1
 kind: Workspace
 metadata:
   name: workspace-${metadataName}
@@ -429,7 +401,7 @@ resource:
       apps: ${appName}
 inference:
   preset:
-    name: ${inferenceName}${privateConfig}`;
+    name: ${inferenceName}`;
     // Passing along gpu specification for subsequent usage
     return { yaml, gpu };
 }


### PR DESCRIPTION
This PR adds the Llama3 and Qwen32b models & removes the Llama2 model which has now been deprecated in KAITO.
- Added Llama3 & Qwen32b
- Bumped apiversion from v1aplha1 to v1beta1
- Removed unused llama2 logic