### PR TITLE
Support version 0.0.5 for AKS MCP Server.

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.4",
+                    "default": "v0.0.5",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 }

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.3",
+                    "default": "v0.0.4",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 }


### PR DESCRIPTION
This PR is to support the `0.0.5` version for aks-mcp server release happened few hours back, bit please note the release for this has to wait. https://github.com/Azure/aks-mcp 

This PR is for three to keep it uptodate.

Thanks.