### PR TITLE
chore(package): update kubectl-gadget release tag to v0.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.38.0",
+                    "default": "v0.42.0",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },


### PR DESCRIPTION
Updated the `azure.kubectlgadget.releaseTag` default value from `v0.38.0` to `v0.42.0` to reflect the latest stable release of the `kubectl-gadget` tool.