### PR TITLE
Update 1es pool to what dalec uses

### DIFF
--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -29,7 +29,7 @@ extends:
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: staging-pool-amd64-mariner-2
-      image: 1es-azlinux-3-amd64
+      image: 1es-azlinux-3-amd64-custom-disk
       os: linux
       hostArchitecture: amd64
     sdl:


### PR DESCRIPTION
This PR updates the 1es pipeline pool in use, as the previous one no longer exist. Thanks.

changing it to `1es-azlinux-3-amd64-custom-disk` to avoid the missing cli error for esrp, I saw this image in dalec, therefore trying this. https://github.com/Azure/dalec-build-defs/blob/48b6e66bcb87a82ab7a7fa4bdaeaef194acb0119/.pipelines/projects/eol-annotations/azure_pipeline.yml#L41

❤️ Gentle fyi cc: @tejhan, @ashu8912 , @bosesuneha , @davidgamero or @gambtho