### PR TITLE
feat: split tree-view Container Assist into discrete cluster actions

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -419,7 +419,7 @@
   "Attach ACR to Cluster": "Attach ACR to Cluster",
   "Draft GitHub Workflow in {0}": "Draft GitHub Workflow in {0}",
   "GitHub repository {0}/{1} not found.": "GitHub repository {0}/{1} not found.",
-  "Draft Validate in {0}": "Draft Validate in {0}",
+  "Run Deployment Safeguards in {0}": "Run Deployment Safeguards in {0}",
   "Draft Dockerfile in {0}": "Draft Dockerfile in {0}",
   "Draft Deployment in {0}": "Draft Deployment in {0}",
   "IMPORTANT: Please be sure to remove any private information before submitting.": "IMPORTANT: Please be sure to remove any private information before submitting.",

--- a/package.json
+++ b/package.json
@@ -426,10 +426,6 @@
                 "title": "AKS: Deploy application to AKS (Preview)"
             },
             {
-                "command": "aks.runContainerAssistFromTree",
-                "title": "AKS: Run Container Assist (Preview)"
-            },
-            {
                 "command": "aks.setupOIDCForGitHub",
                 "title": "AKS: Setup OIDC for GitHub Actions (Preview)"
             },
@@ -442,11 +438,19 @@
                 "title": "%AKS: Migrate Application to AKS%"
             },
             {
-                "command": "aks.containerizationApp",
+                "command": "aks.containerizeApp",
+                "title": "%AKS: Generate Dockerfiles and K8s Manifests for App%"
+            },
+            {
+                "command": "aks.containerizeAppFromTree",
                 "title": "%AKS: Generate Dockerfiles and K8s Manifests for App%"
             },
             {
                 "command": "aks.deployAppWithAutomatedPipeline",
+                "title": "%AKS: Deploy App with Automated Pipeline%"
+            },
+            {
+                "command": "aks.deployAppWithAutomatedPipelineFromTree",
                 "title": "%AKS: Deploy App with Automated Pipeline%"
             }
         ],
@@ -469,7 +473,11 @@
                     "when": "workspaceFolderCount >= 1 && config.aks.containerAssistEnabledPreview"
                 },
                 {
-                    "command": "aks.runContainerAssistFromTree",
+                    "command": "aks.containerizeAppFromTree",
+                    "when": "never"
+                },
+                {
+                    "command": "aks.deployAppWithAutomatedPipelineFromTree",
                     "when": "never"
                 }
             ],
@@ -480,7 +488,7 @@
                     "group": "5_cutcopypaste@50"
                 },
                 {
-                    "command": "aks.containerizationApp",
+                    "command": "aks.containerizeApp",
                     "when": "explorerResourceIsFolder && config.aks.containerAssistEnabledPreview",
                     "group": "5_cutcopypaste@51"
                 },
