### PR TITLE
Add test policy documentation for OpenSSF Best Practices badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,8 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Testing Requirements
+
+When contributing new functionality to this project, you MUST follow our [Test Policy](docs/TEST_POLICY.md).
+All major new features must include corresponding tests. Please review the test policy before submitting your contribution.

--- a/docs/TEST_POLICY.md
+++ b/docs/TEST_POLICY.md
@@ -1,0 +1,52 @@
+# Test Policy
+
+This document outlines the testing policy for the vscode-aks-tools project.
+
+## Overview
+
+All contributions to this project should include appropriate tests to ensure code quality and prevent regressions.
+
+## When Tests Are Required
+
+### New Functionality
+- All new features MUST include corresponding tests
+- Bug fixes SHOULD include tests that demonstrate the bug is fixed
+- Refactoring SHOULD include tests to maintain code coverage
+
+### Test Types
+
+1. **Unit Tests**: Test individual functions/methods in isolation
+2. **Integration Tests**: Test interactions between components
+3. **End-to-End Tests**: Test complete user workflows
+
+## Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Generate test coverage report
+npm run test:coverage
+```
+
+## Test Location
+
+- Unit tests: `src/test/unit/`
+- Integration tests: `src/test/integration/`
+- E2E tests: `src/test/e2e/`
+
+## Pull Request Requirements
+
+All PRs must:
+1. Include tests for new functionality
+2. Pass all existing tests
+3. Maintain or improve code coverage
+
+## CI/CD Enforcement
+
+- All tests run automatically on PRs
+- Code coverage reports are generated
+- Failing tests block merge


### PR DESCRIPTION
This PR addresses the missing OpenSSF Best Practices criteria:\n\n- **test_policy**: Created docs/TEST_POLICY.md documenting the project's testing policy\n- **tests_are_added**: Updated CONTRIBUTING.md with testing requirements referencing the test policy\n\nThis will improve the badge from 97% to 100%.