### PR TITLE
Updates workflow template unit tests to match the current non-managed namespace behavior

### DIFF
--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -201,18 +201,18 @@ describe("Workflow Template Tests", () => {
             assert.ok(result.includes("action: deploy"), "Should specify deploy action");
         });
 
-        it("should annotate namespace with workload identity metadata", () => {
+        it("should not annotate namespace with workload identity metadata for non-managed namespaces", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("Annotate namespace"), "Should have annotate namespace step");
-            assert.ok(result.includes("kubectl annotate namespace"), "Should annotate the namespace");
+            assert.ok(!result.includes("Annotate namespace"), "Should not have annotate namespace step");
+            assert.ok(!result.includes("kubectl annotate namespace"), "Should not annotate the namespace");
             assert.ok(
-                result.includes("aks-project/workload-identity-id="),
-                "Should set workload-identity-id on namespace",
+                !result.includes("aks-project/workload-identity-id="),
+                "Should not set workload-identity-id on namespace",
             );
             assert.ok(
-                result.includes("aks-project/workload-identity-tenant="),
-                "Should set workload-identity-tenant on namespace",
+                !result.includes("aks-project/workload-identity-tenant="),
+                "Should not set workload-identity-tenant on namespace",
             );
         });
 
@@ -246,10 +246,8 @@ describe("Workflow Template Tests", () => {
         it("should not place identity annotations on deployment", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            // Identity annotations should only appear in the namespace annotation step, not deployment
+            // Identity annotations are removed for non-managed template and must not appear in deployment annotation
             const deployAnnotateIdx = result.indexOf("kubectl annotate deployment --all");
-            const nsAnnotateIdx = result.indexOf("kubectl annotate namespace");
-            assert.ok(nsAnnotateIdx !== -1, "Namespace annotation step should exist");
             assert.ok(deployAnnotateIdx !== -1, "Deployment annotation step should exist");
 
             // Workload identity keys must not appear after the deployment annotate command


### PR DESCRIPTION
## Description

This PR updates workflow template unit tests to match the current non-managed namespace behavior.

The non-managed workflow template no longer includes namespace-level workload identity annotation lines, so the previous assertions became stale and caused test failures. This change aligns the test expectations with that intended behavior while preserving managed-namespace validation.

## What Changed

- Updated non-managed workflow assertions in workflowTemplate.test.ts:
  - now expects absence of:
    - `Annotate namespace`
    - `kubectl annotate namespace`
    - `aks-project/workload-identity-id=`
    - `aks-project/workload-identity-tenant=`
- Removed outdated expectation that namespace annotation step must exist in non-managed flow.
- Kept managed-namespace coverage intact (namespace + deployment annotation checks still validated).

## Why

- The test suite was failing because assertions expected namespace annotation lines that were intentionally removed from the non-managed template.
- Aligning tests with actual behavior restores reliability and prevents false negatives.

## Validation

- Ran workflow template test slice via project test harness:
  - `npm test -- --grep "Workflow Template Tests"`
- Result: passing, including previously failing template-content assertions.