### PR TITLE
Bump AKS MCP to v0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.6",
+                    "default": "v0.0.9",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 }


### PR DESCRIPTION
Bump AKS MCP to v0.0.9, which includes a set of bug fixes, refer [here](https://github.com/Azure/aks-mcp/compare/v0.0.6...v0.0.9) for the changes since last version.