### PR TITLE
Bump AKS-MCP Server to v0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.9",
+                    "default": "v0.0.11",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 }


### PR DESCRIPTION
Upgrade AKS-MCP Server to https://github.com/Azure/aks-mcp/releases/tag/v0.0.11

cc: @gossion / @feiskyer