### PR TITLE
Update 1es pipeline with DotNet task

### DIFF
--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -102,6 +102,11 @@ extends:
                   ls -la "$(Pipeline.Workspace)/vscode-extension-unsigned"
                 displayName: "List the unsigned dir"
 
+              # Add this Command to Include the .NET SDK and runtimes
+              - task: UseDotNet@2
+                displayName: Use .NET Runtime
+                inputs:
+                  packageType: "runtime"
               - task: EsrpCodeSigning@5
                 displayName: Publish signed VSCode extension
                 inputs:


### PR DESCRIPTION
This PR updates to get the DotNet in the 1es pipeline pool in use, as the previous image which is removed has DotNet preinstalled which was needed for esop no longer exist. Thanks.

Doc: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines

❤️ Gentle fyi cc: @tejhan, @ashu8912 , @bosesuneha , @davidgamero or @gambtho