### PR TITLE
Added option to port-forward KAITO workspace service

### DIFF
--- a/src/commands/utils/tempfile.ts
+++ b/src/commands/utils/tempfile.ts
@@ -18,7 +18,7 @@ export async function withOptionalTempFile<T>(
 
 export async function createTempFile(content: string, extension: string): Promise<TempFile> {
     // TODO: try/catch and return errorable?
-    const tempFile = fileSync({ prefix: "aks-periscope-", postfix: `.${extension}` });
+    const tempFile = fileSync({ postfix: `.${extension}` });
     await fs.writeFile(tempFile.name, content);
     return new TempFile(tempFile);
 }

--- a/src/commands/utils/tempfile.ts
+++ b/src/commands/utils/tempfile.ts
@@ -18,7 +18,7 @@ export async function withOptionalTempFile<T>(
 
 export async function createTempFile(content: string, extension: string): Promise<TempFile> {
     // TODO: try/catch and return errorable?
-    const tempFile = fileSync({ postfix: `.${extension}` });
+    const tempFile = fileSync({ prefix: "aks-periscope-", postfix: `.${extension}` });
     await fs.writeFile(tempFile.name, content);
     return new TempFile(tempFile);
 }

--- a/src/webview-contract/webviewDefinitions/kaitoManage.ts
+++ b/src/webview-contract/webviewDefinitions/kaitoManage.ts
@@ -21,6 +21,7 @@ export type ToVsCodeMsgDef = {
     redeployWorkspaceRequest: { modelName: string; modelYaml: string | undefined; namespace: string };
     getLogsRequest: {};
     testWorkspaceRequest: { modelName: string; namespace: string };
+    portForwardRequest: { modelName: string; namespace: string };
 };
 
 export type ToWebViewMsgDef = {

--- a/webview-ui/src/KaitoManage/KaitoManage.tsx
+++ b/webview-ui/src/KaitoManage/KaitoManage.tsx
@@ -37,6 +37,10 @@ export function KaitoManage(initialState: InitialState) {
         vscode.postTestWorkspaceRequest({ modelName: modelName, namespace: namespace });
     }
 
+    function portForward(modelName: string, namespace: string) {
+        vscode.postPortForwardRequest({ modelName: modelName, namespace: namespace });
+    }
+
     return (
         <>
             <h2 className={styles.mainTitle}>
@@ -145,6 +149,12 @@ export function KaitoManage(initialState: InitialState) {
                                                         onClick={() => testWorkspace(model.name, model.namespace)}
                                                     >
                                                         {l10n.t("Test")}
+                                                    </button>
+                                                    <button
+                                                        className={`${styles.button} ${styles.testButton}`}
+                                                        onClick={() => portForward(model.name, model.namespace)}
+                                                    >
+                                                        {l10n.t("Port-Forward")}
                                                     </button>
                                                 </div>
                                                 <div className={styles.successIconContainer}>

--- a/webview-ui/src/KaitoManage/state.ts
+++ b/webview-ui/src/KaitoManage/state.ts
@@ -15,6 +15,7 @@ export const vscode = getWebviewMessageContext<"kaitoManage">({
     redeployWorkspaceRequest: null,
     getLogsRequest: null,
     testWorkspaceRequest: null,
+    portForwardRequest: null,
 });
 
 export const stateUpdater: WebviewStateUpdater<"kaitoManage", EventDef, MonitorState> = {

--- a/webview-ui/src/manualTest/kaitoManageTests.tsx
+++ b/webview-ui/src/manualTest/kaitoManageTests.tsx
@@ -56,6 +56,9 @@ export function getKaitoManageScenarios() {
             testWorkspaceRequest: ({ modelName, namespace }) => {
                 console.log("testWorkspaceRequest", modelName, namespace);
             },
+            portForwardRequest: ({ modelName, namespace }) => {
+                console.log("portForwardRequest", modelName, namespace);
+            },
         };
     }
 


### PR DESCRIPTION
This PR introduces a new suggested feature that allows users to easily port-forward any KAITO workspace with a single click. On the KAITO manage page, deployed models will now have an option to initiate port-forwarding. The user will be prompted to specify a port, which will automatically launch an interactive shell with the port-forward process, streamlining the workflow. 

This eliminates the need for users to manually identify the relevant service port and start port-forwarding via the CLI.

.vsix for testing here -> [vscode-aks-tools-1.6.11-port1.vsix.zip](https://github.com/user-attachments/files/21516327/vscode-aks-tools-1.6.11-port1.vsix.zip)
