### PR TITLE
Publish release 1.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.6.10]
+
+* kaito GA changes (#1475)
+* Resolving file path var for azure/identity upgrade fix (#1482)
+* Removing deprecated & adding newly supported models (#1465)
+* Add retro release for enabling. (#1447)
+* Fix for workflow. (#1446)
+* Dependabot updates and bumps.
+
+Thank you so much to @tejhan, @lyantovski , @bosesuneha, or @davidgamero for review contributions, testing and reviews. Thank you @lyantovski for his testing work around KAITO update work.
+
 ## [1.6.9]
 
 * Adding namespace awareness & different runtime support for KAITO models (#1444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.6.10]
 
-* kaito GA changes (#1475)
+* Kaito GA changes (#1475)
 * Resolving file path var for azure/identity upgrade fix (#1482)
 * Removing deprecated & adding newly supported models (#1465)
 * Add retro release for enabling. (#1447)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.9",
+    "version": "1.6.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.9",
+            "version": "1.6.10",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.9",
+    "version": "1.6.10",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR is open for the release of `1.6.10`, this PR contains following:

* kaito GA changes (#1475)
* Resolving file path var for azure/identity upgrade fix (#1482)
* Removing deprecated & adding newly supported models (#1465)
* Add retro release for enabling. (#1447)
* Fix for workflow. (#1446)
* Dependabot updates and bumps.

Thank you so much to @tejhan, @lyantovski , @bosesuneha, or @davidgamero for review contributions, testing and reviews. Thank you @lyantovski for his testing work around KAITO update work. cc: @qpetraroia,  @gambtho

**VSIX for test**

[vscode-aks-tools-1.6.10-test.vsix.zip](https://github.com/user-attachments/files/20966542/vscode-aks-tools-1.6.10-test.vsix.zip)

