### PR TITLE
feat(container-assist): add confirmation dialog before federated identity creation in Container Assist

### DIFF
--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -77,6 +77,24 @@ export async function setupOIDCForGitHub(
             return;
         }
 
+        // Confirm before creating/updating the federated identity credential
+        const federatedBranchPreview = repoInfo.mainBranch ?? "main";
+        const federatedSubjectPreview = `repo:${repoInfo.owner}/${repoInfo.repo}:ref:refs/heads/${federatedBranchPreview}`;
+        const identityAction = azureConfig.isExistingIdentity
+            ? l10n.t("update existing managed identity")
+            : l10n.t("create a new managed identity");
+        const confirmMessage = l10n.t(
+            "A Federated Identity Credential will be {0} in your Azure subscription.\n\nDetails:\n• Identity: {1}\n• Resource group: {2}\n• Subject: {3}\n• Issuer: https://token.actions.githubusercontent.com\n\nProceed?",
+            identityAction,
+            azureConfig.identityName,
+            azureConfig.resourceGroup,
+            federatedSubjectPreview,
+        );
+        const confirmed = await vscode.window.showWarningMessage(confirmMessage, { modal: true }, l10n.t("Proceed"));
+        if (!confirmed) {
+            return;
+        }
+
         // Create managed identity and set up OIDC
         const result = await vscode.window.withProgress(
             {

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -27,6 +27,9 @@ import { showWizardExitConfirmation } from "./wizardUtils";
 
 const execFilePromise = promisify(execFile);
 
+// GitHub OIDC issuer URL
+const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
+
 // Azure built-in role definition IDs
 // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 const AKS_CLUSTER_USER_ROLE_ID = "4abbcc35-e782-43d8-92c5-2d3f1bd2253f";
@@ -78,13 +81,18 @@ export async function setupOIDCForGitHub(
         }
 
         // Confirm before creating/updating the federated identity credential
-        const federatedBranchPreview = repoInfo.mainBranch ?? "main";
+        const federatedBranchPreview = repoInfo.mainBranch || "main";
         const federatedSubjectPreview = `repo:${repoInfo.owner}/${repoInfo.repo}:ref:refs/heads/${federatedBranchPreview}`;
         const identityStatus = azureConfig.isExistingIdentity
             ? l10n.t("Existing managed identity")
             : l10n.t("New managed identity");
         const confirmMessage = l10n.t(
-            "A Federated Identity Credential will be created or updated in your Azure subscription.\n\nDetails:\n• Managed identity: {0} ({1})\n• Resource group: {2}\n• Subject: {3}\n• Issuer: https://token.actions.githubusercontent.com\n\nProceed?",
+            "A Federated Identity Credential will be created or updated in your Azure subscription.\n\nDetails:\n• Managed identity: {0} ({1})\n• Resource group: {2}\n• Subject: {3}\n• Issuer: {4}\n\nProceed?",
+            azureConfig.identityName,
+            identityStatus,
+            azureConfig.resourceGroup,
+            federatedSubjectPreview,
+            GITHUB_OIDC_ISSUER,
             azureConfig.identityName,
             identityStatus,
             azureConfig.resourceGroup,
@@ -773,7 +781,7 @@ async function createFederatedCredential(
     const subject = `repo:${repoInfo.owner}/${repoInfo.repo}:ref:refs/heads/${branch}`;
 
     await msiClient.federatedIdentityCredentials.createOrUpdate(resourceGroup, identityName, credentialName, {
-        issuer: "https://token.actions.githubusercontent.com",
+        issuer: GITHUB_OIDC_ISSUER,
         subject: subject,
         audiences: ["api://AzureADTokenExchange"],
     });
@@ -795,7 +803,7 @@ async function displayOIDCResults(
 AZURE_TENANT_ID: ${result.tenantId}
 AZURE_SUBSCRIPTION_ID: ${result.subscriptionId}`;
 
-    const federatedBranch = repoInfo.mainBranch ?? "main";
+    const federatedBranch = repoInfo.mainBranch || "main";
     const federatedSubject = `repo:${repoInfo.owner}/${repoInfo.repo}:ref:refs/heads/${federatedBranch}`;
 
     const selection = await vscode.window.showInformationMessage(message, setSecrets, copyAll, viewInstructions);

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -80,13 +80,13 @@ export async function setupOIDCForGitHub(
         // Confirm before creating/updating the federated identity credential
         const federatedBranchPreview = repoInfo.mainBranch ?? "main";
         const federatedSubjectPreview = `repo:${repoInfo.owner}/${repoInfo.repo}:ref:refs/heads/${federatedBranchPreview}`;
-        const identityAction = azureConfig.isExistingIdentity
-            ? l10n.t("update existing managed identity")
-            : l10n.t("create a new managed identity");
+        const identityStatus = azureConfig.isExistingIdentity
+            ? l10n.t("Existing managed identity")
+            : l10n.t("New managed identity");
         const confirmMessage = l10n.t(
-            "A Federated Identity Credential will be {0} in your Azure subscription.\n\nDetails:\n• Identity: {1}\n• Resource group: {2}\n• Subject: {3}\n• Issuer: https://token.actions.githubusercontent.com\n\nProceed?",
-            identityAction,
+            "A Federated Identity Credential will be created or updated in your Azure subscription.\n\nDetails:\n• Managed identity: {0} ({1})\n• Resource group: {2}\n• Subject: {3}\n• Issuer: https://token.actions.githubusercontent.com\n\nProceed?",
             azureConfig.identityName,
+            identityStatus,
             azureConfig.resourceGroup,
             federatedSubjectPreview,
         );


### PR DESCRIPTION


## Add confirmation dialog before federated identity creation in Container Assist

### Summary

Adds a mandatory modal confirmation dialog to the OIDC setup flow in Container Assist, shown before any Azure API calls are made. This gives users an explicit consent gate when a Federated Identity Credential is about to be created or updated on a managed identity in their Azure subscription.

### Motivation

Federated Identity Credentials have security and governance implications, they grant a GitHub repository the ability to authenticate as an Azure managed identity without a secret, scoped to a specific branch. Previously this was created silently as part of the OIDC setup progress notification, with no opportunity for the user to review exactly what would be configured before it happened.

### Changes

**oidcSetup.ts**

- Inserted a `vscode.window.showWarningMessage` (modal) between `promptForAzureConfig` and the `withProgress` block in `setupOIDCForGitHub`.
- The dialog displays:
  - Whether a **new** managed identity will be created or an **existing** one updated
  - The managed identity **name** and **resource group**
  - The exact OIDC **subject** (`repo:<owner>/<repo>:ref:refs/heads/<branch>`)
  - The fixed **issuer** (`https://token.actions.githubusercontent.com`)
- Cancelling / dismissing the dialog exits the flow without contacting Azure.

### Behaviour

| User action | Result |
|---|---|
| Clicks **Proceed** | OIDC setup continues as before |
| Clicks **Cancel** or presses Escape | Flow exits silently, no Azure resources created/modified |


<img width="425" height="528" alt="Screenshot 2026-04-14 at 4 27 16 PM" src="https://github.com/user-attachments/assets/d80b64f9-161f-43b2-b509-b0e79f3fead6" />



