### PR TITLE
feat: split AKS app and menu-item simplification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,7 +1071,7 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -1090,7 +1090,7 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1120,7 +1120,7 @@
             "version": "0.23.4",
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
             "integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^3.0.4",
@@ -1135,7 +1135,7 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -1151,7 +1151,7 @@
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
             "integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.0"
@@ -1258,7 +1258,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
             "integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1268,7 +1268,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
             "integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.0",
@@ -1343,7 +1343,7 @@
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1352,7 +1352,7 @@
             "version": "0.16.6",
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -1365,7 +1365,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -1378,7 +1378,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -1391,7 +1391,7 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -2760,14 +2760,14 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -3818,7 +3818,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3844,7 +3844,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "devOptional": true,
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3862,6 +3862,7 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5299,7 +5300,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -6126,7 +6127,7 @@
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
             "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
@@ -6182,7 +6183,7 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
@@ -6201,7 +6202,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6239,7 +6240,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6251,7 +6252,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -6264,7 +6265,7 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.16.0",
@@ -6282,7 +6283,7 @@
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
@@ -6342,7 +6343,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -6355,7 +6356,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6367,7 +6368,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -6376,7 +6377,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6629,13 +6630,14 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
@@ -6741,7 +6743,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6794,7 +6796,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6819,7 +6821,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6832,7 +6834,7 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/foreground-child": {
@@ -7034,7 +7036,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -7362,7 +7364,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -7412,7 +7414,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -7524,7 +7526,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7541,7 +7543,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -7817,7 +7819,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -7828,7 +7830,8 @@
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/json-schema-typed": {
             "version": "8.0.2",
@@ -7840,7 +7843,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -7963,7 +7966,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8014,7 +8017,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8239,7 +8242,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -8870,7 +8873,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/nearley": {
             "version": "2.20.1",
@@ -9209,7 +9212,7 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9360,7 +9363,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -9375,7 +9378,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -9529,7 +9532,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9822,7 +9825,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -11839,7 +11842,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -12408,7 +12411,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12702,7 +12705,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -439,11 +439,15 @@
             },
             {
                 "command": "aks.migrateAndModernizeApp",
-                "title": "%Migrate and Modernize App%"
+                "title": "%AKS: Migrate Application to AKS%"
             },
             {
                 "command": "aks.containerizationApp",
-                "title": "%Containerization App%"
+                "title": "%AKS: Generate Dockerfiles and K8s Manifests for App%"
+            },
+            {
+                "command": "aks.deployAppWithAutomatedPipeline",
+                "title": "%AKS: Deploy App with Automated Pipeline%"
             }
         ],
         "menus": {
@@ -471,19 +475,29 @@
             ],
             "explorer/context": [
                 {
-                    "submenu": "aks.migrateApplicationToAksSubMenu",
+                    "command": "aks.migrateAndModernizeApp",
                     "when": "explorerResourceIsFolder && config.aks.containerAssistEnabledPreview",
                     "group": "5_cutcopypaste@50"
                 },
                 {
+                    "command": "aks.containerizationApp",
+                    "when": "explorerResourceIsFolder && config.aks.containerAssistEnabledPreview",
+                    "group": "5_cutcopypaste@51"
+                },
+                {
+                    "command": "aks.deployAppWithAutomatedPipeline",
+                    "when": "explorerResourceIsFolder && config.aks.containerAssistEnabledPreview",
+                    "group": "5_cutcopypaste@52"
+                },
+                {
                     "command": "aks.aksDraftValidate",
                     "when": "resourceExtname == .yaml || resourceExtname == .yml",
-                    "group": "5_cutcopypaste@50"
+                    "group": "5_cutcopypaste@53"
                 },
                 {
                     "command": "aks.aksDraftValidate",
                     "when": "explorerResourceIsFolder",
-                    "group": "5_cutcopypaste@51"
+                    "group": "5_cutcopypaste@54"
                 }
             ],
             "view/item/context": [
@@ -829,16 +843,6 @@
                     "command": "aks.aksReconcileCluster",
                     "group": "2_operations@3"
                 }
-            ],
-            "aks.migrateApplicationToAksSubMenu": [
-                {
-                    "command": "aks.migrateAndModernizeApp",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "aks.containerizationApp",
-                    "group": "navigation@2"
-                }
             ]
         },
         "submenus": [
@@ -901,10 +905,6 @@
             {
                 "id": "aks.manageClusterSubMenu",
                 "label": "%Manage Cluster%"
-            },
-            {
-                "id": "aks.migrateApplicationToAksSubMenu",
-                "label": "%Migrate Application to AKS%"
             }
         ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,5 +76,8 @@
   "AKS Quick Actions": "AKS Quick Actions",
   "Migrate Application to AKS": "Migrate Application to AKS",
   "Migrate and Modernize App": "Migrate and Modernize App",
-  "Containerization App": "Containerization App"
+  "Containerization App": "Containerization App",
+  "AKS: Migrate Application to AKS": "AKS: Migrate Application to AKS",
+  "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
+  "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline"
 }

