### PR TITLE
Safely bumping @azure/identity 4.6.0 to 4.10.1 with npm 'open' fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@azure/arm-subscriptions": "^5.1.0",
                 "@azure/container-registry": "^1.1.0",
                 "@azure/core-auth": "^1.8.0",
-                "@azure/identity": "4.6",
+                "@azure/identity": "^4.10.1",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/storage-blob": "^12.27.0",
                 "@eslint/compat": "^1.2.9",
@@ -644,9 +644,9 @@
             }
         },
         "node_modules/@azure/identity": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.6.0.tgz",
-            "integrity": "sha512-ANpO1iAvcZmpD4QY7/kaE/P2n66pRXsDp3nMUC6Ow3c9KfXOZF7qMU9VgqPw8m7adP7TVIbVyrCEmD9cth3KQQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.10.1.tgz",
+            "integrity": "sha512-YM/z6RxRtFlXUH2egAYF/FDPes+MUE6ZoknjEdaq7ebJMMNUzn9zCJ3bd2ZZZlkP0r1xKa88kolhFH/FGV7JnA==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
@@ -656,12 +656,9 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^4.0.1",
-                "@azure/msal-node": "^2.15.0",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
-                "open": "^8.0.0",
-                "stoppable": "^1.1.0",
+                "@azure/msal-browser": "^4.2.0",
+                "@azure/msal-node": "^3.5.0",
+                "open": "^10.1.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -800,21 +797,21 @@
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "14.16.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
-            "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.7.1.tgz",
+            "integrity": "sha512-a0eowoYfRfKZEjbiCoA5bPT3IlWRAdGSvi63OU23Hv+X6EI8gbvXCoeqokUceFMoT9NfRUWTJSx5FiuzruqT8g==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
-            "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.6.1.tgz",
+            "integrity": "sha512-ctcVz4xS+st5KxOlQqgpvA+uDFAa59CvkmumnuhlD2XmNczloKBdCiMQG7/TigSlaeHe01qoOlDjz3TyUAmKUg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "14.16.0",
+                "@azure/msal-common": "15.7.1",
                 "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
@@ -3325,6 +3322,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -3944,6 +3956,34 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3962,12 +4002,15 @@
             }
         },
         "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/delayed-stream": {
@@ -5360,15 +5403,15 @@
             }
         },
         "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": ">=8"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5402,6 +5445,24 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-interactive": {
@@ -5473,15 +5534,18 @@
             }
         },
         "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "license": "MIT",
             "dependencies": {
-                "is-docker": "^2.0.0"
+                "is-inside-container": "^1.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -5681,12 +5745,12 @@
             }
         },
         "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
             "license": "MIT",
             "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
+                "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
                 "safe-buffer": "^5.0.1"
             }
@@ -5711,25 +5775,6 @@
                 "pako": "~1.0.2",
                 "readable-stream": "~2.3.6",
                 "setimmediate": "^1.0.5"
-            }
-        },
-        "node_modules/jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/keytar": {
@@ -6539,17 +6584,18 @@
             }
         },
         "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+            "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
             "license": "MIT",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^3.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7490,6 +7536,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/run-applescript": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7956,15 +8014,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-            "engines": {
-                "node": ">=4",
-                "npm": ">=6"
             }
         },
         "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -722,7 +722,7 @@
         "@azure/arm-subscriptions": "^5.1.0",
         "@azure/container-registry": "^1.1.0",
         "@azure/core-auth": "^1.8.0",
-        "@azure/identity": "4.6",
+        "@azure/identity": "^4.10.1",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/storage-blob": "^12.27.0",
         "@eslint/compat": "^1.2.9",

--- a/src/panels/RetinaCapturePanel.ts
+++ b/src/panels/RetinaCapturePanel.ts
@@ -1,5 +1,5 @@
-import open from "open";
 import * as vscode from "vscode";
+import * as path from "path";
 import { Uri, window } from "vscode";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { failed } from "../commands/utils/errorable";
@@ -202,11 +202,12 @@ spec:
             )
             .then((selection) => {
                 if (selection === goToFolder) {
+                    // acquiring absolute path for the file system
+                    const abs = path.resolve(captureHostFolderName);
                     if (env.remoteName === "wsl") {
-                        commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(captureHostFolderName));
+                        commands.executeCommand("remote-wsl.revealInExplorer", Uri.file(abs));
                     } else {
-                        // opening relative file path doesn't work in WSL
-                        open(captureHostFolderName);
+                        commands.executeCommand("revealFileInOS", Uri.file(abs));
                     }
                 }
             });


### PR DESCRIPTION
This PR fixes an activation issue on Windows caused by recent versions of the `@azure/identity` package. We observed that the extension would not activate correctly when bundled with `@azure/identity` above version 4.6.

After investigating, we found that the `open` npm package was also updated alongside `@azure/identity`, and in its newer version calling `open()` on relative paths now throws an error—something it previously supported.

Because `open()` is only used in one place, I’ve replaced it with VS Code’s built-in file-reveal command and ensured the path is always resolved to its absolute form.

I’ve also bumped `@azure/identity` in this PR so we can close the Dependabot one once it’s merged.

Relevant Dependabot PRs: 
- https://github.com/Azure/vscode-aks-tools/pull/1472
- https://github.com/Azure/vscode-aks-tools/pull/1435

.vsix for testing: [vscode-aks-tools-1.6.9-v10.vsix.zip](https://github.com/user-attachments/files/20892355/vscode-aks-tools-1.6.9-v10.vsix.zip)

fyi @Tatsinnit 