@@ -542,9 +550,19 @@
                     "group": "8@1"
                 },
                 {
-                    "command": "aks.runContainerAssistFromTree",
+                    "command": "aks.migrateAndModernizeApp",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && !config.aks.simplifiedMenuStructure && config.aks.containerAssistEnabledPreview",
+                    "group": "8_containerassist@1"
+                },
+                {
+                    "command": "aks.containerizeAppFromTree",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && !config.aks.simplifiedMenuStructure && config.aks.containerAssistEnabledPreview && workspaceFolderCount >= 1",
-                    "group": "8@2"
+                    "group": "8_containerassist@2"
+                },
+                {
+                    "command": "aks.deployAppWithAutomatedPipelineFromTree",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && !config.aks.simplifiedMenuStructure && config.aks.containerAssistEnabledPreview && workspaceFolderCount >= 1",
+                    "group": "8_containerassist@3"
                 },
                 {
                     "command": "aks.eraserTool",
@@ -770,13 +788,23 @@
                     "group": "1_developer@1"
                 },
                 {
-                    "command": "aks.runContainerAssistFromTree",
+                    "command": "aks.migrateAndModernizeApp",
                     "group": "1_developer@2",
+                    "when": "config.aks.containerAssistEnabledPreview"
+                },
+                {
+                    "command": "aks.containerizeAppFromTree",
+                    "group": "1_developer@3",
+                    "when": "config.aks.containerAssistEnabledPreview && workspaceFolderCount >= 1"
+                },
+                {
+                    "command": "aks.deployAppWithAutomatedPipelineFromTree",
+                    "group": "1_developer@4",
                     "when": "config.aks.containerAssistEnabledPreview && workspaceFolderCount >= 1"
                 },
                 {
                     "command": "aks.aksDraftValidate",
-                    "group": "1_developer@3"
+                    "group": "1_developer@5"
                 },
                 {
                     "command": "aks.attachAcrToCluster",

--- a/package.nls.json
+++ b/package.nls.json
@@ -74,9 +74,6 @@
   "Troubleshoot & Diagnose": "Troubleshoot & Diagnose",
   "Manage Cluster": "Manage Cluster",
   "AKS Quick Actions": "AKS Quick Actions",
-  "Migrate Application to AKS": "Migrate Application to AKS",
-  "Migrate and Modernize App": "Migrate and Modernize App",
-  "Containerization App": "Containerization App",
   "AKS: Migrate Application to AKS": "AKS: Migrate Application to AKS",
   "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
   "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline"

--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -17,6 +17,22 @@ import { selectLanguageModel } from "./lmClient";
 import { showWizardExitConfirmation } from "./wizardUtils";
 export { showWizardExitConfirmation } from "./wizardUtils";
 
+export async function containerizeApp(context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssist(context, target, [ContainerAssistAction.GenerateDeployment]);
+}
+
+export async function containerizeAppFromTree(context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssistFromTree(context, target, [ContainerAssistAction.GenerateDeployment]);
+}
+
+export async function deployAppWithAutomatedPipeline(context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssist(context, target, [ContainerAssistAction.GenerateWorkflow]);
+}
+
+export async function deployAppWithAutomatedPipelineFromTree(context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssistFromTree(context, target, [ContainerAssistAction.GenerateWorkflow]);
+}
+
 export async function runContainerAssist(
     _context: IActionContext,
     target: unknown,

--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -86,7 +86,11 @@ export async function runContainerAssist(
  * Subscription and cluster are extracted from the tree node, so the user
  * is NOT prompted for those — only ACR, namespace, and workflow name are asked.
  */
-export async function runContainerAssistFromTree(_context: IActionContext, target: unknown): Promise<void> {
+export async function runContainerAssistFromTree(
+    _context: IActionContext,
+    target: unknown,
+    defaultActions: ContainerAssistAction[] = [],
+): Promise<void> {
     try {
         logger.debug("Container Assist from tree, target", target);
 
@@ -117,8 +121,13 @@ export async function runContainerAssistFromTree(_context: IActionContext, targe
         }
 
         // Step 4: Execute shared action selection & processing logic
-        await executeContainerAssistActions(containerAssistService, workspaceFolder, projectRoot, (hasWorkflow) =>
-            collectAzureContextFromTree(subscriptionId, clusterName, resourceGroupName, hasWorkflow, projectRoot),
+        await executeContainerAssistActions(
+            containerAssistService,
+            workspaceFolder,
+            projectRoot,
+            (hasWorkflow) =>
+                collectAzureContextFromTree(subscriptionId, clusterName, resourceGroupName, hasWorkflow, projectRoot),
+            defaultActions,
         );
     } catch (error) {
         logger.error("Unexpected error in Container Assist (from tree)", error);

--- a/src/commands/aksContainerAssist/appModernizationBridge.ts
+++ b/src/commands/aksContainerAssist/appModernizationBridge.ts
@@ -1,18 +1,26 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 import * as vscode from "vscode";
-import { runContainerAssist } from "./aksContainerAssist";
+import { runContainerAssist, runContainerAssistFromTree } from "./aksContainerAssist";
 import { ContainerAssistAction } from "./types";
 
 const appModernizationExtensionId = "vscjava.migrate-java-to-azure";
 const appModernizationViewCommand = "workbench.view.extension.azureJavaMigrationExplorer";
 
-export async function containerizationApp(_context: IActionContext, target: unknown): Promise<void> {
+export async function containerizeApp(_context: IActionContext, target: unknown): Promise<void> {
     await runContainerAssist(_context, target, [ContainerAssistAction.GenerateDeployment]);
+}
+
+export async function containerizeAppFromTree(_context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssistFromTree(_context, target, [ContainerAssistAction.GenerateDeployment]);
 }
 
 export async function deployAppWithAutomatedPipeline(_context: IActionContext, target: unknown): Promise<void> {
     await runContainerAssist(_context, target, [ContainerAssistAction.GenerateWorkflow]);
+}
+
+export async function deployAppWithAutomatedPipelineFromTree(_context: IActionContext, target: unknown): Promise<void> {
+    await runContainerAssistFromTree(_context, target, [ContainerAssistAction.GenerateWorkflow]);
 }
 
 export async function migrateAndModernizeApp(): Promise<void> {

--- a/src/commands/aksContainerAssist/appModernizationBridge.ts
+++ b/src/commands/aksContainerAssist/appModernizationBridge.ts
@@ -1,27 +1,8 @@
-import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 import * as vscode from "vscode";
-import { runContainerAssist, runContainerAssistFromTree } from "./aksContainerAssist";
-import { ContainerAssistAction } from "./types";
 
 const appModernizationExtensionId = "vscjava.migrate-java-to-azure";
 const appModernizationViewCommand = "workbench.view.extension.azureJavaMigrationExplorer";
-
-export async function containerizeApp(_context: IActionContext, target: unknown): Promise<void> {
-    await runContainerAssist(_context, target, [ContainerAssistAction.GenerateDeployment]);
-}
-
-export async function containerizeAppFromTree(_context: IActionContext, target: unknown): Promise<void> {
-    await runContainerAssistFromTree(_context, target, [ContainerAssistAction.GenerateDeployment]);
-}
-
-export async function deployAppWithAutomatedPipeline(_context: IActionContext, target: unknown): Promise<void> {
-    await runContainerAssist(_context, target, [ContainerAssistAction.GenerateWorkflow]);
-}
-
-export async function deployAppWithAutomatedPipelineFromTree(_context: IActionContext, target: unknown): Promise<void> {
-    await runContainerAssistFromTree(_context, target, [ContainerAssistAction.GenerateWorkflow]);
-}
 
 export async function migrateAndModernizeApp(): Promise<void> {
     const extension = vscode.extensions.getExtension(appModernizationExtensionId);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,14 +71,14 @@ import * as path from "path";
 import * as fs from "fs";
 import { addMcpServerToUserSettings } from "./commands/aksMCP/aksMCPServer";
 import { aksQuickActions, initializeQuickActions } from "./commands/quickActions/aksQuickActions";
-import { runContainerAssist } from "./commands/aksContainerAssist/aksContainerAssist";
 import {
+    runContainerAssist,
     containerizeApp,
     containerizeAppFromTree,
     deployAppWithAutomatedPipeline,
     deployAppWithAutomatedPipelineFromTree,
-    migrateAndModernizeApp,
-} from "./commands/aksContainerAssist/appModernizationBridge";
+} from "./commands/aksContainerAssist/aksContainerAssist";
+import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModernizationBridge";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,10 +71,12 @@ import * as path from "path";
 import * as fs from "fs";
 import { addMcpServerToUserSettings } from "./commands/aksMCP/aksMCPServer";
 import { aksQuickActions, initializeQuickActions } from "./commands/quickActions/aksQuickActions";
-import { runContainerAssist, runContainerAssistFromTree } from "./commands/aksContainerAssist/aksContainerAssist";
+import { runContainerAssist } from "./commands/aksContainerAssist/aksContainerAssist";
 import {
-    containerizationApp,
+    containerizeApp,
+    containerizeAppFromTree,
     deployAppWithAutomatedPipeline,
+    deployAppWithAutomatedPipelineFromTree,
     migrateAndModernizeApp,
 } from "./commands/aksContainerAssist/appModernizationBridge";
 import {
@@ -171,9 +173,13 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.aksSetupMCPServerCommands", addMcpServerToUserSettings);
         registerCommandWithTelemetry("aks.quickActions", aksQuickActions);
         registerCommandWithTelemetry("aks.runContainerAssist", runContainerAssist);
-        registerCommandWithTelemetry("aks.runContainerAssistFromTree", runContainerAssistFromTree);
-        registerCommandWithTelemetry("aks.containerizationApp", containerizationApp);
+        registerCommandWithTelemetry("aks.containerizeApp", containerizeApp);
+        registerCommandWithTelemetry("aks.containerizeAppFromTree", containerizeAppFromTree);
         registerCommandWithTelemetry("aks.deployAppWithAutomatedPipeline", deployAppWithAutomatedPipeline);
+        registerCommandWithTelemetry(
+            "aks.deployAppWithAutomatedPipelineFromTree",
+            deployAppWithAutomatedPipelineFromTree,
+        );
         registerCommandWithTelemetry("aks.migrateAndModernizeApp", migrateAndModernizeApp);
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];

--- a/src/panels/draft/DraftValidatePanel.ts
+++ b/src/panels/draft/DraftValidatePanel.ts
@@ -30,7 +30,7 @@ export class DraftValidateDataProvider implements PanelDataProvider<"draftValida
     }
 
     getTitle(): string {
-        return l10n.t(`Draft Validate in {0}`, this.workspaceFolder.name);
+        return l10n.t(`Run Deployment Safeguards in {0}`, this.workspaceFolder.name);
     }
 
     getInitialState(): InitialState {

--- a/webview-ui/src/Draft/DraftValidate/DraftValidate.tsx
+++ b/webview-ui/src/Draft/DraftValidate/DraftValidate.tsx
@@ -13,7 +13,7 @@ export function DraftValidate(initialState: InitialState) {
 
     return (
         <>
-            <h2>Draft Validate</h2>
+            <h2>Run Deployment Safeguards</h2>
             <pre>{state.validationResults}</pre>
         </>
     );


### PR DESCRIPTION
- Replaces the single `aks.runContainerAssistFromTree` tree-view entry with three discrete actions in both the legacy and simplified cluster context menus: **Migrate Application to AKS**, **Generate Dockerfiles and K8s Manifests for App**, and **Deploy App with Automated Pipeline**. Each tree-variant command pre-selects its corresponding `ContainerAssistAction`, removing the extra multi-select picker step.
- Renames the `containerizationApp` command to `containerizeApp` for naming consistency and fixes the previously broken manifest state where `aks.runContainerAssistFromTree` was still declared in `package.json` but no longer registered in `extension.ts`.
- Renames the user-visible "Draft Validate" strings to "Run Deployment Safeguards" so the webview panel title and heading match the already-renamed `aks.aksDraftValidate` command title.
- Reorganizes `appModernizationBridge.ts` so it only contains the actual bridge to the external app-modernization extension; the four container-assist command adapters now live next to the `runContainerAssist` dispatcher they wrap.