### PR TITLE
Add manifest generation and signing

### DIFF
--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -118,7 +118,53 @@ extends:
                 displayName: "List the unsigned dir"
 
               # =====================================================
-              # CODE SIGNING
+              # MANIFEST GENERATION AND SIGNING
+              # =====================================================
+
+              # Generate extension manifest from the VSIX
+              - pwsh: |
+                  $vsixFile = Get-ChildItem "$(Pipeline.Workspace)/vscode-extension-unsigned/*.vsix" | Select-Object -First 1
+                  Write-Host "Generating manifest for: $($vsixFile.FullName)"
+                  npx @vscode/vsce@latest generate-manifest -i $vsixFile.FullName -o "$(Pipeline.Workspace)/vscode-extension-unsigned/extension.manifest"
+                displayName: 'Generate extension manifest'
+
+              # Prepare manifest for signing (copy to .p7s file that ESRP will sign)
+              - pwsh: |
+                  Copy-Item "$(Pipeline.Workspace)/vscode-extension-unsigned/extension.manifest" "$(Pipeline.Workspace)/vscode-extension-unsigned/extension.signature.p7s"
+                  Write-Host "Prepared manifest for signing"
+                displayName: 'Prepare manifest for signing'
+
+              # Sign the extension manifest with ESRP (VSCodePublisherSign)
+              - task: EsrpCodeSigning@5
+                displayName: Sign extension manifest with ESRP
+                inputs:
+                  ConnectedServiceName: "ESRP-AME-AZCU"
+                  UseMSIAuthentication: true
+                  AppRegistrationClientId: "70ebf75b-d46f-46da-90e6-1fa654251514"
+                  AppRegistrationTenantId: "33e01921-4d64-4f8c-a055-5bdaffd5e33d"
+                  EsrpClientId: "150f8d2b-ad88-4a27-b782-c9bc3b028430"
+                  AuthAKVName: "upstreamci-ado"
+                  AuthSignCertName: "azcu-ersp-corp"
+                  FolderPath: $(Pipeline.Workspace)/vscode-extension-unsigned
+                  Pattern: 'extension.signature.p7s'
+                  signConfigType: inlineSignParams
+                  inlineOperation: |
+                    [
+                      {
+                        "keyCode": "CP-401405",
+                        "operationSetCode": "VSCodePublisherSign",
+                        "parameters": [],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                      }
+                    ]
+                  SessionTimeout: 90
+                  MaxConcurrency: 25
+                  MaxRetryAttempts: 5
+                  PendingAnalysisWaitTimeoutMinutes: 5
+
+              # =====================================================
+              # CODE SIGNING (VSIX OPC SIGNING)
               # =====================================================
 
               - task: EsrpCodeSigning@5
@@ -191,7 +237,10 @@ extends:
                     echo "Publishing VSIX package: $VSIX_PATH"
                     echo "Using PAT: ${TOKEN:0:4}**** (masked)"
 
-                    npx vsce publish --pat "$TOKEN" --packagePath "$VSIX_PATH"
+                    MANIFEST_PATH="$(Pipeline.Workspace)/vscode-extension-unsigned/extension.manifest"
+                    SIGNATURE_PATH="$(Pipeline.Workspace)/vscode-extension-unsigned/extension.signature.p7s"
+
+                    npx vsce publish --pat "$TOKEN" --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
                 env:
                   TOKEN: ${{ parameters.token }}
 


### PR DESCRIPTION
This pull request updates the extension publishing pipeline to add manifest generation and signing steps before code signing, and ensures the signed manifest and signature are included in the publishing process. 

**Manifest Generation and Signing:**

* Added steps to generate an extension manifest from the VSIX using `vsce generate-manifest`, prepare it for signing, and sign it with ESRP (VSCodePublisherSign) prior to the existing code signing steps in `.github/workflows/1es-pipeline.yml`.

**Publishing Process:**

* Updated the publish command to include the signed manifest and signature by passing `--manifestPath` and `--signaturePath` to `vsce publish`, ensuring the signed artifacts are published with the extension.