--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -17,7 +17,11 @@ import { selectLanguageModel } from "./lmClient";
 import { showWizardExitConfirmation } from "./wizardUtils";
 export { showWizardExitConfirmation } from "./wizardUtils";
 
-export async function runContainerAssist(_context: IActionContext, target: unknown): Promise<void> {
+export async function runContainerAssist(
+    _context: IActionContext,
+    target: unknown,
+    defaultActions: ContainerAssistAction[] = [],
+): Promise<void> {
     try {
         logger.debug("Command target", target);
 
@@ -62,8 +66,12 @@ export async function runContainerAssist(_context: IActionContext, target: unkno
 
         const projectRoot = await findProjectRoot(startPath, workspaceFolder.uri.fsPath);
 
-        await executeContainerAssistActions(containerAssistService, workspaceFolder, projectRoot, (hasWorkflow) =>
-            collectAzureContext(hasWorkflow, projectRoot),
+        await executeContainerAssistActions(
+            containerAssistService,
+            workspaceFolder,
+            projectRoot,
+            (hasWorkflow) => collectAzureContext(hasWorkflow, projectRoot),
+            defaultActions,
         );
     } catch (error) {
         logger.error("Unexpected error in Container Assist", error);
@@ -217,19 +225,24 @@ async function findProjectRoot(startPath: string, workspaceRoot: string): Promis
     return startPath;
 }
 
-async function showContainerAssistQuickPick(): Promise<ContainerAssistAction[] | undefined> {
+async function showContainerAssistQuickPick(
+    defaultActions: ContainerAssistAction[] = [],
+): Promise<ContainerAssistAction[] | undefined> {
+    const deploymentPicked = defaultActions.includes(ContainerAssistAction.GenerateDeployment);
+    const workflowPicked = defaultActions.includes(ContainerAssistAction.GenerateWorkflow);
+
     const items: ContainerAssistQuickPickItem[] = [
         {
             label: l10n.t("$(file) Generate Deployment Files"),
             description: l10n.t("Analyze → Generate Dockerfile → Generate Kubernetes Manifests"),
             action: ContainerAssistAction.GenerateDeployment,
-            picked: false,
+            picked: deploymentPicked,
         },
         {
             label: l10n.t("$(github-action) Generate GitHub Workflow"),
             description: l10n.t("Create GitHub Actions workflow for CI/CD to AKS"),
             action: ContainerAssistAction.GenerateWorkflow,
-            picked: false,
+            picked: workflowPicked,
         },
     ];
 
@@ -256,8 +269,9 @@ async function executeContainerAssistActions(
     workspaceFolder: vscode.WorkspaceFolder,
     projectRoot: string,
     azureContextProvider: (hasWorkflow: boolean) => Promise<AzureContext | undefined>,
+    defaultActions: ContainerAssistAction[] = [],
 ): Promise<void> {
-    const selectedActions = await showContainerAssistQuickPick();
+    const selectedActions = await showContainerAssistQuickPick(defaultActions);
     if (!selectedActions || selectedActions.length === 0) {
         return;
     }

--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -253,7 +253,7 @@ async function showContainerAssistQuickPick(
     });
 
     if (!selected || selected.length === 0) {
-        return showWizardExitConfirmation(() => showContainerAssistQuickPick());
+        return showWizardExitConfirmation(() => showContainerAssistQuickPick(defaultActions));
     }
 
     return selected.map((item) => item.action);

--- a/src/commands/aksContainerAssist/appModernizationBridge.ts
+++ b/src/commands/aksContainerAssist/appModernizationBridge.ts
@@ -2,12 +2,17 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 import * as vscode from "vscode";
 import { runContainerAssist } from "./aksContainerAssist";
+import { ContainerAssistAction } from "./types";
 
 const appModernizationExtensionId = "vscjava.migrate-java-to-azure";
 const appModernizationViewCommand = "workbench.view.extension.azureJavaMigrationExplorer";
 
 export async function containerizationApp(_context: IActionContext, target: unknown): Promise<void> {
-    await runContainerAssist(_context, target);
+    await runContainerAssist(_context, target, [ContainerAssistAction.GenerateDeployment]);
+}
+
+export async function deployAppWithAutomatedPipeline(_context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssist(_context, target, [ContainerAssistAction.GenerateWorkflow]);
 }
 
 export async function migrateAndModernizeApp(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,11 @@ import * as fs from "fs";
 import { addMcpServerToUserSettings } from "./commands/aksMCP/aksMCPServer";
 import { aksQuickActions, initializeQuickActions } from "./commands/quickActions/aksQuickActions";
 import { runContainerAssist, runContainerAssistFromTree } from "./commands/aksContainerAssist/aksContainerAssist";
-import { containerizationApp, migrateAndModernizeApp } from "./commands/aksContainerAssist/appModernizationBridge";
+import {
+    containerizationApp,
+    deployAppWithAutomatedPipeline,
+    migrateAndModernizeApp,
+} from "./commands/aksContainerAssist/appModernizationBridge";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,
@@ -169,6 +173,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.runContainerAssist", runContainerAssist);
         registerCommandWithTelemetry("aks.runContainerAssistFromTree", runContainerAssistFromTree);
         registerCommandWithTelemetry("aks.containerizationApp", containerizationApp);
+        registerCommandWithTelemetry("aks.deployAppWithAutomatedPipeline", deployAppWithAutomatedPipeline);
         registerCommandWithTelemetry("aks.migrateAndModernizeApp", migrateAndModernizeApp);
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -938,6 +938,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1670,7 +1671,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6155,8 +6157,7 @@
     "@fortawesome/react-fontawesome": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.0.tgz",
-      "integrity": "sha512-EHmHeTf8WgO29sdY3iX/7ekE3gNUdlc2RW6mm/FzELlHFKfTrA9S4MlyquRR+RRCRCn8+jXfLFpLGB2l7wCWyw==",
-      "requires": {}
+      "integrity": "sha512-EHmHeTf8WgO29sdY3iX/7ekE3gNUdlc2RW6mm/FzELlHFKfTrA9S4MlyquRR+RRCRCn8+jXfLFpLGB2l7wCWyw=="
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -6449,6 +6450,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "requires": {
         "csstype": "^3.2.2"
       }
@@ -6457,8 +6459,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/unist": {
       "version": "3.0.0",
@@ -6533,8 +6534,7 @@
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
       "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "8.58.2",
@@ -6663,8 +6663,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.14.0",
@@ -6900,7 +6899,8 @@
     "csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "data-view-buffer": {
       "version": "1.0.2",
@@ -9070,8 +9070,7 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.4",
@@ -9095,8 +9094,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tslib": {
       "version": "2.8.1",
@@ -9471,8 +9469,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "zwitch": {
       "version": "2.0.4",


### PR DESCRIPTION
This PR refines the AKS VsCode File Explorer entry points for Container Assist and app modernization flows.

Instead of grouping these actions under a submenu, the folder context menu now exposes three direct commands when `aks.containerAssistEnabledPreview` is enabled:

It one of the key feature @bosesuneha added so key that she review this please. thanks everyone else also welcome. ❤️ 

- `AKS: Migrate Application to AKS`
- `AKS: Generate Dockerfiles and K8s Manifests for App`
- `AKS: Deploy App with Automated Pipeline`

## What Changed

- Added a new command: `aks.deployAppWithAutomatedPipeline`
- Renamed existing Explorer-facing command labels to be more explicit and AKS-scoped
- Replaced the Explorer submenu with three direct folder context menu actions
- Updated localization strings for the new command titles
- Extended `runContainerAssist(...)` to accept default actions
- Preselects Container Assist flows based on the entry point:
  - `containerizationApp` defaults to deployment file generation
  - `deployAppWithAutomatedPipeline` defaults to workflow generation

## Implementation Notes

- aksContainerAssist.ts
  - Added optional `defaultActions: ContainerAssistAction[]`
  - Passed default actions through to quick pick selection
  - Preselects quick pick items when invoked from dedicated entry points

- appModernizationBridge.ts
  - `containerizationApp(...)` now launches Container Assist with `GenerateDeployment`
  - Added `deployAppWithAutomatedPipeline(...)` to launch Container Assist with `GenerateWorkflow`

- extension.ts
  - Registered `aks.deployAppWithAutomatedPipeline`

- package.json
  - Updated command contributions and Explorer menu entries
  - Removed the `aks.migrateApplicationToAksSubMenu` contribution

- package.nls.json
  - Added localized labels for the new AKS command titles

## Why

The previous submenu added an extra click and made the preview flows less discoverable. Direct commands make the user intent clearer:

- modernization
- deployment artifact generation
- automated pipeline setup

This also lets each command open Container Assist with the most relevant action already selected.

## Validation

- Verified command contributions and Explorer menu wiring align with the new direct-action model
- Confirmed dedicated entry points map to the expected preselected Container Assist actions

<img width="629" height="265" alt="Screenshot 2026-04-16 at 1 43 43 PM" src="https://github.com/user-attachments/assets/5f562f4c-4ba8-4903-b12e-a3ff641d73c4" />
