### PR TITLE
Increase max tool call and handle lm error

### DIFF
--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -433,6 +433,9 @@ async function generateDeploymentFiles(
 
     if (generatedFiles.length === 0) {
         logger.warn("No files were generated");
+        if (hasBothActions) {
+            return { deploymentFiles: [] };
+        }
         vscode.window.showWarningMessage(l10n.t("No deployment files were generated."));
         return undefined;
     }

--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -25,8 +25,6 @@ import {
 } from "./prompts";
 import { PROJECT_TOOLS, handleToolCall } from "./tools";
 
-const MAX_TOOL_ROUNDS = 15;
-
 export class ContainerAssistService {
     readonly lmClient: LMClient;
 
@@ -173,7 +171,6 @@ export class ContainerAssistService {
             {
                 tools: PROJECT_TOOLS,
                 toolHandler: (call) => handleToolCall(call, workspaceRoot),
-                maxToolRounds: MAX_TOOL_ROUNDS,
             },
             token,
         );
@@ -284,7 +281,6 @@ export class ContainerAssistService {
             {
                 tools: PROJECT_TOOLS,
                 toolHandler: (call) => handleToolCall(call, workspaceRoot),
-                maxToolRounds: MAX_TOOL_ROUNDS,
             },
             token,
         );

--- a/src/commands/aksContainerAssist/lmClient.ts
+++ b/src/commands/aksContainerAssist/lmClient.ts
@@ -5,6 +5,7 @@ import { logger } from "./logger";
 import { showWizardExitConfirmation } from "./wizardUtils";
 import * as l10n from "@vscode/l10n";
 
+const MAX_TOOL_CALLS = 20;
 /**
  * Reads the configured model family and vendor from user/workspace settings.
  * Defaults are defined in package.json under aks.containerAssist.modelFamily / modelVendor.
@@ -110,8 +111,7 @@ export class LMClient {
             };
         }
 
-        const maxRounds = options.maxToolRounds ?? 15;
-
+        const maxRounds = options.maxToolRounds ?? MAX_TOOL_CALLS;
         try {
             const messages: vscode.LanguageModelChatMessage[] = [
                 vscode.LanguageModelChatMessage.User(systemPrompt),


### PR DESCRIPTION
- Fix LM tool-calling loop to gracefully produce output when max rounds are exhausted instead of failing
- Add error handling to skip workflow generation when deployment files (Dockerfile/manifests) fail to generate
- Refactor LMClient for readability: extract stream helpers, parallelize tool execution