### PR TITLE
Fix the client using sessionProvider instead of default.

### DIFF
--- a/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
+++ b/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
@@ -72,6 +72,7 @@ export async function aksUploadRetinaCapture(_context: IActionContext, target: u
     }
 
     const containerName = await chooseContainerFromStorageAccount(
+        sessionProvider,
         clusterStorageAccountId,
         storageInfo.result.blobEndpoint,
     );

--- a/src/commands/utils/azurestorage.ts
+++ b/src/commands/utils/azurestorage.ts
@@ -213,21 +213,9 @@ async function getStorageCredential(sessionProvider: ReadyAzureSessionProvider) 
                 throw new Error(`No Microsoft authentication session found: ${session.error}`);
             }
 
-            // Use the actual expiration timestamp if available, otherwise fallback to 1 hour from now
-            let expiresOnTimestamp: number;
-            if (session.result.expiresOn) {
-                // expiresOn may be a Date object or a string
-                const expiresOnDate = typeof session.result.expiresOn === "string"
-                    ? new Date(session.result.expiresOn)
-                    : session.result.expiresOn;
-                expiresOnTimestamp = expiresOnDate.getTime();
-            } else if (session.result.expiresOnTimestamp) {
-                expiresOnTimestamp = session.result.expiresOnTimestamp;
-            } else {
-                // Fallback: 1 hour from now
-                expiresOnTimestamp = Date.now() + 60 * 60 * 1000;
-            }
-            return { token: session.result.accessToken, expiresOnTimestamp };
+            // For Azure Storage, we don't need to set a specific expiration timestamp
+            // The Azure SDK will handle token refresh automatically
+            return { token: session.result.accessToken, expiresOnTimestamp: 0 };
         },
     };
 }

--- a/src/commands/utils/azurestorage.ts
+++ b/src/commands/utils/azurestorage.ts
@@ -213,7 +213,21 @@ async function getStorageCredential(sessionProvider: ReadyAzureSessionProvider) 
                 throw new Error(`No Microsoft authentication session found: ${session.error}`);
             }
 
-            return { token: session.result.accessToken, expiresOnTimestamp: 0 };
+            // Use the actual expiration timestamp if available, otherwise fallback to 1 hour from now
+            let expiresOnTimestamp: number;
+            if (session.result.expiresOn) {
+                // expiresOn may be a Date object or a string
+                const expiresOnDate = typeof session.result.expiresOn === "string"
+                    ? new Date(session.result.expiresOn)
+                    : session.result.expiresOn;
+                expiresOnTimestamp = expiresOnDate.getTime();
+            } else if (session.result.expiresOnTimestamp) {
+                expiresOnTimestamp = session.result.expiresOnTimestamp;
+            } else {
+                // Fallback: 1 hour from now
+                expiresOnTimestamp = Date.now() + 60 * 60 * 1000;
+            }
+            return { token: session.result.accessToken, expiresOnTimestamp };
         },
     };
 }

--- a/src/commands/utils/azurestorage.ts
+++ b/src/commands/utils/azurestorage.ts
@@ -183,7 +183,10 @@ export async function chooseContainerInStorageAccount(
     }
 }
 
-async function listStorageContainers(sessionProvider: ReadyAzureSessionProvider, blobEndpoint: string): Promise<string[]> {
+async function listStorageContainers(
+    sessionProvider: ReadyAzureSessionProvider,
+    blobEndpoint: string,
+): Promise<string[]> {
     // Get a credential with the proper Azure Storage scope
     const storageCredential = await getStorageCredential(sessionProvider);
     const blobServiceClient = new BlobServiceClient(blobEndpoint, storageCredential);
@@ -202,7 +205,7 @@ async function listStorageContainers(sessionProvider: ReadyAzureSessionProvider,
 async function getStorageCredential(sessionProvider: ReadyAzureSessionProvider) {
     // Azure Storage requires the storage scope instead of the default ARM scope
     const storageScopes = ["https://storage.azure.com/.default"];
-    
+
     return {
         getToken: async () => {
             const session = await sessionProvider.getAuthSession({ scopes: storageScopes });


### PR DESCRIPTION
💡 This PR is to fix avoid using `DefaultAzureCredential` and user properly formed object via  `sessionProvider` .

Instead of using DefaultAzureCredential (which is designed for development/testing), the code now uses the existing VS Code authentication session through. Now it uses the `[ReadyAzureSessionProvider]` that manages the user's sign-in state.

Tested locally.

* **VSIX:**  [vscode-aks-tools-1.6.12-storage-test.vsix.zip](https://github.com/user-attachments/files/21801714/vscode-aks-tools-1.6.12-storage-test.vsix.zip)
