### PR TITLE
InspektorGadget v0.51.0 Update & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.38.0",
+                    "default": "v0.51.0",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },

--- a/src/commands/aksInspektorGadget/clusterOperations.ts
+++ b/src/commands/aksInspektorGadget/clusterOperations.ts
@@ -4,6 +4,7 @@ import { invokeKubectlCommand, streamKubectlOutput } from "../utils/kubectl";
 import { KubernetesClusterInfo } from "../utils/clusters";
 import { OutputStream } from "../utils/commands";
 import { asFlatItems, parseOutputLine } from "./traceItems";
+import { getKubectlGadgetConfig } from "../utils/config";
 import {
     GadgetArguments,
     GadgetVersion,
@@ -81,7 +82,10 @@ export class KubectlClusterOperations implements ClusterOperations {
     }
 
     private getKubectlArgs(args: GadgetArguments): string[] {
-        const pluginCommand = ["gadget", args.gadgetCategory, args.gadgetResource, "--output", "json"];
+        const config = getKubectlGadgetConfig();
+        const tag = failed(config) ? "latest" : config.result.releaseTag;
+        const gadgetImageName = `${args.gadgetCategory}_${args.gadgetResource.replace(/-/g, "")}:${tag}`;
+        const pluginCommand = ["gadget", "run", gadgetImageName, "-o", "json"];
         const nodeNameFilter = args.filters.nodeName ? ["--node", args.filters.nodeName] : [];
         const namespaceFilter =
             args.filters.namespace === NamespaceSelection.Default
@@ -100,8 +104,7 @@ export class KubectlClusterOperations implements ClusterOperations {
               ]
             : [];
         const sort = args.sortString ? ["--sort", args.sortString] : [];
-        const limit = args.maxRows ? ["--max-rows", args.maxRows.toString()] : [];
-        const interval = args.interval ? ["--interval", args.interval.toString()] : [];
+        const limit = args.maxRows ? ["--max-entries", args.maxRows.toString()] : [];
         const timeout = args.timeout ? ["--timeout", args.timeout.toString()] : [];
         return [
             ...pluginCommand,
@@ -112,7 +115,6 @@ export class KubectlClusterOperations implements ClusterOperations {
             ...labelFilter,
             ...sort,
             ...limit,
-            ...interval,
             ...timeout,
         ];
     }
@@ -132,12 +134,22 @@ export class KubectlClusterOperations implements ClusterOperations {
     async getPods(namespace: string): Promise<Errorable<string[]>> {
         const command = `get pod -n ${namespace} --no-headers -o custom-columns=":metadata.name"`;
         const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
-        return errmap(commandResult, (sr) => sr.stdout.trim().split("\n"));
+        return errmap(commandResult, (sr) =>
+            sr.stdout
+                .trim()
+                .split("\n")
+                .filter((s) => s.length > 0),
+        );
     }
 
     async getContainers(namespace: string, podName: string): Promise<Errorable<string[]>> {
         const command = `get pod -n ${namespace} ${podName} -o jsonpath={.spec.containers[*].name}`;
         const commandResult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFile, command);
-        return errmap(commandResult, (sr) => sr.stdout.trim().split(" "));
+        return errmap(commandResult, (sr) =>
+            sr.stdout
+                .trim()
+                .split(" ")
+                .filter((s) => s.length > 0),
+        );
     }
 }

--- a/src/commands/aksInspektorGadget/traceItems.ts
+++ b/src/commands/aksInspektorGadget/traceItems.ts
@@ -5,7 +5,59 @@ import { isArray, isObject } from "../utils/runtimeTypes";
 
 // The keys of values which should be serialized as JSON, rather than flattened or spread into separate
 // objects (see `asFlatItems`).
-const jsonKeys = ["userStack", "kernelStack", "addresses", "args"];
+const jsonKeys = ["user_stack", "kern_stack", "addresses", "args"];
+
+/**
+ * Helper to normalize image-based gadget JSON output to match the flat field structure implemented
+ * by the webview. Image-based gadgets now nest process info under "proc", credentials under
+ * "proc.creds", and parent process info under "proc.parent". This function hoists those
+ * fields to the top level so that our existing field definitions continue to work.
+ */
+function normalizeItem(item: Record<string, unknown>): Record<string, unknown> {
+    const result = { ...item };
+
+    // Hoist process fields from proc.* to the top level
+    if (isObject(result.proc)) {
+        const proc = result.proc as Record<string, unknown>;
+        const hoistKeys = ["comm", "pid", "tid", "mntns_id"];
+        for (const key of hoistKeys) {
+            if (key in proc && !(key in result)) {
+                result[key] = proc[key];
+            }
+        }
+
+        // Hoist uid / gid from proc.creds.*
+        if (isObject(proc.creds)) {
+            const creds = proc.creds as Record<string, unknown>;
+            for (const key of ["uid", "gid"]) {
+                if (key in creds && !(key in result)) {
+                    result[key] = creds[key];
+                }
+            }
+        }
+
+        // Hoist parent pid as ppid
+        if (isObject(proc.parent)) {
+            const parent = proc.parent as Record<string, unknown>;
+            if ("pid" in parent && !("ppid" in result)) {
+                result.ppid = parent.pid;
+            }
+        }
+
+        delete result.proc;
+    }
+
+    // v0.51 moved the numeric timestamp to timestamp_raw; use it as timestamp.
+    if ("timestamp_raw" in result) {
+        result.timestamp = result.timestamp_raw;
+        delete result.timestamp_raw;
+    }
+
+    // Remove runtime node (not used by our UI)
+    delete result.runtime;
+
+    return result;
+}
 
 /**
  * Takes IG output and converts it to an array of (unflattened) objects.
@@ -36,7 +88,8 @@ export function parseOutputLine(line: string): Errorable<object[]> {
  * @returns An array of objects that contain no nested objects or arrays for consumption by the webview presentation layer.
  */
 export function asFlatItems(item: object): TraceOutputItem[] {
-    const allObjectEntries = Object.entries(item).reduce(addFlatEntries, [[]]);
+    const normalized = normalizeItem(item as Record<string, unknown>);
+    const allObjectEntries = Object.entries(normalized).reduce(addFlatEntries, [[]]);
     return allObjectEntries.map((objectEntries) => Object.fromEntries(objectEntries) as TraceOutputItem);
 }
 

--- a/src/commands/utils/download/download.ts
+++ b/src/commands/utils/download/download.ts
@@ -3,7 +3,8 @@ import { succeeded, Errorable, getErrorMessage } from "../errorable";
 import { Dictionary } from "../dictionary";
 import { sleep } from "../sleep";
 import { mkdir } from "fs/promises";
-import { WriteStream, createWriteStream } from "fs";
+import { createWriteStream } from "fs";
+import { pipeline } from "stream/promises";
 import fetch from "node-fetch";
 
 const DOWNLOAD_ONCE_STATUS: Dictionary<DownloadOperationStatus> = {};
@@ -16,7 +17,11 @@ enum DownloadOperationStatus {
 
 export async function to(sourceUrl: string, destinationFile: string): Promise<Errorable<null>> {
     try {
-        await download(sourceUrl, destinationFile);
+        const result = await download(sourceUrl, destinationFile);
+
+        if (!succeeded(result)) {
+            return result;
+        }
 
         return { succeeded: true, result: null };
     } catch (e) {
@@ -57,26 +62,15 @@ async function download(url: string, outputFilepath: string): Promise<Errorable<
         return { succeeded: false, error: `Unable to create directory ${directory}: ${getErrorMessage(e)}` };
     }
 
-    let fileStream: WriteStream;
-    try {
-        fileStream = createWriteStream(outputFilepath);
-    } catch (e) {
-        return { succeeded: false, error: `Unable to create file ${outputFilepath}: ${getErrorMessage(e)}` };
-    }
-
     try {
         const response = await fetch(url);
         if (response.body === null) {
             return { succeeded: false, error: `No body in response from ${url}` };
         }
 
-        for await (const chunk of response.body) {
-            fileStream.write(chunk);
-        }
+        await pipeline(response.body, createWriteStream(outputFilepath));
     } catch (e) {
         return { succeeded: false, error: `Error downloading from ${url} to ${outputFilepath}: ${getErrorMessage(e)}` };
-    } finally {
-        fileStream.end();
     }
 
     return { succeeded: true, result: undefined };

--- a/src/panels/InspektorGadgetPanel.ts
+++ b/src/panels/InspektorGadgetPanel.ts
@@ -26,6 +26,7 @@ export interface InspektorGadgetConfig {
 export class InspektorGadgetPanel extends BasePanel<"gadget"> {
     constructor(extensionUri: vscode.Uri) {
         super(extensionUri, "gadget", {
+            deployFailed: null,
             getContainersResponse: null,
             getNamespacesResponse: null,
             getNodesResponse: null,
@@ -136,6 +137,7 @@ export class InspektorGadgetDataProvider implements PanelDataProvider<"gadget"> 
         const version = await this.clusterOperations.deploy();
         if (failed(version)) {
             vscode.window.showErrorMessage(version.error);
+            webview.postDeployFailed(version.error);
             return;
         }
 
@@ -146,6 +148,7 @@ export class InspektorGadgetDataProvider implements PanelDataProvider<"gadget"> 
         const version = await this.clusterOperations.undeploy();
         if (failed(version)) {
             vscode.window.showErrorMessage(version.error);
+            webview.postDeployFailed(version.error);
             return;
         }
 

--- a/src/webview-contract/webviewDefinitions/inspektorGadget.ts
+++ b/src/webview-contract/webviewDefinitions/inspektorGadget.ts
@@ -68,6 +68,7 @@ export type ToVsCodeMsgDef = {
 
 export type ToWebViewMsgDef = {
     updateVersion: GadgetVersion;
+    deployFailed: string;
     runTraceResponse: {
         traceId: number;
         items: TraceOutputItem[];

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -105,9 +105,9 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
         const { namespace, podName, containerName, ...rest } = traceConfig.filters!;
         const newNamespace = extraProperties.noK8sResourceFiltering
             ? NamespaceSelection.Default
-            : !namespace
-              ? NamespaceSelection.All
-              : namespace;
+            : selection.namespace
+              ? selection.namespace
+              : NamespaceSelection.All;
         const filters = { ...rest, ...selection, namespace: newNamespace };
         setTraceConfig({ ...traceConfig, filters });
     }

--- a/webview-ui/src/InspektorGadget/ResourceSelector.tsx
+++ b/webview-ui/src/InspektorGadget/ResourceSelector.tsx
@@ -1,33 +1,19 @@
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import styles from "./InspektorGadget.module.css";
-import { NamespaceResources, PodResources } from "./helpers/clusterResources";
-import { Lazy, isLoaded, isNotLoaded, map as lazyMap, orDefault } from "../utilities/lazy";
-import { Lookup, asLookup, exclude, intersection } from "../utilities/array";
+import { NamespaceResources } from "./helpers/clusterResources";
+import { isLoaded, isNotLoaded } from "../utilities/lazy";
 import { EventHandlers } from "../utilities/state";
 import { EventDef, vscode } from "./helpers/state";
 import { ProgressRing } from "../components/ProgressRing";
 
 type ChangeEvent = Event | FormEvent<HTMLElement>;
 
-type PodItemStatus = {
-    isExpanded: boolean;
-};
-
-type AllPodItemStatuses = Lookup<PodItemStatus>;
-
-type NamespaceItemStatus = {
-    isExpanded: boolean;
-    podStatuses: AllPodItemStatuses;
-};
-
-type AllNamespaceItemStatuses = Lookup<NamespaceItemStatus>;
-
-const resourceProperties = { namespace: "namespace", podName: "podName", container: "container" } as const;
+const resourceProperties = { namespace: "namespace", podName: "podName", containerName: "containerName" } as const;
 type SelectedNamespace = { [resourceProperties.namespace]: string };
 type SelectedPod = SelectedNamespace & { [resourceProperties.podName]: string };
-type SelectedContainer = SelectedPod & { [resourceProperties.container]: string };
+type SelectedContainer = SelectedPod & { [resourceProperties.containerName]: string };
 
 type SelectedResource = Record<string, never> | SelectedNamespace | SelectedPod | SelectedContainer;
 
@@ -39,171 +25,79 @@ function isNamespaceResource(selectedResource: SelectedResource): selectedResour
     return (
         resourceProperties.namespace in selectedResource &&
         !(resourceProperties.podName in selectedResource) &&
-        !(resourceProperties.container in selectedResource)
+        !(resourceProperties.containerName in selectedResource)
     );
 }
 
 function isPodResource(selectedResource: SelectedResource): selectedResource is SelectedPod {
-    return resourceProperties.podName in selectedResource && !(resourceProperties.container in selectedResource);
+    return resourceProperties.podName in selectedResource && !(resourceProperties.containerName in selectedResource);
 }
 
 function isContainerResource(selectedResource: SelectedResource): selectedResource is SelectedContainer {
-    return resourceProperties.container in selectedResource;
-}
-
-function lazyAsLookup<T>(lazyList: Lazy<T[]>, keyFn: (value: T) => string): Lookup<T> {
-    return orDefault(
-        lazyMap(lazyList, (items) => asLookup(items, keyFn)),
-        {},
-    );
-}
-
-function getUpdatedNamespaceItemStatus(status: NamespaceItemStatus, resource: NamespaceResources): NamespaceItemStatus {
-    const resources = lazyAsLookup(resource.children, (p) => p.name);
-    const pods = Object.keys(resources);
-    const podsWithStatus = Object.keys(status.podStatuses);
-    const existingStatuses = intersection(pods, podsWithStatus).map((p) => [p, status.podStatuses[p]]);
-    const newStatuses = exclude(pods, podsWithStatus).map((p) => [p, { isExpanded: false }]);
-    const podStatuses = Object.fromEntries(existingStatuses.concat(newStatuses));
-    return { ...status, podStatuses };
-}
-
-function getUpdatedStatus(
-    status: AllNamespaceItemStatuses,
-    clusterResources: NamespaceResources[],
-): AllNamespaceItemStatuses {
-    const resources = asLookup(clusterResources, (ns) => ns.name);
-    const namespaces = Object.keys(resources);
-    const namespacesWithStatus = Object.keys(status);
-    const existingStatuses = intersection(namespaces, namespacesWithStatus).map((ns) => [
-        ns,
-        getUpdatedNamespaceItemStatus(status[ns], resources[ns]),
-    ]);
-    const newStatuses = exclude(namespaces, namespacesWithStatus).map((ns) => [
-        ns,
-        getUpdatedNamespaceItemStatus({ isExpanded: false, podStatuses: {} }, resources[ns]),
-    ]);
-    return Object.fromEntries(existingStatuses.concat(newStatuses));
+    return resourceProperties.containerName in selectedResource;
 }
 
 export interface ResourceSelectorProps {
     id?: string;
     className?: string;
     resources: NamespaceResources[];
-    onSelectionChanged: (selection: { namespace?: string; podName?: string; container?: string }) => void;
+    onSelectionChanged: (selection: { namespace?: string; podName?: string; containerName?: string }) => void;
     userMessageHandlers: EventHandlers<EventDef>;
 }
 
+// Expansion state to track which namespaces and pods are expanded.
+type ExpandedState = {
+    namespaces: Record<string, boolean>;
+    pods: Record<string, boolean>; // keyed as "namespace/podName"
+};
+
 export function ResourceSelector(props: ResourceSelectorProps) {
-    const [status, setStatus] = useState<AllNamespaceItemStatuses>({});
+    const [expanded, setExpanded] = useState<ExpandedState>({ namespaces: {}, pods: {} });
     const [selectedResource, setSelectedResource] = useState<SelectedResource>({});
 
-    const updatedStatus = getUpdatedStatus(status, props.resources);
-    useEffect(() => {
-        setStatus(updatedStatus);
-    }, [props.resources, updatedStatus]);
-
-    return (
-        <ul
-            id={props.id}
-            className={props.className ? `${props.className} ${styles.hierarchyList}` : styles.hierarchyList}
-        >
-            <li>
-                <div className={styles.radioLine}>
-                    <input
-                        type="radio"
-                        onChange={handleNoResourceChange}
-                        checked={isNoResource(selectedResource)}
-                    ></input>
-                    <label className={styles.radioLabel}>All</label>
-                </div>
-            </li>
-            {renderNamespaceItems(props.resources, updatedStatus)}
-        </ul>
-    );
-
-    function renderNamespaceItems(items: NamespaceResources[], status: AllNamespaceItemStatuses) {
-        return items.map((item) => (
-            <li key={item.name}>
-                <FontAwesomeIcon
-                    className={styles.expander}
-                    onClick={() => toggleNamespaceExpanded(item.name)}
-                    icon={status[item.name].isExpanded ? faChevronDown : faChevronRight}
-                />
-                <div className={styles.radioLine}>
-                    <input
-                        type="radio"
-                        className={styles.selector}
-                        onChange={(e) => handleNamespaceChange(e, item.name)}
-                        checked={isNamespaceResource(selectedResource) && selectedResource.namespace === item.name}
-                    ></input>
-                    <label className={styles.radioLabel}>{item.name}</label>
-                </div>
-                {status[item.name].isExpanded && (
-                    <ul className={styles.hierarchyList}>
-                        {isLoaded(item.children) ? (
-                            renderPodItems(item.name, item.children.value, status[item.name].podStatuses)
-                        ) : (
-                            <ProgressRing />
-                        )}
-                    </ul>
-                )}
-            </li>
-        ));
+    function isNamespaceExpanded(ns: string): boolean {
+        return !!expanded.namespaces[ns];
     }
 
-    function renderPodItems(namespace: string, items: PodResources[], status: AllPodItemStatuses) {
-        return items.map((item) => (
-            <li key={item.name}>
-                <FontAwesomeIcon
-                    className={styles.expander}
-                    onClick={() => togglePodExpanded(namespace, item.name)}
-                    icon={status[item.name].isExpanded ? faChevronDown : faChevronRight}
-                />
-                <div className={styles.radioLine}>
-                    <input
-                        type="radio"
-                        onChange={(e) => handlePodChange(e, namespace, item.name)}
-                        checked={
-                            isPodResource(selectedResource) &&
-                            selectedResource.namespace === namespace &&
-                            selectedResource.podName === item.name
-                        }
-                    ></input>
-
-                    <label className={styles.radioLabel}>{item.name}</label>
-                </div>
-                {status[item.name].isExpanded && (
-                    <ul className={styles.hierarchyList}>
-                        {isLoaded(item.children) ? (
-                            renderContainerItems(namespace, item.name, item.children.value)
-                        ) : (
-                            <ProgressRing />
-                        )}
-                    </ul>
-                )}
-            </li>
-        ));
+    // Pods are keyed as "namespace/podName"
+    function isPodExpanded(ns: string, pod: string): boolean {
+        return !!expanded.pods[`${ns}/${pod}`];
     }
 
-    function renderContainerItems(namespace: string, podName: string, containerNames: string[]) {
-        return containerNames.map((c) => (
-            <li key={c}>
-                <div className={styles.radioLine}>
-                    <input
-                        type="radio"
-                        onChange={(e) => handleContainerChange(e, namespace, podName, c)}
-                        checked={
-                            isContainerResource(selectedResource) &&
-                            selectedResource.namespace === namespace &&
-                            selectedResource.podName === podName &&
-                            selectedResource.container === c
-                        }
-                    ></input>
-                    <label className={styles.radioLabel}>{c}</label>
-                </div>
-            </li>
-        ));
+    function toggleNamespaceExpanded(namespace: string) {
+        const wasExpanded = isNamespaceExpanded(namespace);
+        setExpanded((prev) => ({
+            ...prev,
+            namespaces: { ...prev.namespaces, [namespace]: !wasExpanded },
+        }));
+
+        if (!wasExpanded) {
+            const nsResource = props.resources.find((ns) => ns.name === namespace);
+            if (nsResource && isNotLoaded(nsResource.children)) {
+                props.userMessageHandlers.onSetPodsLoading({ namespace });
+                vscode.postGetPodsRequest({ namespace });
+            }
+        }
+    }
+
+    function togglePodExpanded(namespace: string, podName: string) {
+        const key = `${namespace}/${podName}`;
+        const wasExpanded = isPodExpanded(namespace, podName);
+        setExpanded((prev) => ({
+            ...prev,
+            pods: { ...prev.pods, [key]: !wasExpanded },
+        }));
+
+        if (!wasExpanded) {
+            const nsResource = props.resources.find((ns) => ns.name === namespace);
+            if (nsResource && isLoaded(nsResource.children)) {
+                const podResource = nsResource.children.value.find((p) => p.name === podName);
+                if (podResource && isNotLoaded(podResource.children)) {
+                    props.userMessageHandlers.onSetContainersLoading({ namespace, podName });
+                    vscode.postGetContainersRequest({ namespace, podName });
+                }
+            }
+        }
     }
 
     function handleNoResourceChange(e: ChangeEvent) {
@@ -227,44 +121,134 @@ export function ResourceSelector(props: ResourceSelectorProps) {
         }
     }
 
-    function handleContainerChange(e: ChangeEvent, namespace: string, podName: string, container: string) {
+    function handleContainerChange(e: ChangeEvent, namespace: string, podName: string, containerName: string) {
         if ((e.target as HTMLInputElement).checked) {
-            setSelectedResource({ namespace, podName, container });
-            props.onSelectionChanged({ namespace, podName, container });
+            setSelectedResource({ namespace, podName, containerName });
+            props.onSelectionChanged({ namespace, podName, containerName });
         }
     }
 
-    function toggleNamespaceExpanded(namespace: string) {
-        const namespaceItem = status[namespace];
-        const newNamespaceItem = { ...namespaceItem, isExpanded: !namespaceItem.isExpanded };
-        const newStatus = { ...status, [namespace]: newNamespaceItem };
-        setStatus(newStatus);
-
-        if (newNamespaceItem.isExpanded) {
-            const nsResources = asLookup(props.resources, (ns) => ns.name);
-            if (isNotLoaded(nsResources[namespace].children)) {
-                props.userMessageHandlers.onSetPodsLoading({ namespace });
-                vscode.postGetPodsRequest({ namespace });
-            }
-        }
-    }
-
-    function togglePodExpanded(namespace: string, podName: string) {
-        const namespaceItem = status[namespace];
-        const podItem = namespaceItem.podStatuses[podName];
-        const newPodItem = { ...podItem, isExpanded: !podItem.isExpanded };
-        const newPodStatuses = { ...namespaceItem.podStatuses, [podName]: newPodItem };
-        const newNamespaceItem = { ...namespaceItem, podStatuses: newPodStatuses };
-        const newStatus = { ...status, [namespace]: newNamespaceItem };
-        setStatus(newStatus);
-
-        if (newPodItem.isExpanded) {
-            const nsResources = asLookup(props.resources, (ns) => ns.name);
-            const podResources = lazyAsLookup(nsResources[namespace].children, (pod) => pod.name);
-            if (isNotLoaded(podResources[podName].children)) {
-                props.userMessageHandlers.onSetContainersLoading({ namespace, podName });
-                vscode.postGetContainersRequest({ namespace, podName });
-            }
-        }
-    }
+    return (
+        <ul
+            id={props.id}
+            className={props.className ? `${props.className} ${styles.hierarchyList}` : styles.hierarchyList}
+        >
+            <li>
+                <div className={styles.radioLine}>
+                    <input
+                        type="radio"
+                        onChange={handleNoResourceChange}
+                        checked={isNoResource(selectedResource)}
+                    ></input>
+                    <label className={styles.radioLabel}>All</label>
+                </div>
+            </li>
+            {props.resources.map((nsItem) => (
+                <li key={nsItem.name}>
+                    <FontAwesomeIcon
+                        className={styles.expander}
+                        onClick={() => toggleNamespaceExpanded(nsItem.name)}
+                        icon={isNamespaceExpanded(nsItem.name) ? faChevronDown : faChevronRight}
+                    />
+                    <div className={styles.radioLine}>
+                        <input
+                            type="radio"
+                            className={styles.selector}
+                            onChange={(e) => handleNamespaceChange(e, nsItem.name)}
+                            checked={
+                                isNamespaceResource(selectedResource) && selectedResource.namespace === nsItem.name
+                            }
+                        ></input>
+                        <label className={styles.radioLabel}>{nsItem.name}</label>
+                    </div>
+                    {isNamespaceExpanded(nsItem.name) && (
+                        <ul className={styles.hierarchyList}>
+                            {isLoaded(nsItem.children) ? (
+                                nsItem.children.value.length === 0 ? (
+                                    <li>
+                                        <label className={styles.radioLabel}>
+                                            <i>No pods</i>
+                                        </label>
+                                    </li>
+                                ) : (
+                                    nsItem.children.value.map((podItem) => (
+                                        <li key={podItem.name}>
+                                            <FontAwesomeIcon
+                                                className={styles.expander}
+                                                onClick={() => togglePodExpanded(nsItem.name, podItem.name)}
+                                                icon={
+                                                    isPodExpanded(nsItem.name, podItem.name)
+                                                        ? faChevronDown
+                                                        : faChevronRight
+                                                }
+                                            />
+                                            <div className={styles.radioLine}>
+                                                <input
+                                                    type="radio"
+                                                    onChange={(e) => handlePodChange(e, nsItem.name, podItem.name)}
+                                                    checked={
+                                                        isPodResource(selectedResource) &&
+                                                        selectedResource.namespace === nsItem.name &&
+                                                        selectedResource.podName === podItem.name
+                                                    }
+                                                ></input>
+                                                <label className={styles.radioLabel}>{podItem.name}</label>
+                                            </div>
+                                            {isPodExpanded(nsItem.name, podItem.name) && (
+                                                <ul className={styles.hierarchyList}>
+                                                    {isLoaded(podItem.children) ? (
+                                                        podItem.children.value.length === 0 ? (
+                                                            <li>
+                                                                <label className={styles.radioLabel}>
+                                                                    <i>No containers</i>
+                                                                </label>
+                                                            </li>
+                                                        ) : (
+                                                            podItem.children.value.map((containerName) => (
+                                                                <li key={containerName}>
+                                                                    <div className={styles.radioLine}>
+                                                                        <input
+                                                                            type="radio"
+                                                                            onChange={(e) =>
+                                                                                handleContainerChange(
+                                                                                    e,
+                                                                                    nsItem.name,
+                                                                                    podItem.name,
+                                                                                    containerName,
+                                                                                )
+                                                                            }
+                                                                            checked={
+                                                                                isContainerResource(selectedResource) &&
+                                                                                selectedResource.namespace ===
+                                                                                    nsItem.name &&
+                                                                                selectedResource.podName ===
+                                                                                    podItem.name &&
+                                                                                selectedResource.containerName ===
+                                                                                    containerName
+                                                                            }
+                                                                        ></input>
+                                                                        <label className={styles.radioLabel}>
+                                                                            {containerName}
+                                                                        </label>
+                                                                    </div>
+                                                                </li>
+                                                            ))
+                                                        )
+                                                    ) : (
+                                                        <ProgressRing />
+                                                    )}
+                                                </ul>
+                                            )}
+                                        </li>
+                                    ))
+                                )
+                            ) : (
+                                <ProgressRing />
+                            )}
+                        </ul>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
 }

--- a/webview-ui/src/InspektorGadget/helpers/gadgets.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets.ts
@@ -6,7 +6,7 @@ import {
 import { ProcessThreadKey } from "./gadgets/common";
 import { cpuProfileMetadata } from "./gadgets/profile";
 import { processSnapshotMetadata, socketSnapshotMetadata } from "./gadgets/snapshot";
-import { blockIOTopMetadata, ebpfTopMetadata, fileTopMetadata, tcpTopMetadata } from "./gadgets/top";
+import { blockIOTopMetadata, fileTopMetadata, tcpTopMetadata } from "./gadgets/top";
 import { dnsTraceMetadata, execTraceMetadata, tcpTraceMetadata } from "./gadgets/trace";
 import {
     DataItem,
@@ -65,7 +65,6 @@ const snapshotGadgetResources: ConfiguredGadgetResources<GadgetSnapshotResource>
 const topGadgetResources: ConfiguredGadgetResources<GadgetTopResource> = {
     tcp: tcpTopMetadata,
     "block-io": blockIOTopMetadata,
-    ebpf: ebpfTopMetadata,
     file: fileTopMetadata,
 };
 

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/common.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/common.ts
@@ -26,10 +26,10 @@ export const eventKeyMetadata: ItemMetadata<EventKey> = {
 };
 
 // Mount namespace
-export const mountNsKeys = ["mountnsid"] as const;
+export const mountNsKeys = ["mntns_id"] as const;
 export type MountNsKey = (typeof mountNsKeys)[number];
 export const mountNsKeyMetadata: ItemMetadata<MountNsKey> = {
-    mountnsid: { identifier: "mntns", name: "MountNsID" },
+    mntns_id: { identifier: "mntns", name: "MountNsID" },
 };
 
 // Network endpoints

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/profile.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/profile.ts
@@ -15,16 +15,16 @@ type CpuProfileKey =
     | (typeof k8sKeys)[number]
     | (typeof commandKeys)[number]
     | "pid"
-    | "userStack"
-    | "kernelStack"
-    | "count";
+    | "user_stack"
+    | "kern_stack"
+    | "samples";
 const cpuProfileKeyMetadata: ItemMetadata<CpuProfileKey> = {
     ...k8sKeyMetadata,
     ...commandKeyMetadata,
     pid: { identifier: "pid", name: "PID" },
-    userStack: { identifier: "userStack", name: "User Stack" },
-    kernelStack: { identifier: "kernelStack", name: "Kernel Stack" },
-    count: { identifier: "gid", name: "GID" },
+    user_stack: { identifier: "userStack", name: "User Stack" },
+    kern_stack: { identifier: "kernelStack", name: "Kernel Stack" },
+    samples: { identifier: "count", name: "Count" },
 };
 type DerivedCpuProfileKey = "stack";
 const allCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey>[] = [
@@ -34,8 +34,8 @@ const allCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey
         "stack",
         (item) => {
             const kernelStack =
-                item.kernelStack && typeof item.kernelStack === "string" ? JSON.parse(item.kernelStack) : [];
-            const userStack = item.userStack && typeof item.userStack === "string" ? JSON.parse(item.userStack) : [];
+                item.kern_stack && typeof item.kern_stack === "string" ? JSON.parse(item.kern_stack) : [];
+            const userStack = item.user_stack && typeof item.user_stack === "string" ? JSON.parse(item.user_stack) : [];
             return [...kernelStack, ...userStack].join("\n");
         },
         ValueType.StackTrace,
@@ -43,7 +43,7 @@ const allCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey
 ];
 const defaultCpuProfileProperties: ItemProperty<CpuProfileKey | DerivedCpuProfileKey>[] = toProperties(
     allCpuProfileProperties,
-    ["k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName", "comm", "pid", "count", "stack"],
+    ["k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName", "comm", "pid", "samples", "stack"],
 );
 export const cpuProfileMetadata: GadgetMetadata<CpuProfileKey | DerivedCpuProfileKey> = {
     name: "CPU",

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/snapshot.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/snapshot.ts
@@ -75,20 +75,18 @@ export const processSnapshotMetadata: GadgetMetadata<ProcessSnapshotKey> = {
 type SocketSnapshotKey =
     | (typeof k8sKeys)[number]
     | (typeof eventKeys)[number]
-    | "netnsid"
-    | "protocol"
+    | "netns_id"
     | (typeof networkEndpointKeys)[number]
-    | "status"
-    | "inodeNumber";
+    | "state"
+    | "ino";
 
 const socketSnapshotKeyMetadata: ItemMetadata<SocketSnapshotKey> = {
     ...k8sKeyMetadata,
     ...eventKeyMetadata,
-    netnsid: { identifier: "netns", name: "NetNS" },
-    protocol: { identifier: "protocol", name: "Protocol" },
+    netns_id: { identifier: "netns", name: "NetNS" },
     ...networkEndpointKeyMetadata,
-    status: { identifier: "status", name: "Status" },
-    inodeNumber: { identifier: "inode", name: "Inode" },
+    state: { identifier: "status", name: "Status" },
+    ino: { identifier: "inode", name: "Inode" },
 };
 type DerivedSocketSnapshotKey = (typeof derivedNetworkEndpointKeys)[number];
 
@@ -98,17 +96,16 @@ const allSocketSnapshotProperties: ItemProperty<SocketSnapshotKey | DerivedSocke
 ];
 const defaultSocketSnapshotProperties: ItemProperty<SocketSnapshotKey | DerivedSocketSnapshotKey>[] = toProperties(
     allSocketSnapshotProperties,
-    ["k8s.node", "k8s.namespace", "k8s.podName", "protocol", "src", "dst", "status"],
+    ["k8s.node", "k8s.namespace", "k8s.podName", "src", "dst", "state"],
 );
 const defaultSocketSnapshotSort = getSortSpecifiers(allSocketSnapshotProperties, [
     { key: "k8s.node", direction: SortDirection.Ascending },
     { key: "k8s.namespace", direction: SortDirection.Ascending },
     { key: "k8s.podName", direction: SortDirection.Ascending },
-    { key: "protocol", direction: SortDirection.Ascending },
-    { key: "status", direction: SortDirection.Ascending },
+    { key: "state", direction: SortDirection.Ascending },
     { key: "src", direction: SortDirection.Ascending },
     { key: "dst", direction: SortDirection.Ascending },
-    { key: "inodeNumber", direction: SortDirection.Ascending },
+    { key: "ino", direction: SortDirection.Ascending },
 ]);
 export const socketSnapshotMetadata: GadgetMetadata<SocketSnapshotKey | DerivedSocketSnapshotKey> = {
     name: "Sockets",

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/top.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/top.ts
@@ -17,7 +17,6 @@ import {
     ItemProperty,
     SortDirection,
     ValueType,
-    getDerivedProperty,
     getLiteralProperties,
     getSortSpecifiers,
     toProperties,
@@ -29,24 +28,24 @@ type BlockIOTopKey =
     | (typeof mountNsKeys)[number]
     | "pid"
     | (typeof commandKeys)[number]
-    | "write"
+    | "rw"
     | "major"
     | "minor"
     | "bytes"
     | "us"
-    | "ops";
+    | "io";
 
 const blockIOTopKeyMetadata: ItemMetadata<BlockIOTopKey> = {
     ...k8sKeyMetadata,
     ...mountNsKeyMetadata,
     pid: { identifier: "pid", name: "PID" },
     ...commandKeyMetadata,
-    write: { identifier: "r/w", name: "R/W" },
+    rw: { identifier: "r/w", name: "R/W" },
     major: { identifier: "major", name: "Major" },
     minor: { identifier: "minor", name: "Minor" },
     bytes: { identifier: "bytes", name: "Bytes" },
     us: { identifier: "time", name: "Time" },
-    ops: { identifier: "ops", name: "Ops" },
+    io: { identifier: "ops", name: "Ops" },
 };
 const allBlockIOTopProperties: ItemProperty<BlockIOTopKey>[] = [...getLiteralProperties(blockIOTopKeyMetadata)];
 const defaultBlockIOTopProperties: ItemProperty<BlockIOTopKey>[] = toProperties(allBlockIOTopProperties, [
@@ -56,15 +55,15 @@ const defaultBlockIOTopProperties: ItemProperty<BlockIOTopKey>[] = toProperties(
     "k8s.containerName",
     "pid",
     "comm",
-    "write",
+    "rw",
     "major",
     "minor",
     "bytes",
     "us",
-    "ops",
+    "io",
 ]);
 const defaultBlockIOTopSort = getSortSpecifiers(allBlockIOTopProperties, [
-    { key: "ops", direction: SortDirection.Descending },
+    { key: "io", direction: SortDirection.Descending },
     { key: "bytes", direction: SortDirection.Descending },
     { key: "us", direction: SortDirection.Descending },
 ]);
@@ -148,10 +147,10 @@ type FileTopKey =
     | "pid"
     | (typeof commandKeys)[number]
     | "reads"
-    | "rbytes"
-    | "fileType"
-    | "filename"
-    | "wbytes"
+    | "rbytes_raw"
+    | "t"
+    | "file"
+    | "wbytes_raw"
     | "writes";
 
 const fileTopKeyMetadata: ItemMetadata<FileTopKey> = {
@@ -160,10 +159,10 @@ const fileTopKeyMetadata: ItemMetadata<FileTopKey> = {
     pid: { identifier: "pid", name: "PID" },
     ...commandKeyMetadata,
     reads: { identifier: "reads", name: "Reads" },
-    rbytes: { identifier: "rbytes", name: "RBytes" },
-    fileType: { identifier: "t", name: "T", valueType: ValueType.CharByte },
-    filename: { identifier: "file", name: "File" },
-    wbytes: { identifier: "wbytes", name: "WBytes" },
+    rbytes_raw: { identifier: "rbytes", name: "RBytes" },
+    t: { identifier: "t", name: "T", valueType: ValueType.CharByte },
+    file: { identifier: "file", name: "File" },
+    wbytes_raw: { identifier: "wbytes", name: "WBytes" },
     writes: { identifier: "writes", name: "Writes" },
 };
 const allFileTopProperties: ItemProperty<FileTopKey>[] = [...getLiteralProperties(fileTopKeyMetadata)];
@@ -176,16 +175,16 @@ const defaultFileTopProperties: ItemProperty<FileTopKey>[] = toProperties(allFil
     "comm",
     "reads",
     "writes",
-    "rbytes",
-    "wbytes",
-    "fileType",
-    "filename",
+    "rbytes_raw",
+    "wbytes_raw",
+    "t",
+    "file",
 ]);
 const defaultFileTopSort = getSortSpecifiers(allFileTopProperties, [
     { key: "reads", direction: SortDirection.Descending },
     { key: "writes", direction: SortDirection.Descending },
-    { key: "rbytes", direction: SortDirection.Descending },
-    { key: "wbytes", direction: SortDirection.Descending },
+    { key: "rbytes_raw", direction: SortDirection.Descending },
+    { key: "wbytes_raw", direction: SortDirection.Descending },
 ]);
 export const fileTopMetadata: GadgetMetadata<FileTopKey> = {
     name: "Top File",
@@ -201,27 +200,23 @@ type TcpTopKey =
     | (typeof mountNsKeys)[number]
     | "pid"
     | (typeof commandKeys)[number]
-    | "family"
     | (typeof networkEndpointKeys)[number]
-    | "sent"
-    | "received";
+    | "sent_raw"
+    | "received_raw";
 
 const tcpTopKeyMetadata: ItemMetadata<TcpTopKey> = {
     ...k8sKeyMetadata,
     ...mountNsKeyMetadata,
     pid: { identifier: "pid", name: "PID" },
     ...commandKeyMetadata,
-    family: { identifier: "ip", name: "IP" },
     ...networkEndpointKeyMetadata,
-    sent: { identifier: "sent", name: "Sent", valueType: ValueType.Bytes },
-    received: { identifier: "recv", name: "Recv", valueType: ValueType.Bytes },
+    sent_raw: { identifier: "sent", name: "Sent", valueType: ValueType.Bytes },
+    received_raw: { identifier: "recv", name: "Recv", valueType: ValueType.Bytes },
 };
-type DerivedTcpTopKey = "ip" | (typeof derivedNetworkEndpointKeys)[number];
+type DerivedTcpTopKey = (typeof derivedNetworkEndpointKeys)[number];
 
 const allTcpTopProperties: ItemProperty<TcpTopKey | DerivedTcpTopKey>[] = [
     ...getLiteralProperties(tcpTopKeyMetadata),
-    // https://github.com/inspektor-gadget/inspektor-gadget/blob/08056695b8cfc02698afcbd41add88acfac4d8cf/pkg/gadgets/top/tcp/types/types.go#L64-L69
-    getDerivedProperty("IP", "ip", (item) => (item.family === 2 ? 4 : 6)),
     ...derivedNetworkEndpointProperties,
 ];
 const defaultTcpTopProperties: ItemProperty<TcpTopKey | DerivedTcpTopKey>[] = toProperties(allTcpTopProperties, [
@@ -231,15 +226,14 @@ const defaultTcpTopProperties: ItemProperty<TcpTopKey | DerivedTcpTopKey>[] = to
     "k8s.containerName",
     "pid",
     "comm",
-    "ip",
     "src",
     "dst",
-    "sent",
-    "received",
+    "sent_raw",
+    "received_raw",
 ]);
 const defaultTcpTopSort = getSortSpecifiers(allTcpTopProperties, [
-    { key: "sent", direction: SortDirection.Descending },
-    { key: "received", direction: SortDirection.Descending },
+    { key: "sent_raw", direction: SortDirection.Descending },
+    { key: "received_raw", direction: SortDirection.Descending },
 ]);
 export const tcpTopMetadata: GadgetMetadata<TcpTopKey | DerivedTcpTopKey> = {
     name: "Top TCP",

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/trace.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/trace.ts
@@ -32,36 +32,36 @@ type DnsTraceKey =
     | (typeof k8sKeys)[number]
     | (typeof timestampKeys)[number]
     | (typeof mountNsKeys)[number]
-    | "netnsid"
+    | "netns_id"
     | (typeof processThreadKeys)[number]
     | (typeof commandKeys)[number]
     | (typeof userKeys)[number]
     | "id"
     | "qr"
     | "nameserver"
-    | "pktType"
+    | "pkt_type"
     | "qtype"
     | "name"
     | "rcode"
-    | "numAnswers"
+    | "num_answers"
     | "addresses";
 
 const dnsTraceKeyMetadata: ItemMetadata<DnsTraceKey> = {
     ...k8sKeyMetadata,
     ...timestampKeyMetadata,
     ...mountNsKeyMetadata,
-    netnsid: { identifier: "netns", name: "NetNS" },
+    netns_id: { identifier: "netns", name: "NetNS" },
     ...processThreadKeyMetadata,
     ...commandKeyMetadata,
     ...userKeyMetadata,
     id: { identifier: "id", name: "ID" },
     qr: { identifier: "qr", name: "QR" },
     nameserver: { identifier: "nameserver", name: "Nameserver" },
-    pktType: { identifier: "type", name: "Type" },
+    pkt_type: { identifier: "type", name: "Type" },
     qtype: { identifier: "qtype", name: "QType" },
     name: { identifier: "name", name: "Name" },
     rcode: { identifier: "rcode", name: "RCode" },
-    numAnswers: { identifier: "numAnswers", name: "#Answers" },
+    num_answers: { identifier: "numAnswers", name: "#Answers" },
     addresses: { identifier: "addresses", name: "Addresses", valueType: ValueType.AddressArray },
 };
 const allDnsTraceProperties: ItemProperty<DnsTraceKey>[] = [...getLiteralProperties(dnsTraceKeyMetadata)];
@@ -73,11 +73,11 @@ const defaultDnsTraceProperties: ItemProperty<DnsTraceKey>[] = toProperties(allD
     "tid",
     "comm",
     "qr",
-    "pktType",
+    "pkt_type",
     "qtype",
     "name",
     "rcode",
-    "numAnswers",
+    "num_answers",
 ]);
 export const dnsTraceMetadata: GadgetMetadata<DnsTraceKey> = {
     name: "Trace DNS",
@@ -95,7 +95,7 @@ type ExecTraceKey =
     | "pid"
     | "ppid"
     | (typeof commandKeys)[number]
-    | "ret"
+    | "error"
     | "args"
     | (typeof userKeys)[number]
     | "loginuid"
@@ -109,7 +109,7 @@ const execTraceKeyMetadata: ItemMetadata<ExecTraceKey> = {
     pid: { identifier: "pid", name: "PID" },
     ppid: { identifier: "ppid", name: "PPID" },
     ...commandKeyMetadata,
-    ret: { identifier: "ret", name: "Return" },
+    error: { identifier: "error", name: "Error" },
     args: { identifier: "args", name: "Args" },
     ...userKeyMetadata,
     loginuid: { identifier: "loginuid", name: "LoginUID" },
@@ -125,7 +125,7 @@ const defaultExecTraceProperties: ItemProperty<ExecTraceKey>[] = toProperties(al
     "pid",
     "ppid",
     "comm",
-    "ret",
+    "error",
     "args",
 ]);
 export const execTraceMetadata: GadgetMetadata<ExecTraceKey> = {
@@ -139,19 +139,17 @@ export const execTraceMetadata: GadgetMetadata<ExecTraceKey> = {
 // TCP
 type TcpTraceKey =
     | (typeof k8sKeys)[number]
-    | "operation"
+    | "type"
     | "pid"
     | (typeof commandKeys)[number]
-    | "ipversion"
     | (typeof networkEndpointKeys)[number]
     | (typeof mountNsKeys)[number];
 
 const tcpTraceKeyMetadata: ItemMetadata<TcpTraceKey> = {
     ...k8sKeyMetadata,
-    operation: { identifier: "t", name: "T" },
+    type: { identifier: "t", name: "T" },
     pid: { identifier: "pid", name: "PID" },
     ...commandKeyMetadata,
-    ipversion: { identifier: "ip", name: "IP" },
     ...networkEndpointKeyMetadata,
     ...mountNsKeyMetadata,
 };
@@ -160,11 +158,11 @@ type DerivedTcpTraceKey = "t" | (typeof derivedNetworkEndpointKeys)[number];
 const allTcpTraceProperties: ItemProperty<TcpTraceKey | DerivedTcpTraceKey>[] = [
     ...getLiteralProperties(tcpTraceKeyMetadata),
     ...derivedNetworkEndpointProperties,
-    getDerivedProperty("T", "t", (item) => tcpOperationDisplay[item.operation as string] || "U"),
+    getDerivedProperty("T", "t", (item) => tcpOperationDisplay[item.type as string] || "U"),
 ];
 const defaultTcpTraceProperties: ItemProperty<TcpTraceKey | DerivedTcpTraceKey>[] = toProperties(
     allTcpTraceProperties,
-    ["k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName", "t", "pid", "comm", "ipversion", "src", "dst"],
+    ["k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName", "t", "pid", "comm", "src", "dst"],
 );
 export const tcpTraceMetadata: GadgetMetadata<TcpTraceKey | DerivedTcpTraceKey> = {
     name: "Trace TCP",

--- a/webview-ui/src/InspektorGadget/helpers/gadgets/types.ts
+++ b/webview-ui/src/InspektorGadget/helpers/gadgets/types.ts
@@ -3,7 +3,7 @@ export type GadgetCategory = (typeof gadgetCategories)[number];
 
 export const gadgetProfileResources = ["block-io", "cpu", "tcprtt"] as const;
 export const gadgetSnapshotResources = ["process", "socket"] as const;
-export const gadgetTopResources = ["block-io", "ebpf", "file", "tcp"] as const;
+export const gadgetTopResources = ["block-io", "file", "tcp"] as const;
 export const gadgetTraceResources = [
     "bind",
     "capabilities",
@@ -11,13 +11,11 @@ export const gadgetTraceResources = [
     "exec",
     "fsslower",
     "mount",
-    "network",
     "oomkill",
     "open",
     "signal",
     "sni",
     "tcp",
-    "tcpconnect",
     "tcpdrop",
     "tcpretrans",
 ] as const;

--- a/webview-ui/src/InspektorGadget/helpers/state.ts
+++ b/webview-ui/src/InspektorGadget/helpers/state.ts
@@ -64,6 +64,11 @@ export const stateUpdater: WebviewStateUpdater<"gadget", EventDef, InspektorGadg
     }),
     vscodeMessageHandler: {
         updateVersion: (state, args) => ({ ...state, overviewStatus: "", version: args }),
+        deployFailed: (state, args) => ({
+            ...state,
+            overviewStatus: `Deploy/undeploy failed: ${args}`,
+            version: { client: "", server: null },
+        }),
         runTraceResponse: (state, args) => ({
             ...state,
             allTraces: getUpdatedTraces(state.allTraces, args.traceId, args.items),


### PR DESCRIPTION
This PR upgrades our InspektorGadget from v0.38.0 to v0.51.0, and also includes several fixes for buggy/inconsistent IG behavior. 

The primary breaking changes accounted for are the switch from built-in to image based gadgets, modifications / removals of a few flags / gadgets & structural changes to response JSON. 

### Version Update Changes: ###


- Bumped `azure.kubectlgadget.releaseTag` default to `v0.51.0`
- Changed command format to support image-based gadgets
- Update outdated cli flags: (`--max-rows` changed to `--max-entries`, removed `--interval`)
- Rename gadget output fields to match the new snake_case naming for trace, top, snapshot, &profile gadgets (For ex. `mountnsid` -> `mntns_id`, `netnsid` -> `netns_id`, etc.)
- Remove gadgets no longer available as images: (`top ebpf`, `trace network` &`trace tcpconnect`)
- Added `normalizeItem()` to handle new JSON output structure: We hoist the elements nested in `proc.*` fields to top level to match the flat structure our UI utilizes. 
-
### Bug fixes: ###
1) Dropdown toggle inconsistency: When clicking the dropdown button for a namespace or pod, it would most of the time not work & the few times it did, fail again when toggling. This issue stems from our state handling that was inconsistent & out of sync.
Thus, rewrote the resource selector list & dropdown section to fix the unreliable expand/collapse behavior. Replaced with simpler expansion state maps and a few helpers funcs for state updates.

2) Namespace filter ignored: The gadget would run on all namespaces despite a user's specific namespace selection. Fixed `handleResourceSelectionChanged` to use the new `selection.namespace` value instead of falling back to the previous filter

3) Container filter not applied: Similarly, selecting a container wouldn't populate things either. We had existing mismatches in field names `container` vs. `containerName` that casued this. Thus, normalized all to containerName for functionality. 

4) Empty items in dropdowns: Namespaces with no return data would return an empty item when expanded. Empty namespaces will now surface 'No pods' to the user when expanded.

5) Occasional Binary download failure: When opening IG on clusters, sometimes the binary download would appear to fail, with an error surfaced to the user. Source was a race condition where we checked the file before it was fully downloaded. Now we wait for `fileStream.end()` to complete before returning, fixing this.

6) Failed deployments not surfaced in UI: If a deployment failed, error would surface via VSCode notifications, but webview UI would be stuck in 'Deploying' state. Added `deployFailed` webview message so deploy/undeploy errors now properly reset the UI and surface the error.

VSIX For testing: [vscode-aks-tools-1.6.15-inspektorupdate.vsix.zip](https://github.com/user-attachments/files/26639344/vscode-aks-tools-1.6.15-inspektorupdate.vsix.zip)
(Remove .zip)


