### PR TITLE
Publish release 1.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.6.12]
 
+* Windows binary release for win arch is specific format. (#1526)
 * Add AKS MCP Server using AKS Ext level command. (#1524)
 * Added option to port-forward KAITO workspace service (#1525)
 * Adding deploy workspace feature to KAITO (#1493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.6.12]
+
+* Add AKS MCP Server using AKS Ext level command. (#1524)
+* Added option to port-forward KAITO workspace service (#1525)
+* Adding deploy workspace feature to KAITO (#1493)
+* Add fix for arm-container package update. (#1521)
+* Update Inspektor Gadget doc (#1522)
+* Dependabot updates and bumps.
+
+Thank you so much to @bosesuneha, @ReinierCC, @tejhan for review contributions, testing and reviews.
+
 ## [1.6.11]
 
 * Add new monitoring and profiling commands for Inspektor Gadget (#1512)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Update Inspektor Gadget doc (#1522)
 * Dependabot updates and bumps.
 
-Thank you so much to @bosesuneha, @ReinierCC, @tejhan for review contributions, testing and reviews.
+Thank you so much to @bosesuneha, @ReinierCC, @pavneeta, @tejhan, Julia Yin for review contributions, testing and reviews.
 
 ## [1.6.11]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Kubernetes Service (AKS) Extension for Visual Studio Code
 
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8315/badge)](https://www.bestpractices.dev/projects/8315) [![Build & Publish](https://github.com/Azure/vscode-aks-tools/actions/workflows/publish-v2.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/publish-v2.yml) [![Build](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml) [![CodeQL](https://github.com/Azure/vscode-aks-tools/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/codeql-analysis.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8315/badge)](https://www.bestpractices.dev/projects/8315) [![Build](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/build.yml) [![CodeQL](https://github.com/Azure/vscode-aks-tools/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/codeql-analysis.yml)
 [![Prettier Check](https://github.com/Azure/vscode-aks-tools/actions/workflows/format-check.yml/badge.svg)](https://github.com/Azure/vscode-aks-tools/actions/workflows/format-check.yml)
 
 * [Introduction](https://azure.github.io/vscode-aks-tools/index.html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.11",
+    "version": "1.6.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.11",
+            "version": "1.6.12",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.11",
+    "version": "1.6.12",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR is open for the release of `1.6.12`, this PR contains following:

* Windows binary release for win arch is specific format. (#1526)
* Add AKS MCP Server using AKS Ext level command. (#1524)
* Added option to port-forward KAITO workspace service (#1525)
* Adding deploy workspace feature to KAITO (#1493)
* Add fix for arm-container package update. (#1521)
* Update Inspektor Gadget doc (#1522)
* Dependabot updates and bumps.

Thank you so much to @bosesuneha, @ReinierCC, @pavneeta, @tejhan, Julia Yin for review contributions, testing and reviews. Gentle fyi and cc: @qpetraroia , @gambtho , @pavneeta 

Side note please: let's merge #1526 before this PR to be merged.

**VSIX for test:**

* ~~Needs #1526  to be merged before I can provide the VISX~~.  
*  [vscode-aks-tools-1.6.12-test.vsix.zip](https://github.com/user-attachments/files/21583438/vscode-aks-tools-1.6.12-test.vsix.zip)

