### PR TITLE
Windows binary release for win arch is specific format.

### DIFF
--- a/src/commands/utils/helper/mcpServerDownloadHelper.ts
+++ b/src/commands/utils/helper/mcpServerDownloadHelper.ts
@@ -45,7 +45,13 @@ function getArchiveFilename() {
         operatingSystem = "win";
     }
 
-    return `aks-mcp-${operatingSystem}-${architecture}`;
+    let extension = "";
+    if (operatingSystem === "win") {
+        operatingSystem = "windows";
+        extension = ".exe";
+    }
+
+    return `aks-mcp-${operatingSystem}-${architecture}${extension}`;
 }
 
 function getPathToBinaryInArchive() {


### PR DESCRIPTION
This PR fixes the download name for the aks-mcp binary for windows which is of specific format and contains extension as well.

THanks,

[vscode-aks-tools-1.6.11-windows-fix.vsix.zip](https://github.com/user-attachments/files/21555075/vscode-aks-tools-1.6.11-windows-fix.vsix.zip)
