### PR TITLE
[Fix] Bug when creating automatic clusters

### DIFF
--- a/src/panels/CreateClusterPanel.ts
+++ b/src/panels/CreateClusterPanel.ts
@@ -417,10 +417,6 @@ async function doFeatureRegistration(preset: PresetType, featureClient: FeatureC
         },
         {
             resourceProviderNamespace: "Microsoft.ContainerService",
-            featureName: "NodeAutoProvisioningPreview",
-        },
-        {
-            resourceProviderNamespace: "Microsoft.ContainerService",
             featureName: "DisableSSHPreview",
         },
         {

--- a/src/panels/templates/AutomaticCreateCluster.json
+++ b/src/panels/templates/AutomaticCreateCluster.json
@@ -68,8 +68,7 @@
                     {
                         "name": "systempool",
                         "mode": "System",
-                        "count": 3,
-                        "osType": "Linux"
+                        "count": 3
                     }
                 ],
                 "supportPlan": "[parameters('supportPlan')]"

--- a/src/panels/utilities/ClusterSpecCreationBuilder.ts
+++ b/src/panels/utilities/ClusterSpecCreationBuilder.ts
@@ -24,7 +24,8 @@ export type ClusterSpec = {
 type TemplateContent = Record<string, unknown>;
 
 const deploymentApiVersion = "2023-08-01";
-const deploymentApiVersionPreview = "2024-03-02-preview";
+// Updated to latest stable API version (Nov 2024) - was 2024-03-02-preview
+const deploymentApiVersionPreview = "2025-08-01";
 const presetTemplates: Record<PresetType, TemplateContent> = {
     [PresetType.Automatic]: automaticTemplate,
     [PresetType.Dev]: devTestTemplate,


### PR DESCRIPTION
Observed an issue with Automatic Cluster creation failing consistently with the following error: 

<img width="1111" height="197" alt="image" src="https://github.com/user-attachments/assets/d87f3302-1dd5-413b-93cb-709b3455fae2" />


This occurs because the NodeAutoProvisioningPreview feature is no longer valid. Upon the registration prerequisite steps, this would always trigger an error and stop cluster creation.

I've removed the feature registration, alongside updating the API to the recent version as opposed to the preview version which used the older preview features as well, so automatic cluster creation is working now. 

Also following recent docs just removed osType specification to leave it to the automatic config.