### PR TITLE
Publish release 1.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.6.11]
+
+* Add new monitoring and profiling commands for Inspektor Gadget (#1512)
+* Fix vsc update. (#1502)
+* Fix telemetery update failure. (#1501)
+* IG menu restructure: Investigate DNS and Real-time TCP Monitoring (#1466)
+* Dependabot updates and bumps.
+
+Thank you so much to @bosesuneha, @ReinierCC, @tejhan for review contributions, testing and reviews.
+
 ## [1.6.10]
 
 * Kaito GA changes (#1475)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.10",
+    "version": "1.6.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.10",
+            "version": "1.6.11",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.10",
+    "version": "1.6.11",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR is open for the release of `1.6.11`, this PR contains following:

* Add new monitoring and profiling commands for Inspektor Gadget (#1512)
* Fix vsc update. (#1502)
* Fix telemetery update failure. (#1501)
* IG menu restructure: Investigate DNS and Real-time TCP Monitoring (#1466)
* Dependabot updates and bumps.

Thank you so much to @bosesuneha, @ReinierCC, @tejhan, @davidgamero  for contributions, testing and reviews. gentle fyi and cc: @qpetraroia , @gambtho 

Side note please: let's merge #1522 post the successful release for the documentation update. what do you all think?

**VSIX for test:**

[vscode-aks-tools-1.6.11-test.vsix.zip](https://github.com/user-attachments/files/21471899/vscode-aks-tools-1.6.11-test.vsix.zip)
