### PR TITLE
Bump AKS MCP server to v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.3",
+                    "default": "v0.0.6",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 }


### PR DESCRIPTION
Refer https://github.com/Azure/aks-mcp/releases/tag/v0.0.6 for its release notes.