### PR TITLE
Update isManagedNamespace function

### DIFF
--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -615,7 +615,7 @@ export async function getClusterNamespacesWithTypes(
                         let type: "system" | "user" | "managed" | "unknown";
                         if (isSystemNamespace(name)) {
                             type = "system";
-                        } else if (isManagedNamespace(labels, annotations)) {
+                        } else if (isManagedNamespace(labels)) {
                             type = "managed";
                         } else {
                             type = "user";
@@ -644,30 +644,8 @@ function isSystemNamespace(name: string): boolean {
     return systemNamespaces.includes(name);
 }
 
-function isManagedNamespace(labels: { [key: string]: string }, annotations: { [key: string]: string }): boolean {
-    // Check for common managed service labels and annotations
-    const managedLabels = [
-        "app.kubernetes.io/managed-by",
-        "kubernetes.azure.com/managed-by",
-        "azure.workload.identity/use",
-        "managed-by",
-        "headlamp.dev/project-managed-by",
-    ];
-
-    const managedAnnotations = [
-        "kubernetes.azure.com/managed",
-        "azure.workload.identity/service-account-token-expiration",
-    ];
-
-    return (
-        managedLabels.some((label) => labels[label]) ||
-        managedAnnotations.some((annotation) => annotations[annotation]) ||
-        // Check for Azure-specific managed namespaces
-        labels["app.kubernetes.io/component"] === "azure-workload-identity" ||
-        labels["control-plane"] === "controller-manager" ||
-        // Check for AKS Desktop managed namespaces
-        labels["headlamp.dev/project-managed-by"] === "aks-desktop"
-    );
+function isManagedNamespace(labels: { [key: string]: string }): boolean {
+    return labels["kubernetes.azure.com/managedByArm"] === "true";
 }
 
 export async function createClusterNamespace(


### PR DESCRIPTION
This pull request simplifies the logic used to determine if a Kubernetes namespace is "managed" within the `clusters.ts` utility. The main change is narrowing the criteria for managed namespaces to a single label check, which streamlines the code and reduces potential sources of error.

Namespace classification logic simplification:

* The `isManagedNamespace` function now only checks if the `labels["kubernetes.azure.com/managedByArm"]` is set to `"true"` instead of evaluating multiple labels and annotations.
* The call to `isManagedNamespace` in `getClusterNamespacesWithTypes` was updated to pass only the `labels` argument, removing the unnecessary `annotations` parameter.