### PR TITLE
Publish release 1.6.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.6.14",
+    "version": "1.6.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.6.14",
+            "version": "1.6.15",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.6.14",
+    "version": "1.6.15",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR is open for the release of `1.6.15`, this PR contains following:

* Update: remove old release mechanism (#1808)
* Update vscode pacakge and engine. (#1793)
* Fix prettier error (#1779)
* Update react-dom (#1764)
* Cleanup: update react dom to latest (#1765)
* vscode engine update and security fix. (#1763)
* Fix js-yaml sec alert. (#1742)
* Fixing automatic cluster creation (#1715)
* Gradual retiring the old publish workflow. (#1717)
* Dependabot updates and bumps.


❤️ Thank you so much to @tejhan, @ashu8912, @bosesuneha , @davidgamero and @ReinierCC  for review contributions, testing and reviews. cc: @gambtho and @qpetraroia 

VSIX to test please:
[vscode-aks-tools-1.6.15-test.vsix.zip](https://github.com/user-attachments/files/24476551/vscode-aks-tools-1.6.15-test.vsix.zip)

Thanks heaps