### PR TITLE
Add Argo CD GitOps integration for AKS clusters

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -34,6 +34,7 @@
   - [Manage and Test KAITO Deployments](./features/kaito-manage-test.md)
   - [Create AKS Fleet Manager from VS Code](./features/aks-fleet-manager.md)
   - [Setup AKS MCP Server from VS Code](./features/aks-mcp-server-integration.md)
+  - [Argo CD GitOps Integration](./features/argocd-gitops-integration.md)
 
 - [Release](./release.md)
   - [What's New in 1.7.0](./release/whats-new-1.7.0.md)

--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -1,0 +1,129 @@
+# Argo CD GitOps Integration
+
+The Argo CD integration brings a complete GitOps workflow to AKS clusters directly inside VS Code. Argo CD must be **pre-installed** on your cluster — the extension checks for its presence and directs you to the [official docs](https://argo-cd.readthedocs.io/en/stable/getting_started/) if it is missing.
+
+> **GitOps "Hollywood Principle"** — *Don't call us, we'll call you.*
+> Your cluster never pushes. Argo CD continuously pulls desired state from a dedicated Git config repository and reconciles it automatically.
+
+---
+
+## Prerequisites
+
+- An AKS cluster with Argo CD installed (via `kubectl`, Helm, or the `az k8s-extension` marketplace add-on).
+- `kubectl` available on your PATH (the extension uses the active kubectl context).
+- A **separate GitOps config repository** — Argo CD manifests should live apart from your application source code.
+
+---
+
+## Commands
+
+The integration provides four commands, all prefixed with **AKS:**
+
+| Command | Where it appears | Description |
+|---------|-----------------|-------------|
+| **AKS: Create Argo CD GitOps Pipeline** | Command Palette, Explorer folder context menu | Scaffold an annotated Argo CD Application manifest in a config repo |
+| **AKS: Apply Argo CD Application to Cluster** | Explorer YAML file context menu, Editor context menu | Apply an Application YAML to the active cluster |
+| **AKS: Check Argo CD Status** | AKS cluster tree right-click menu | Show Argo CD pod and service health in an output channel |
+| **AKS: Argo CD Post-Deploy Actions** | Shown after a successful apply | Open UI, get credentials, register repo credentials, or view sync guide |
+
+---
+
+## Scaffold a GitOps Config Repository
+
+1. Open the **Command Palette** (`Cmd+Shift+P` on macOS / `Ctrl+Shift+P` on Windows/Linux).
+2. Run **AKS: Create Argo CD GitOps Pipeline**.
+3. If you are inside an application source repository (detected by the presence of `Dockerfile`, `package.json`, `go.mod`, etc.), the extension warns you and offers to open a separate config repo folder instead.
+4. Fill in the prompted parameters:
+   - **App name** — validated as `[a-z0-9][a-z0-9-]*`.
+   - **GitOps config repo URL** — enter manually, browse a local folder (reads `.git/config` origin automatically), or browse your GitHub repos (authenticates via VS Code's built-in GitHub provider).
+   - **Source repo URL** (optional) — same picker options.
+   - **Target cluster API server URL**.
+   - **Target namespace** — where your workloads will be deployed.
+   - **Container image** and **port**.
+5. The extension scaffolds an `apps/<name>/` directory containing:
+   - `application.yaml` — the Argo CD Application CR with all placeholders substituted.
+   - `README.md` — step-by-step setup guide covering install, UI access, repo registration, day-2 workflow, and monitoring commands.
+6. A notification offers quick-open buttons for the generated files.
+
+---
+
+## Apply an Application YAML to a Cluster
+
+1. Open or right-click an Argo CD Application YAML file (`.yaml` / `.yml`).
+2. Select **AKS: Apply Argo CD Application to Cluster**.
+   - Alternatively, when you open an Application YAML, the extension detects it and shows an **"Apply to Cluster"** notification.
+3. The extension:
+   1. Validates the file is an `argoproj.io/v1alpha1 Application`.
+   2. Resolves the active kubectl context (no subscription or cluster picker needed).
+   3. Checks that Argo CD is installed (looks for the `argocd` namespace).
+   4. Confirms the apply action.
+   5. Runs `kubectl apply -n argocd -f <file>`.
+4. After a successful apply, a notification offers four actions:
+
+### Open Argo CD UI
+
+- If the `argocd-server` Service has a **LoadBalancer** with an external IP, the extension opens `https://<address>` directly.
+- If the Service is **ClusterIP** (common for local setups), the extension starts a `kubectl port-forward` in an integrated terminal and shows an **Open Browser** button once the tunnel is ready.
+
+### Get Credentials
+
+- Fetches the initial admin password from the `argocd-initial-admin-secret` Secret.
+- Displays `Username: admin | Password: ••••••••` (masked).
+- Offers **Copy Password** and **Reveal Password** buttons.
+- If the secret has been rotated or deleted, shows an informational message.
+
+### Register Repo Credentials (Private Repos)
+
+- Pre-populates `spec.source.repoURL` from the applied Application YAML.
+- Choose an auth type:
+  - **HTTPS** — enter username + PAT/password (input is masked; credentials are never logged).
+  - **SSH** — pick a private key file.
+- Creates a labelled Kubernetes Secret (`argocd.argoproj.io/secret-type: repository`) directly via `kubectl` — credentials never touch disk as temp files.
+- Argo CD picks up the Secret automatically without a restart.
+
+### Sync Guide
+
+- Opens the Argo CD documentation for syncing applications.
+
+---
+
+## Check Argo CD Status
+
+1. In the AKS cluster tree, right-click a cluster node.
+2. Select **AKS: Check Argo CD Status**.
+3. The **Argo CD** output channel shows:
+   - Whether the `argocd` namespace exists.
+   - Pod status (`kubectl get pods -n argocd -o wide`).
+   - Service status (`kubectl get svc -n argocd`).
+   - Tips for port-forwarding and authentication.
+
+---
+
+## Copilot Chat Integration
+
+A GitHub Copilot chat skill is registered so you can ask questions like:
+
+- *"How do I set up Argo CD on my AKS cluster?"*
+- *"Create an Argo CD deployment for my cluster"*
+
+The skill explains the GitOps principle and offers a button to launch the scaffold command directly from chat.
+
+---
+
+## Security Notes
+
+- **PAT / passwords** are never written to disk or logged to output channels. Repo credential Secrets are created via `kubectl create secret --from-literal`.
+- **Admin password** is masked in all UI modals; only accessible via explicit Copy or Reveal actions.
+- **SSH keys** are read from a user-selected file and passed directly to the Secret — never cached.
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Argo CD is not installed on cluster" | Install Argo CD first: [Getting Started guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) |
+| `kubectl` not found | Ensure `kubectl` is on your PATH and the correct context is active |
+| Port-forward fails | Check that no other process is using port 8080, or that the `argocd-server` Service exists |
+| Repo not syncing after credential registration | Verify the repo URL matches `spec.source.repoURL` exactly (including `.git` suffix if used) |
+| Application CR not visible in Argo CD UI | Ensure the YAML has `namespace: argocd` in `metadata` — the Application CR must be in the Argo CD namespace |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,6 +1481,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -1493,6 +1494,7 @@
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
             "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2562,10 +2564,11 @@
             }
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true
+            "version": "0.27.10",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "2.3.0",
@@ -2802,13 +2805,15 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
             "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
@@ -2818,6 +2823,7 @@
             "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
             "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
@@ -2950,10 +2956,11 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -2962,7 +2969,8 @@
             "version": "21.0.3",
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
             "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.59.1",
@@ -4610,6 +4618,7 @@
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -7763,6 +7772,7 @@
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
             "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -7780,6 +7790,7 @@
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
             "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "jest-util": "^29.7.0",
@@ -7795,6 +7806,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -455,28 +455,23 @@
             },
             {
                 "command": "aks.draftArgoCDDeployment",
-                "title": "%Create Argo CD Deployment (GitOps)%",
-                "category": "AKS"
+                "title": "%AKS: Create Argo CD GitOps Pipeline%"
             },
             {
                 "command": "aks.argoCDInstall",
-                "title": "%Install Argo CD on Cluster%",
-                "category": "AKS"
+                "title": "%AKS: Install Argo CD on Cluster%"
             },
             {
                 "command": "aks.argoCDCheckStatus",
-                "title": "%Check Argo CD Status%",
-                "category": "AKS"
+                "title": "%AKS: Check Argo CD Status%"
             },
             {
                 "command": "aks.argoCDApplyApp",
-                "title": "%Apply Argo CD Application to Cluster%",
-                "category": "AKS"
+                "title": "%AKS: Apply Argo CD Application to Cluster%"
             },
             {
                 "command": "aks.argoCDPostApplyActions",
-                "title": "%ArgoCD UI and GH Token completion%",
-                "category": "AKS"
+                "title": "%AKS: Argo CD Post-Deploy Actions%"
             }
         ],
         "menus": {
@@ -539,19 +534,24 @@
                     "group": "5_cutcopypaste@52"
                 },
                 {
-                    "command": "aks.aksDraftValidate",
-                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
+                    "command": "aks.draftArgoCDDeployment",
+                    "when": "explorerResourceIsFolder",
                     "group": "5_cutcopypaste@53"
                 },
                 {
                     "command": "aks.aksDraftValidate",
-                    "when": "explorerResourceIsFolder",
+                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
                     "group": "5_cutcopypaste@54"
+                },
+                {
+                    "command": "aks.aksDraftValidate",
+                    "when": "explorerResourceIsFolder",
+                    "group": "5_cutcopypaste@55"
                 },
                 {
                     "command": "aks.argoCDApplyApp",
                     "when": "resourceExtname == .yaml || resourceExtname == .yml",
-                    "group": "5_cutcopypaste@52"
+                    "group": "5_cutcopypaste@56"
                 }
             ],
             "editor/context": [

--- a/package.json
+++ b/package.json
@@ -451,7 +451,12 @@
             },
             {
                 "command": "aks.deployAppWithAutomatedPipelineFromTree",
-                "title": "%AKS: Deploy App with Automated Pipeline%"
+                "title": "%AKS: Deploy App with Automated Pipeline%",
+            },
+            {
+                "command": "aks.draftArgoCDDeployment",
+                "title": "%Create Argo CD Deployment (GitOps)%",
+                "category": "AKS"
             }
         ],
         "menus": {
@@ -459,6 +464,10 @@
                 {
                     "command": "aks.refreshSubscription",
                     "when": "never"
+                },
+                {
+                    "command": "aks.draftArgoCDDeployment",
+                    "when": "workspaceFolderCount >= 1"
                 },
                 {
                     "command": "aks.draftWorkflow",

--- a/package.json
+++ b/package.json
@@ -457,6 +457,21 @@
                 "command": "aks.draftArgoCDDeployment",
                 "title": "%Create Argo CD Deployment (GitOps)%",
                 "category": "AKS"
+            },
+            {
+                "command": "aks.argoCDInstall",
+                "title": "%Install Argo CD on Cluster%",
+                "category": "AKS"
+            },
+            {
+                "command": "aks.argoCDCheckStatus",
+                "title": "%Check Argo CD Status%",
+                "category": "AKS"
+            },
+            {
+                "command": "aks.argoCDApplyApp",
+                "title": "%Apply Argo CD Application to Cluster%",
+                "category": "AKS"
             }
         ],
         "menus": {
@@ -468,6 +483,18 @@
                 {
                     "command": "aks.draftArgoCDDeployment",
                     "when": "workspaceFolderCount >= 1"
+                },
+                {
+                    "command": "aks.argoCDInstall",
+                    "when": "never"
+                },
+                {
+                    "command": "aks.argoCDCheckStatus",
+                    "when": "never"
+                },
+                {
+                    "command": "aks.argoCDApplyApp",
+                    "when": "resourceExtname == .yaml || resourceExtname == .yml"
                 },
                 {
                     "command": "aks.draftWorkflow",
@@ -515,6 +542,18 @@
                     "command": "aks.aksDraftValidate",
                     "when": "explorerResourceIsFolder",
                     "group": "5_cutcopypaste@54"
+                },
+                {
+                    "command": "aks.argoCDApplyApp",
+                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
+                    "group": "5_cutcopypaste@52"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "aks.argoCDApplyApp",
+                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
+                    "group": "1_modification@100"
                 }
             ],
             "view/item/context": [
@@ -823,6 +862,14 @@
                     "command": "aks.draftWorkflow",
                     "group": "2_deploy@3",
                     "when": "workspaceFolderCount >= 1"
+                },
+                {
+                    "command": "aks.argoCDInstall",
+                    "group": "2_deploy@4"
+                },
+                {
+                    "command": "aks.argoCDCheckStatus",
+                    "group": "2_deploy@5"
                 },
                 {
                     "submenu": "aks.kaitoInstallSubMenu",

--- a/package.json
+++ b/package.json
@@ -451,7 +451,7 @@
             },
             {
                 "command": "aks.deployAppWithAutomatedPipelineFromTree",
-                "title": "%AKS: Deploy App with Automated Pipeline%",
+                "title": "%AKS: Deploy App with Automated Pipeline%"
             },
             {
                 "command": "aks.draftArgoCDDeployment",

--- a/package.json
+++ b/package.json
@@ -472,6 +472,11 @@
                 "command": "aks.argoCDApplyApp",
                 "title": "%Apply Argo CD Application to Cluster%",
                 "category": "AKS"
+            },
+            {
+                "command": "aks.argoCDPostApplyActions",
+                "title": "%ArgoCD UI and GH Token completion%",
+                "category": "AKS"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -457,10 +457,7 @@
                 "command": "aks.draftArgoCDDeployment",
                 "title": "%AKS: Create Argo CD GitOps Pipeline%"
             },
-            {
-                "command": "aks.argoCDInstall",
-                "title": "%AKS: Install Argo CD on Cluster%"
-            },
+
             {
                 "command": "aks.argoCDCheckStatus",
                 "title": "%AKS: Check Argo CD Status%"
@@ -484,10 +481,7 @@
                     "command": "aks.draftArgoCDDeployment",
                     "when": "workspaceFolderCount >= 1"
                 },
-                {
-                    "command": "aks.argoCDInstall",
-                    "when": "never"
-                },
+
                 {
                     "command": "aks.argoCDCheckStatus",
                     "when": "never"
@@ -868,10 +862,7 @@
                     "group": "2_deploy@3",
                     "when": "workspaceFolderCount >= 1"
                 },
-                {
-                    "command": "aks.argoCDInstall",
-                    "group": "2_deploy@4"
-                },
+
                 {
                     "command": "aks.argoCDCheckStatus",
                     "group": "2_deploy@5"

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,5 +76,6 @@
   "AKS Quick Actions": "AKS Quick Actions",
   "AKS: Migrate Application to AKS": "AKS: Migrate Application to AKS",
   "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
-  "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline"
+  "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline",
+  "Create Argo CD Deployment (GitOps)": "Create Argo CD Deployment (GitOps)"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -80,5 +80,6 @@
   "Create Argo CD Deployment (GitOps)": "Create Argo CD Deployment (GitOps)",
   "Install Argo CD on Cluster": "Install Argo CD on Cluster",
   "Check Argo CD Status": "Check Argo CD Status",
-  "Apply Argo CD Application to Cluster": "Apply Argo CD Application to Cluster"
+  "Apply Argo CD Application to Cluster": "Apply Argo CD Application to Cluster",
+  "ArgoCD UI and GH Token completion": "ArgoCD UI and GH Token completion"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -78,7 +78,6 @@
   "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
   "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline",
   "AKS: Create Argo CD GitOps Pipeline": "AKS: Create Argo CD GitOps Pipeline",
-  "AKS: Install Argo CD on Cluster": "AKS: Install Argo CD on Cluster",
   "AKS: Check Argo CD Status": "AKS: Check Argo CD Status",
   "AKS: Apply Argo CD Application to Cluster": "AKS: Apply Argo CD Application to Cluster",
   "AKS: Argo CD Post-Deploy Actions": "AKS: Argo CD Post-Deploy Actions"

--- a/package.nls.json
+++ b/package.nls.json
@@ -77,5 +77,8 @@
   "AKS: Migrate Application to AKS": "AKS: Migrate Application to AKS",
   "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
   "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline",
-  "Create Argo CD Deployment (GitOps)": "Create Argo CD Deployment (GitOps)"
+  "Create Argo CD Deployment (GitOps)": "Create Argo CD Deployment (GitOps)",
+  "Install Argo CD on Cluster": "Install Argo CD on Cluster",
+  "Check Argo CD Status": "Check Argo CD Status",
+  "Apply Argo CD Application to Cluster": "Apply Argo CD Application to Cluster"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -77,9 +77,9 @@
   "AKS: Migrate Application to AKS": "AKS: Migrate Application to AKS",
   "AKS: Generate Dockerfiles and K8s Manifests for App": "AKS: Generate Dockerfiles and K8s Manifests for App",
   "AKS: Deploy App with Automated Pipeline": "AKS: Deploy App with Automated Pipeline",
-  "Create Argo CD Deployment (GitOps)": "Create Argo CD Deployment (GitOps)",
-  "Install Argo CD on Cluster": "Install Argo CD on Cluster",
-  "Check Argo CD Status": "Check Argo CD Status",
-  "Apply Argo CD Application to Cluster": "Apply Argo CD Application to Cluster",
-  "ArgoCD UI and GH Token completion": "ArgoCD UI and GH Token completion"
+  "AKS: Create Argo CD GitOps Pipeline": "AKS: Create Argo CD GitOps Pipeline",
+  "AKS: Install Argo CD on Cluster": "AKS: Install Argo CD on Cluster",
+  "AKS: Check Argo CD Status": "AKS: Check Argo CD Status",
+  "AKS: Apply Argo CD Application to Cluster": "AKS: Apply Argo CD Application to Cluster",
+  "AKS: Argo CD Post-Deploy Actions": "AKS: Argo CD Post-Deploy Actions"
 }

--- a/resources/yaml/argocd-application.template.yaml
+++ b/resources/yaml/argocd-application.template.yaml
@@ -2,7 +2,7 @@
 # Argo CD Application Manifest
 # =============================================================================
 #
-# ⚠️  IMPORTANT — Hollywood Principle / GitOps "Don't call us, we'll call you"
+# ⚠️  IMPORTANT — GitOps Principle (Hollywood Principle) "Don't call us, we'll call you"
 #
 # This file belongs in a SEPARATE GitOps config repository, NOT in your
 # application source repository.

--- a/resources/yaml/argocd-application.template.yaml
+++ b/resources/yaml/argocd-application.template.yaml
@@ -1,0 +1,94 @@
+# =============================================================================
+# Argo CD Application Manifest
+# =============================================================================
+#
+# ⚠️  IMPORTANT — Hollywood Principle / GitOps "Don't call us, we'll call you"
+#
+# This file belongs in a SEPARATE GitOps config repository, NOT in your
+# application source repository.
+#
+# Argo CD watches this config repo and PULLS changes automatically to your
+# AKS cluster.  It will detect drift between the live cluster state and what
+# is declared here, and reconcile automatically.
+#
+# Recommended GitOps config repo layout:
+#
+#   config-repo/
+#   └── apps/
+#       └── {{APP_NAME}}/
+#           ├── application.yaml   ← this file
+#           ├── deployment.yaml    ← your Kubernetes workload manifests
+#           └── service.yaml
+#
+# Reference: https://argo-cd.readthedocs.io/en/stable/
+# =============================================================================
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # The name used inside Argo CD to identify this application.
+  name: {{APP_NAME}}
+
+  # Argo CD system namespace — do NOT change unless you installed Argo CD
+  # in a custom namespace.
+  namespace: argocd
+
+  labels:
+    app.kubernetes.io/name: {{APP_NAME}}
+    app.kubernetes.io/managed-by: argocd
+
+  annotations:
+    # URL of the *application source* repository (informational).
+    # Keep this separate from repoURL below which points to THIS config repo.
+    aks-extension/source-repo: "{{SOURCE_REPO_URL}}"
+
+    # Link to Argo CD docs for reference.
+    aks-extension/docs: "https://argo-cd.readthedocs.io/en/stable/"
+
+spec:
+  # Argo CD project — "default" works for most setups.
+  # See: https://argo-cd.readthedocs.io/en/stable/user-guide/projects/
+  project: default
+
+  source:
+    # ✅ This is the URL of THIS GitOps config repository.
+    #    It is NOT the application source repository.
+    repoURL: {{CONFIG_REPO_URL}}
+
+    # Branch / tag / commit SHA to track.
+    targetRevision: HEAD
+
+    # Path inside this repo that contains the Kubernetes manifests for this app.
+    path: {{APP_PATH}}
+
+  destination:
+    # AKS cluster API server URL.
+    # Use "https://kubernetes.default.svc" when Argo CD runs inside the same cluster.
+    # For an external AKS cluster, use the API server URL from kubeconfig.
+    server: {{CLUSTER_SERVER}}
+
+    # Kubernetes namespace to deploy resources into.
+    namespace: {{NAMESPACE}}
+
+  syncPolicy:
+    automated:
+      # Remove resources from the cluster when they are deleted from Git.
+      prune: true
+
+      # Automatically bring the cluster back in sync when it drifts from Git.
+      selfHeal: true
+
+    syncOptions:
+      # Create the target namespace automatically if it does not exist.
+      - CreateNamespace=true
+
+      # Validate manifests against the Kubernetes API schema before applying.
+      - Validate=true
+
+    # Retry failed sync operations with exponential back-off.
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/resources/yaml/argocd-application.template.yaml
+++ b/resources/yaml/argocd-application.template.yaml
@@ -16,9 +16,12 @@
 #   config-repo/
 #   └── apps/
 #       └── {{APP_NAME}}/
-#           ├── application.yaml   ← this file
-#           ├── deployment.yaml    ← your Kubernetes workload manifests
-#           └── service.yaml
+#           └── application.yaml   ← this file (Argo CD Application CR)
+#
+# Kubernetes workload manifests (deployment.yaml, service.yaml, etc.)
+# live in the directory referenced by spec.source.path — either in this
+# config repo or in your application source repo, depending on your
+# GitOps layout.
 #
 # Reference: https://argo-cd.readthedocs.io/en/stable/
 # =============================================================================

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -23,6 +23,7 @@ import * as l10n from "@vscode/l10n";
 import { invokeKubectlCommand } from "../utils/kubectl";
 import { createTempFile } from "../utils/tempfile";
 import { failed } from "../utils/errorable";
+import { getAuthenticatedKubeconfigYaml } from "../utils/clusters";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
 import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
@@ -129,7 +130,17 @@ async function resolveCurrentKubectlContext(
         return undefined;
     }
 
-    return { contextName, kubeconfigYaml: cfgResult.stdout };
+    // AKS AAD clusters have a kubelogin exec block that calls Azure CLI, which is not on
+    // the extension host PATH. Inject the VS Code-managed cached token instead.
+    const authenticatedConfig = await getAuthenticatedKubeconfigYaml(cfgResult.stdout);
+    if (failed(authenticatedConfig)) {
+        vscode.window.showErrorMessage(
+            l10n.t("Could not authenticate kubeconfig for context '{0}': {1}", contextName, authenticatedConfig.error),
+        );
+        return undefined;
+    }
+
+    return { contextName, kubeconfigYaml: authenticatedConfig.result };
 }
 
 // ---------------------------------------------------------------------------
@@ -1101,7 +1112,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
                 invokeKubectlCommand(
                     kubectl,
                     kubeConfigFile.filePath,
-                    `apply -n ${targetNamespace} -f "${fileUri.fsPath}"`,
+                    `apply -n ${targetNamespace} -f "${fileUri.fsPath}" --validate=false`,
                 ),
         );
 

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -857,11 +857,17 @@ async function applyRepoSecret(
  *   - Repository access: only this repo (via repository_ids[] when available)
  *   - Permissions: Contents = Read-only, Metadata = Read-only
  *
- * After the user generates the token on GitHub and pastes it back, the token
- * is copied to the clipboard and a short note tells them where to paste it
- * inside the Argo CD UI (Settings → Repositories).
+ * After the user generates the token on GitHub and pastes it back, the repo
+ * is registered directly in Argo CD (argocd namespace repository Secret) so
+ * that Settings → Repositories already shows the connected repo with the
+ * supplied token — no manual paste required.
  */
-async function guideGitHubPatForRepo(repoUrl: string): Promise<void> {
+async function guideGitHubPatForRepo(
+    repoUrl: string,
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    clusterName: string,
+): Promise<void> {
     if (!repoUrl) {
         vscode.window.showWarningMessage(l10n.t("No source repository URL found in the Application manifest."));
         return;
@@ -936,25 +942,13 @@ async function guideGitHubPatForRepo(repoUrl: string): Promise<void> {
         );
 
         if (autoToken) {
-            await vscode.env.clipboard.writeText(autoToken);
-            const COPY_AGAIN = l10n.t("Copy Again");
-            await vscode.window
-                .showInformationMessage(
-                    l10n.t(
-                        "Fine-grained PAT generated for '{0}/{1}' and copied to clipboard.\n\n" +
-                            "Permissions: Contents (read-only), Metadata (read-only) — this repo only.\n\n" +
-                            "In Argo CD: Settings \u2192 Repositories \u2192 Connect Repo \u2192 paste as the password.",
-                        owner,
-                        repoSlug,
-                    ),
-                    { modal: true },
-                    COPY_AGAIN,
-                )
-                .then((a) => {
-                    if (a === COPY_AGAIN) {
-                        void vscode.env.clipboard.writeText(autoToken);
-                    }
-                });
+            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
+                type: "git",
+                url: repoUrl.trim(),
+                username: "git",
+                password: autoToken,
+            });
+            if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
             return;
         }
     }
@@ -1000,13 +994,13 @@ async function guideGitHubPatForRepo(repoUrl: string): Promise<void> {
     });
     if (!token) return;
 
-    await vscode.env.clipboard.writeText(token.trim());
-    vscode.window.showInformationMessage(
-        l10n.t(
-            "Token copied to clipboard. In Argo CD: Settings \u2192 Repositories \u2192 Connect Repo \u2192 paste it as the password for '{0}'.",
-            repoUrl,
-        ),
-    );
+    const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
+        type: "git",
+        url: repoUrl.trim(),
+        username: "git",
+        password: token.trim(),
+    });
+    if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
 }
 
 // ---------------------------------------------------------------------------
@@ -1191,7 +1185,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             } else if (pick.id === "get_creds") {
                 await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
             } else if (pick.id === "github_pat") {
-                await guideGitHubPatForRepo(repoUrl);
+                await guideGitHubPatForRepo(repoUrl, kubectl, kubeConfigFile.filePath, clusterName);
             } else if (pick.id === "register_repo") {
                 await registerRepoCredentials(kubectl, kubeConfigFile.filePath, repoUrl, clusterName);
             } else if (pick.id === "open_docs") {

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -28,6 +28,7 @@ import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
 import { selectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
 import { ClusterPreference } from "../../plugins/shared/types";
+import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -37,6 +38,7 @@ interface ArgoCDApplication {
     apiVersion: string;
     kind: string;
     metadata?: { name?: string; namespace?: string };
+    spec?: { source?: { repoURL?: string } };
 }
 
 function isArgoCDApplication(doc: unknown): doc is ArgoCDApplication {
@@ -91,6 +93,351 @@ function resolveFileUri(target: unknown): vscode.Uri | undefined {
     if (activeEditor) return activeEditor.document.uri;
 
     return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: open the Argo CD UI in the browser
+// ---------------------------------------------------------------------------
+// Helper: fetch Argo CD initial admin credentials from the cluster
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the username and initial admin password from the
+ * `argocd-initial-admin-secret` Secret.
+ *
+ * Argo CD stores the auto-generated password as a base64 value in the
+ * `password` field of that Secret.  After a user changes the password via
+ * `argocd account update-password`, this Secret is deleted — in that case
+ * the function returns undefined and warns the user.
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/getting_started/#4-login-using-the-cli
+ */
+async function getArgoCDAdminCredentials(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+): Promise<{ username: string; password: string } | undefined> {
+    const result = await longRunning(l10n.t("Fetching Argo CD admin credentials…"), () =>
+        invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `get secret argocd-initial-admin-secret -n argocd --ignore-not-found ` + `-o jsonpath="{.data.password}"`,
+            NonZeroExitCodeBehaviour.Succeed,
+        ),
+    );
+
+    if (failed(result)) return undefined;
+
+    const b64 = result.result.stdout.trim().replace(/^"|"$/g, "");
+    if (!b64) {
+        vscode.window.showInformationMessage(
+            l10n.t(
+                "argocd-initial-admin-secret not found — the password has likely already been changed via 'argocd account update-password' and the secret deleted.",
+            ),
+        );
+        return undefined;
+    }
+
+    const password = Buffer.from(b64, "base64").toString("utf8");
+    return { username: "admin", password };
+}
+
+/**
+ * Shows the Argo CD admin credentials with a masked password by default.
+ * Offers "Copy Password" and "Reveal Password" actions.
+ * Returns the URL that was opened (or undefined if the user just viewed creds).
+ */
+async function showArgoCDCredentials(kubectl: k8s.APIAvailable<k8s.KubectlV1>, kubeConfigFile: string): Promise<void> {
+    const creds = await getArgoCDAdminCredentials(kubectl, kubeConfigFile);
+    if (!creds) return;
+
+    const COPY_PASSWORD = l10n.t("Copy Password");
+    const REVEAL = l10n.t("Reveal Password");
+
+    const action = await vscode.window.showInformationMessage(
+        l10n.t("Argo CD credentials — Username: {0}  |  Password: {1}", creds.username, "••••••••"),
+        COPY_PASSWORD,
+        REVEAL,
+    );
+
+    if (action === COPY_PASSWORD) {
+        await vscode.env.clipboard.writeText(creds.password);
+        vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
+    } else if (action === REVEAL) {
+        const reveal = await vscode.window.showInformationMessage(
+            l10n.t("Argo CD credentials — Username: {0}  |  Password: {1}", creds.username, creds.password),
+            COPY_PASSWORD,
+        );
+        if (reveal === COPY_PASSWORD) {
+            await vscode.env.clipboard.writeText(creds.password);
+            vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Tries to open the Argo CD UI in the default browser.
+ *
+ * 1. Checks the argocd-server Service for an external LoadBalancer IP/hostname.
+ * 2. If found, opens https://<ip-or-hostname> directly.
+ * 3. Otherwise, starts a port-forward in an integrated terminal and opens
+ *    https://localhost:8080 — the user must keep that terminal open.
+ *
+ * Before opening the browser, fetches and displays the admin credentials so
+ * the user can log in immediately.
+ */
+async function openArgoCDUI(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    clusterName: string,
+): Promise<void> {
+    // Fetch credentials first so they're ready when the browser opens.
+    const creds = await getArgoCDAdminCredentials(kubectl, kubeConfigFile);
+
+    // Prefer a real LoadBalancer address so the terminal port-forward isn't needed.
+    const lbResult = await longRunning(l10n.t("Checking for Argo CD external address on '{0}'…", clusterName), () =>
+        invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `get svc argocd-server -n argocd --ignore-not-found ` +
+                `-o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'`,
+            NonZeroExitCodeBehaviour.Succeed,
+        ),
+    );
+
+    const externalAddr = !failed(lbResult) ? lbResult.result.stdout.trim().replace(/^'|'$/g, "") : "";
+
+    let uiUrl: string;
+    let needsPortForward = false;
+
+    if (externalAddr) {
+        uiUrl = `https://${externalAddr}`;
+    } else {
+        // No external address — verify the service exists before starting a port-forward.
+        const svcCheck = await longRunning(l10n.t("Checking Argo CD server service on '{0}'…", clusterName), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeConfigFile,
+                `get svc argocd-server -n argocd --ignore-not-found -o name`,
+                NonZeroExitCodeBehaviour.Succeed,
+            ),
+        );
+
+        if (failed(svcCheck) || svcCheck.result.stdout.trim() === "") {
+            vscode.window.showWarningMessage(
+                l10n.t(
+                    "argocd-server service not found on cluster '{0}'. Argo CD may still be starting up.",
+                    clusterName,
+                ),
+            );
+            return;
+        }
+
+        uiUrl = "https://localhost:8080";
+        needsPortForward = true;
+    }
+
+    // Show credentials before opening the browser so the user can copy the password.
+    if (creds) {
+        const COPY_AND_OPEN = l10n.t("Copy Password & Open");
+        const OPEN_ONLY = l10n.t("Open Without Copying");
+
+        const credAction = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Argo CD UI: {0}\n\nUsername: {1}\nPassword: {2}\n\n(This is the initial admin password from argocd-initial-admin-secret.)",
+                uiUrl,
+                creds.username,
+                creds.password,
+            ),
+            { modal: true },
+            COPY_AND_OPEN,
+            OPEN_ONLY,
+        );
+
+        if (!credAction) return;
+
+        if (credAction === COPY_AND_OPEN) {
+            await vscode.env.clipboard.writeText(creds.password);
+            vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
+        }
+    }
+
+    if (needsPortForward) {
+        // Start the port-forward and show the terminal — the user can see the
+        // "Forwarding from 127.0.0.1:8080 -> 8080" line appear.
+        // We must NOT open the browser immediately; the kubectl process needs a
+        // moment to bind the port.  Instead, show a notification with an
+        // "Open Browser" button so the user clicks it once the tunnel is ready.
+        const terminal = vscode.window.createTerminal({ name: `Argo CD UI — ${clusterName}` });
+        terminal.sendText(`kubectl port-forward svc/argocd-server -n argocd 8080:443 --kubeconfig="${kubeConfigFile}"`);
+        terminal.show();
+
+        const OPEN_BROWSER = l10n.t("Open Browser");
+        const action = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Port-forward started in terminal 'Argo CD UI — {0}'.\n\nWait for 'Forwarding from 127.0.0.1:8080' to appear in the terminal, then click Open Browser.",
+                clusterName,
+            ),
+            OPEN_BROWSER,
+        );
+        if (action === OPEN_BROWSER) {
+            await vscode.env.openExternal(vscode.Uri.parse(uiUrl));
+        }
+    } else {
+        await vscode.env.openExternal(vscode.Uri.parse(uiUrl));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: register a Git repository's credentials with Argo CD
+// ---------------------------------------------------------------------------
+
+/**
+ * Prompts the user for credentials for a private Git repository and creates
+ * (or updates) the corresponding Argo CD repository Secret in the cluster.
+ *
+ * Supports:
+ *  - HTTPS — username + personal access token (GitHub PAT, etc.)
+ *  - SSH   — private key file (id_rsa, id_ed25519, etc.)
+ *
+ * The secret is labelled `argocd.argoproj.io/secret-type: repository` so
+ * Argo CD picks it up automatically.
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories
+ */
+async function registerRepoCredentials(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    defaultRepoUrl: string,
+): Promise<void> {
+    // 1. Confirm / enter the repository URL.
+    const repoUrl = await vscode.window.showInputBox({
+        prompt: l10n.t("Git repository URL to register with Argo CD"),
+        value: defaultRepoUrl,
+        ignoreFocusOut: true,
+        validateInput: (v) => (!v || !v.trim() ? l10n.t("Repository URL is required.") : undefined),
+    });
+    if (!repoUrl) return;
+
+    // 2. Choose authentication type.
+    const authType = await vscode.window.showQuickPick(
+        [
+            {
+                label: "$(lock) HTTPS",
+                description: l10n.t("Username + personal access token or password"),
+                id: "https",
+            },
+            {
+                label: "$(key) SSH",
+                description: l10n.t("Private key file (id_rsa, id_ed25519, etc.)"),
+                id: "ssh",
+            },
+        ],
+        {
+            title: l10n.t("Authentication type for '{0}'", repoUrl.trim()),
+            ignoreFocusOut: true,
+        },
+    );
+    if (!authType) return;
+
+    let secretStringData: Record<string, string>;
+
+    if (authType.id === "https") {
+        // --- HTTPS: username + token ---
+        const username = await vscode.window.showInputBox({
+            prompt: l10n.t("Username (for GitHub PATs any value works, e.g. 'git' or 'token')"),
+            value: "git",
+            ignoreFocusOut: true,
+        });
+        if (username === undefined) return;
+
+        const token = await vscode.window.showInputBox({
+            prompt: l10n.t("Personal access token or password"),
+            password: true,
+            ignoreFocusOut: true,
+            validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
+        });
+        if (!token) return;
+
+        secretStringData = {
+            type: "git",
+            url: repoUrl.trim(),
+            username: username.trim() || "git",
+            password: token,
+        };
+    } else {
+        // --- SSH: private key file ---
+        const keyFiles = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+                "Private key files": ["pem", "key", "rsa", "ed25519", "ppk", "openssh"],
+                "All files": ["*"],
+            },
+            title: l10n.t("Select SSH private key file"),
+            openLabel: l10n.t("Use this key"),
+        });
+        if (!keyFiles || keyFiles.length === 0) return;
+
+        let privateKey: string;
+        try {
+            const bytes = await vscode.workspace.fs.readFile(keyFiles[0]);
+            privateKey = Buffer.from(bytes).toString("utf8");
+        } catch (e) {
+            vscode.window.showErrorMessage(l10n.t("Failed to read private key file: {0}", String(e)));
+            return;
+        }
+
+        secretStringData = {
+            type: "git",
+            url: repoUrl.trim(),
+            sshPrivateKey: privateKey,
+        };
+    }
+
+    // 3. Build a valid Kubernetes Secret name from the repo URL.
+    const secretName = `repo-${repoUrl
+        .trim()
+        .replace(/^https?:\/\/|^git@|\.git$/g, "")
+        .replace(/[^a-z0-9]/gi, "-")
+        .toLowerCase()
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 50)
+        .replace(/-+$/g, "")}`;
+
+    // 4. Serialize the secret object via js-yaml to avoid YAML injection.
+    const secretObj = {
+        apiVersion: "v1",
+        kind: "Secret",
+        metadata: {
+            name: secretName,
+            namespace: "argocd",
+            labels: { "argocd.argoproj.io/secret-type": "repository" },
+        },
+        stringData: secretStringData,
+    };
+    const secretYaml = yaml.dump(secretObj);
+
+    // 5. Apply via a temp file (never log credentials to channels).
+    const tmpFile = await createTempFile(secretYaml, "yaml");
+    try {
+        const result = await longRunning(l10n.t("Registering repository credentials with Argo CD…"), () =>
+            invokeKubectlCommand(kubectl, kubeConfigFile, `apply -f "${tmpFile.filePath}"`),
+        );
+
+        if (failed(result)) {
+            vscode.window.showErrorMessage(l10n.t("Failed to register repository credentials: {0}", result.error));
+            return;
+        }
+
+        vscode.window.showInformationMessage(
+            l10n.t("Repository '{0}' registered with Argo CD successfully.", repoUrl.trim()),
+        );
+    } finally {
+        tmpFile.dispose();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -161,28 +508,42 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         // ------------------------------------------------------------------
         // 6. Verify Argo CD is installed (check for argocd namespace).
         // ------------------------------------------------------------------
-        const nsCheck = await invokeKubectlCommand(
-            kubectl,
-            kubeConfigFile.filePath,
-            `get namespace argocd --ignore-not-found -o name`,
-            NonZeroExitCodeBehaviour.Succeed,
+        const nsCheck = await longRunning(
+            l10n.t("Checking if Argo CD is installed on '{0}'…", cluster.clusterName),
+            () =>
+                invokeKubectlCommand(
+                    kubectl,
+                    kubeConfigFile.filePath,
+                    `get namespace argocd --ignore-not-found -o name`,
+                    NonZeroExitCodeBehaviour.Succeed,
+                ),
         );
 
         const argoCDMissing = failed(nsCheck) || nsCheck.result.stdout.trim() === "";
 
         if (argoCDMissing) {
-            const INSTALL_FIRST = l10n.t("Install Argo CD First");
+            const INSTALL_NOW = l10n.t("Install Argo CD Now");
             const APPLY_ANYWAY = l10n.t("Apply Anyway");
             const choice = await vscode.window.showWarningMessage(
                 l10n.t(
-                    "Argo CD does not appear to be installed on cluster '{0}' (namespace 'argocd' not found).\n\nInstall it first via the cluster right-click menu → 'Install Argo CD on Cluster'.",
+                    "Argo CD does not appear to be installed on cluster '{0}' (namespace 'argocd' not found).\n\nInstall it now, or apply the manifest anyway.",
                     cluster.clusterName,
                 ),
                 { modal: true },
-                INSTALL_FIRST,
+                INSTALL_NOW,
                 APPLY_ANYWAY,
             );
-            if (!choice || choice === INSTALL_FIRST) return;
+            if (!choice) return;
+            if (choice === INSTALL_NOW) {
+                const channel = getOutputChannel();
+                const installed = await performArgoCDInstall(
+                    kubectl,
+                    kubeConfigFile.filePath,
+                    cluster.clusterName,
+                    channel,
+                );
+                if (!installed) return;
+            }
         }
 
         // ------------------------------------------------------------------
@@ -207,7 +568,10 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
 
         const output = applyResult.result.stdout.trim();
 
-        const OPEN_DOCS = l10n.t("Sync the Application (docs)");
+        const OPEN_UI = l10n.t("Open Argo CD UI");
+        const GET_CREDS = l10n.t("Get Credentials");
+        const REGISTER_REPO = l10n.t("Register Repo Credentials");
+        const OPEN_DOCS = l10n.t("Sync Guide");
         const followUp = await vscode.window.showInformationMessage(
             l10n.t(
                 "Argo CD Application '{0}' applied to cluster '{1}'.\n\n{2}\n\nArgo CD will begin syncing from the configured Git repository.",
@@ -215,10 +579,19 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
                 cluster.clusterName,
                 output,
             ),
+            OPEN_UI,
+            GET_CREDS,
+            REGISTER_REPO,
             OPEN_DOCS,
         );
 
-        if (followUp === OPEN_DOCS) {
+        if (followUp === OPEN_UI) {
+            await openArgoCDUI(kubectl, kubeConfigFile.filePath, cluster.clusterName);
+        } else if (followUp === GET_CREDS) {
+            await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
+        } else if (followUp === REGISTER_REPO) {
+            await registerRepoCredentials(kubectl, kubeConfigFile.filePath, doc.spec?.source?.repoURL ?? "");
+        } else if (followUp === OPEN_DOCS) {
             await vscode.env.openExternal(
                 vscode.Uri.parse(
                     "https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application",

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -167,9 +167,10 @@ async function detectArgoCDAuthMode(
     );
     if (failed(result)) return "admin-password";
     const oidcConfig = result.result.stdout.trim().replace(/^"|"$/g, "");
-    return oidcConfig.includes("microsoftonline.com") || oidcConfig.includes("useWorkloadIdentity")
-        ? "sso"
-        : "admin-password";
+    // Use a strict URL pattern to avoid incomplete substring matching (CodeQL: incomplete-url-substring-sanitization).
+    // This ensures the hostname is exactly "login.microsoftonline.com" and not a look-alike domain.
+    const isMicrosoftOidc = /https:\/\/login\.microsoftonline\.com\//.test(oidcConfig);
+    return isMicrosoftOidc || oidcConfig.includes("useWorkloadIdentity") ? "sso" : "admin-password";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -846,6 +846,170 @@ async function applyRepoSecret(
 }
 
 // ---------------------------------------------------------------------------
+// Helper: guide the user to create a fine-grained GitHub PAT for the
+// specific private repo referenced in spec.source.repoURL, and copy it
+// to the clipboard so they can paste it straight into Argo CD.
+// ---------------------------------------------------------------------------
+
+/**
+ * Opens the GitHub fine-grained PAT creation page pre-filled with:
+ *   - Token name: argocd-<repo>
+ *   - Repository access: only this repo (via repository_ids[] when available)
+ *   - Permissions: Contents = Read-only, Metadata = Read-only
+ *
+ * After the user generates the token on GitHub and pastes it back, the token
+ * is copied to the clipboard and a short note tells them where to paste it
+ * inside the Argo CD UI (Settings → Repositories).
+ */
+async function guideGitHubPatForRepo(repoUrl: string): Promise<void> {
+    if (!repoUrl) {
+        vscode.window.showWarningMessage(l10n.t("No source repository URL found in the Application manifest."));
+        return;
+    }
+
+    // Accept HTTPS and SSH URLs, optional .git suffix, optional trailing slash.
+    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?\/?\s*$/i);
+    if (!urlMatch) {
+        vscode.window.showWarningMessage(
+            l10n.t(
+                "'{0}' is not a recognized GitHub repository URL. Use 'Register Repo Credentials' for non-GitHub or SSH repos.",
+                repoUrl,
+            ),
+        );
+        return;
+    }
+    const [, owner, repoSlug] = urlMatch;
+
+    // Try to silently resolve the numeric repo ID (needed for programmatic PAT
+    // creation and to pre-select the repo on the GitHub PAT creation page).
+    let repoId: number | undefined;
+    let repoIsPrivate: boolean | undefined;
+    let sessionToken: string | undefined;
+    try {
+        const session = await vscode.authentication.getSession("github", ["repo"], {
+            createIfNone: false,
+            silent: true,
+        });
+        if (session) {
+            sessionToken = session.accessToken;
+            const res = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}`, {
+                headers: {
+                    Authorization: `Bearer ${session.accessToken}`,
+                    Accept: "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            });
+            if (res.ok) {
+                const data = (await res.json()) as { id: number; private: boolean };
+                repoId = data.id;
+                repoIsPrivate = data.private;
+            }
+        }
+    } catch {
+        // No session or API error — proceed without the repo ID.
+    }
+
+    if (repoIsPrivate === false) {
+        vscode.window.showInformationMessage(
+            l10n.t(
+                "'{0}/{1}' is a public repository — Argo CD can pull from it without any credentials.",
+                owner,
+                repoSlug,
+            ),
+        );
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    // Strategy 1: programmatic fine-grained PAT via GitHub REST API.
+    //
+    // POST /user/personal-access-tokens requires the caller's token to be a
+    // **classic PAT** with the `manage_user:personal_access_tokens` scope.
+    // A VS Code OAuth app token does NOT carry this scope, so this call will
+    // silently return undefined in most cases.  It does work for users who
+    // have already authenticated with a suitably scoped classic PAT.
+    // ------------------------------------------------------------------
+    if (sessionToken && repoId !== undefined) {
+        const autoToken = await longRunning(
+            l10n.t("Attempting to auto-generate a fine-grained PAT for '{0}/{1}'…", owner, repoSlug),
+            () => generateGitHubRepoScopedPat(sessionToken!, repoId!, repoSlug),
+        );
+
+        if (autoToken) {
+            await vscode.env.clipboard.writeText(autoToken);
+            const COPY_AGAIN = l10n.t("Copy Again");
+            await vscode.window
+                .showInformationMessage(
+                    l10n.t(
+                        "Fine-grained PAT generated for '{0}/{1}' and copied to clipboard.\n\n" +
+                            "Permissions: Contents (read-only), Metadata (read-only) — this repo only.\n\n" +
+                            "In Argo CD: Settings \u2192 Repositories \u2192 Connect Repo \u2192 paste as the password.",
+                        owner,
+                        repoSlug,
+                    ),
+                    { modal: true },
+                    COPY_AGAIN,
+                )
+                .then((a) => {
+                    if (a === COPY_AGAIN) {
+                        void vscode.env.clipboard.writeText(autoToken);
+                    }
+                });
+            return;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Strategy 2: guided manual flow — open the GitHub PAT creation page
+    // pre-filled with the correct settings, then collect the pasted token.
+    // ------------------------------------------------------------------
+    const tokenName = `argocd-${repoSlug}`
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/-{2,}/g, "-")
+        .replace(/-+$/g, "")
+        .slice(0, 40);
+
+    // GitHub accepts `description` and `repository_ids[]` as query params.
+    const params = new URLSearchParams({ description: tokenName });
+    if (repoId !== undefined) {
+        params.append("repository_ids[]", String(repoId));
+    }
+    const patUrl = `https://github.com/settings/personal-access-tokens/new?${params.toString()}`;
+
+    const OPEN_GITHUB = l10n.t("Open GitHub \u2192");
+    const repoNote = repoId !== undefined ? " (pre-selected)" : "";
+    const patInstructions =
+        `Create a fine-grained GitHub PAT so Argo CD can pull from '${owner}/${repoSlug}':\n\n` +
+        `  \u2022 Token name: ${tokenName}  (pre-filled)\n` +
+        `  \u2022 Expiration: 90 days (or custom)\n` +
+        `  \u2022 Repository access: Only select '${owner}/${repoSlug}'${repoNote}\n` +
+        `  \u2022 Permissions \u2192 Contents: Read-only\n` +
+        `  \u2022 Permissions \u2192 Metadata: Read-only\n\n` +
+        `Click 'Open GitHub \u2192', generate the token, then paste it into the next prompt.`;
+    const action = await vscode.window.showInformationMessage(patInstructions, { modal: true }, OPEN_GITHUB);
+    if (action !== OPEN_GITHUB) return;
+
+    await vscode.env.openExternal(vscode.Uri.parse(patUrl));
+
+    const token = await vscode.window.showInputBox({
+        prompt: l10n.t("Paste the generated GitHub PAT"),
+        password: true,
+        placeHolder: "github_pat_\u2026",
+        ignoreFocusOut: true,
+        validateInput: (v) => (!v?.trim() ? l10n.t("Token is required.") : undefined),
+    });
+    if (!token) return;
+
+    await vscode.env.clipboard.writeText(token.trim());
+    vscode.window.showInformationMessage(
+        l10n.t(
+            "Token copied to clipboard. In Argo CD: Settings \u2192 Repositories \u2192 Connect Repo \u2192 paste it as the password for '{0}'.",
+            repoUrl,
+        ),
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Command: Apply Argo CD Application to Cluster
 // ---------------------------------------------------------------------------
 
@@ -956,40 +1120,87 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
 
         const output = applyResult.result.stdout.trim();
 
-        const OPEN_UI = l10n.t("Open Argo CD UI");
-        const GET_CREDS = l10n.t("Get Credentials");
-        const REGISTER_REPO = l10n.t("Register Repo Credentials");
-        const OPEN_DOCS = l10n.t("Sync Guide");
-        const followUp = await vscode.window.showInformationMessage(
+        // Log kubectl output to the shared channel.
+        const postChannel = getOutputChannel();
+        postChannel.appendLine(`\n[Apply] ${appName} → ${clusterName}`);
+        postChannel.appendLine(output);
+
+        // Brief success toast (auto-dismisses).
+        vscode.window.showInformationMessage(
             l10n.t(
-                "'{0}' applied to '{1}'.\n\n{2}\n\nArgo CD will begin syncing from the configured Git repository.",
+                "✓ '{0}' applied to '{1}'. Use the action menu to open the UI or manage credentials.",
                 appName,
                 clusterName,
-                output,
             ),
-            OPEN_UI,
-            GET_CREDS,
-            REGISTER_REPO,
-            OPEN_DOCS,
         );
 
-        if (followUp === OPEN_UI) {
-            await openArgoCDUI(kubectl, kubeConfigFile.filePath, clusterName);
-        } else if (followUp === GET_CREDS) {
-            await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
-        } else if (followUp === REGISTER_REPO) {
-            await registerRepoCredentials(
-                kubectl,
-                kubeConfigFile.filePath,
-                doc.spec?.source?.repoURL ?? "",
-                clusterName,
-            );
-        } else if (followUp === OPEN_DOCS) {
-            await vscode.env.openExternal(
-                vscode.Uri.parse(
-                    "https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application",
-                ),
-            );
+        // ------------------------------------------------------------------
+        // Persistent follow-up menu — loops until the user presses Esc so
+        // all actions remain available even after performing one.
+        // ------------------------------------------------------------------
+        const repoUrl = doc.spec?.source?.repoURL ?? "";
+        const isGitHub = /github\.com/i.test(repoUrl);
+
+        interface ActionItem extends vscode.QuickPickItem {
+            id: string;
+        }
+        const actionItems: ActionItem[] = [
+            {
+                label: "$(browser) Open Argo CD UI",
+                description: l10n.t("Open the Argo CD dashboard in your browser"),
+                id: "open_ui",
+            },
+            {
+                label: "$(key) Get Argo CD Credentials",
+                description: l10n.t("View / copy the initial admin password"),
+                id: "get_creds",
+            },
+            ...(isGitHub
+                ? [
+                      {
+                          label: "$(github) Generate GitHub Token for Repo",
+                          description: l10n.t("Fine-grained PAT (Contents: read-only) for {0}", repoUrl),
+                          id: "github_pat",
+                      } as ActionItem,
+                  ]
+                : []),
+            {
+                label: "$(repo) Register Repo Credentials",
+                description: l10n.t("Register Git repo auth with Argo CD (HTTPS / SSH / Bearer)"),
+                id: "register_repo",
+            },
+            {
+                label: "$(book) Sync Guide",
+                description: l10n.t("Open Argo CD docs: sync the application"),
+                id: "open_docs",
+            },
+        ];
+
+        // Loop until the user presses Esc.
+        while (true) {
+            const pick = (await vscode.window.showQuickPick(actionItems, {
+                title: l10n.t("Argo CD — '{0}' on '{1}' (Esc to close)", appName, clusterName),
+                placeHolder: l10n.t("Select an action"),
+                ignoreFocusOut: false,
+            })) as ActionItem | undefined;
+
+            if (!pick) break;
+
+            if (pick.id === "open_ui") {
+                await openArgoCDUI(kubectl, kubeConfigFile.filePath, clusterName);
+            } else if (pick.id === "get_creds") {
+                await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
+            } else if (pick.id === "github_pat") {
+                await guideGitHubPatForRepo(repoUrl);
+            } else if (pick.id === "register_repo") {
+                await registerRepoCredentials(kubectl, kubeConfigFile.filePath, repoUrl, clusterName);
+            } else if (pick.id === "open_docs") {
+                await vscode.env.openExternal(
+                    vscode.Uri.parse(
+                        "https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application",
+                    ),
+                );
+            }
         }
     } finally {
         kubeConfigFile.dispose();

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -27,7 +27,6 @@ import { getAuthenticatedKubeconfigYaml } from "../utils/clusters";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
 import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
-import { generateGitHubRepoScopedPat, createGitHubDeployKey, generateSshDeployKeyPair } from "./argoCDDeployment";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -144,7 +143,35 @@ async function resolveCurrentKubectlContext(
 }
 
 // ---------------------------------------------------------------------------
-// Helper: open the Argo CD UI in the browser
+// Helper: detect whether Argo CD is using Microsoft SSO (workload identity)
+// or the classic admin-password flow.
+//
+// When installed via `az k8s-extension create --extension-type Microsoft.ArgoCD`
+// with workload identity, the argocd-cm ConfigMap contains an `oidc.config`
+// entry that references login.microsoftonline.com.  In that case the
+// argocd-initial-admin-secret is absent and the UI login is handled entirely
+// by Microsoft Entra ID — no password prompt needed.
+// ---------------------------------------------------------------------------
+
+type ArgoCDAuthMode = "sso" | "admin-password";
+
+async function detectArgoCDAuthMode(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+): Promise<ArgoCDAuthMode> {
+    const result = await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFile,
+        `get configmap argocd-cm -n argocd --ignore-not-found -o jsonpath="{.data['oidc\\.config']}"`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+    if (failed(result)) return "admin-password";
+    const oidcConfig = result.result.stdout.trim().replace(/^"|"$/g, "");
+    return oidcConfig.includes("microsoftonline.com") || oidcConfig.includes("useWorkloadIdentity")
+        ? "sso"
+        : "admin-password";
+}
+
 // ---------------------------------------------------------------------------
 // Helper: fetch Argo CD initial admin credentials from the cluster
 // ---------------------------------------------------------------------------
@@ -190,69 +217,37 @@ async function getArgoCDAdminCredentials(
 }
 
 /**
- * Shows the Argo CD admin credentials with a masked password by default.
- * Offers "Copy Password" and "Reveal Password" actions.
- * Returns the URL that was opened (or undefined if the user just viewed creds).
- */
-async function showArgoCDCredentials(kubectl: k8s.APIAvailable<k8s.KubectlV1>, kubeConfigFile: string): Promise<void> {
-    const creds = await getArgoCDAdminCredentials(kubectl, kubeConfigFile);
-    if (!creds) return;
-
-    const COPY_PASSWORD = l10n.t("Copy Password");
-    const REVEAL = l10n.t("Reveal Password");
-
-    const action = await vscode.window.showInformationMessage(
-        l10n.t("Argo CD credentials — Username: {0}  |  Password: {1}", creds.username, "••••••••"),
-        COPY_PASSWORD,
-        REVEAL,
-    );
-
-    if (action === COPY_PASSWORD) {
-        await vscode.env.clipboard.writeText(creds.password);
-        vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
-    } else if (action === REVEAL) {
-        const reveal = await vscode.window.showInformationMessage(
-            l10n.t("Argo CD credentials — Username: {0}  |  Password: {1}", creds.username, creds.password),
-            COPY_PASSWORD,
-        );
-        if (reveal === COPY_PASSWORD) {
-            await vscode.env.clipboard.writeText(creds.password);
-            vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-
-/**
  * Tries to open the Argo CD UI in the default browser.
  *
- * 1. Checks the argocd-server Service for an external LoadBalancer IP/hostname.
- * 2. If found, opens https://<ip-or-hostname> directly.
- * 3. Otherwise, starts a port-forward in an integrated terminal and opens
+ * 1. Detects whether Argo CD was installed with Microsoft SSO (workload identity)
+ *    or the OSS admin-password flow, and adjusts the pre-open prompt accordingly.
+ * 2. Checks the argocd-server Service for an external LoadBalancer IP/hostname.
+ * 3. If found, opens https://<ip-or-hostname> directly.
+ * 4. Otherwise, starts a port-forward in an integrated terminal and opens
  *    https://localhost:8080 — the user must keep that terminal open.
  *
- * Before opening the browser, fetches and displays the admin credentials so
- * the user can log in immediately.
+ * SSO path  — no credentials are fetched; the browser redirects to Microsoft login.
+ * Password path — fetches and displays the initial admin password before opening.
  */
 async function openArgoCDUI(
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
     kubeConfigFile: string,
     clusterName: string,
 ): Promise<void> {
-    // Fetch credentials first so they're ready when the browser opens.
-    const creds = await getArgoCDAdminCredentials(kubectl, kubeConfigFile);
-
-    // Prefer a real LoadBalancer address so the terminal port-forward isn't needed.
-    const lbResult = await longRunning(l10n.t("Checking for Argo CD external address on '{0}'…", clusterName), () =>
-        invokeKubectlCommand(
-            kubectl,
-            kubeConfigFile,
-            `get svc argocd-server -n argocd --ignore-not-found ` +
-                `-o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'`,
-            NonZeroExitCodeBehaviour.Succeed,
+    // Detect auth mode and (for the password path) fetch credentials in parallel
+    // with the LoadBalancer probe so we don't add extra round-trips.
+    const [authMode, lbResult] = await Promise.all([
+        detectArgoCDAuthMode(kubectl, kubeConfigFile),
+        longRunning(l10n.t("Checking for Argo CD external address on '{0}'…", clusterName), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeConfigFile,
+                `get svc argocd-server -n argocd --ignore-not-found ` +
+                    `-o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'`,
+                NonZeroExitCodeBehaviour.Succeed,
+            ),
         ),
-    );
+    ]);
 
     const externalAddr = !failed(lbResult) ? lbResult.result.stdout.trim().replace(/^'|'$/g, "") : "";
 
@@ -286,28 +281,38 @@ async function openArgoCDUI(
         needsPortForward = true;
     }
 
-    // Show credentials before opening the browser so the user can copy the password.
-    if (creds) {
-        const COPY_AND_OPEN = l10n.t("Copy Password & Open");
-        const OPEN_ONLY = l10n.t("Open Without Copying");
-
-        const credAction = await vscode.window.showInformationMessage(
-            l10n.t(
-                "Argo CD UI: {0}\n\nUsername: {1}\nPassword: {2}\n\n(This is the initial admin password from argocd-initial-admin-secret.)",
-                uiUrl,
-                creds.username,
-                creds.password,
-            ),
-            { modal: true },
-            COPY_AND_OPEN,
-            OPEN_ONLY,
+    if (authMode === "sso") {
+        // Microsoft SSO path — no admin password exists; the browser will redirect
+        // to Microsoft Entra ID automatically.  Just open the URL directly.
+        vscode.window.showInformationMessage(
+            l10n.t("Opening Argo CD UI ({0}). Sign in with your Microsoft account.", uiUrl),
         );
+    } else {
+        // Admin-password path — fetch and surface the initial admin password so
+        // the user can copy it before the browser tab opens.
+        const creds = await getArgoCDAdminCredentials(kubectl, kubeConfigFile);
+        if (creds) {
+            const COPY_AND_OPEN = l10n.t("Copy Password & Open");
+            const OPEN_ONLY = l10n.t("Open Without Copying");
 
-        if (!credAction) return;
+            const credAction = await vscode.window.showInformationMessage(
+                l10n.t(
+                    "Argo CD UI: {0}\n\nUsername: {1}\nPassword: {2}\n\n(This is the initial admin password from argocd-initial-admin-secret.)",
+                    uiUrl,
+                    creds.username,
+                    creds.password,
+                ),
+                { modal: true },
+                COPY_AND_OPEN,
+                OPEN_ONLY,
+            );
 
-        if (credAction === COPY_AND_OPEN) {
-            await vscode.env.clipboard.writeText(creds.password);
-            vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
+            if (!credAction) return;
+
+            if (credAction === COPY_AND_OPEN) {
+                await vscode.env.clipboard.writeText(creds.password);
+                vscode.window.showInformationMessage(l10n.t("Argo CD password copied to clipboard."));
+            }
         }
     }
 
@@ -338,577 +343,81 @@ async function openArgoCDUI(
 }
 
 // ---------------------------------------------------------------------------
-// Helper: register a Git repository's credentials with Argo CD
+// Helper: silently probe whether a GitHub repo is public or private
 // ---------------------------------------------------------------------------
 
 /**
- * Prompts the user for credentials for a private Git repository and creates
- * (or updates) the corresponding Argo CD repository Secret in the cluster.
+ * Uses a silent VS Code GitHub session (no sign-in prompt) to call the
+ * GitHub REST API and determine repo visibility.
  *
- * Supports:
- *  - HTTPS — username + personal access token (GitHub PAT, etc.)
- *  - SSH   — private key file (id_rsa, id_ed25519, etc.)
- *
- * The secret is labelled `argocd.argoproj.io/secret-type: repository` so
- * Argo CD picks it up automatically.
- *
- * Reference: https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories
+ * Returns:
+ *   "public"  — repo exists and is public (Argo CD can pull without credentials)
+ *   "private" — repo exists and is private (credentials required)
+ *   "unknown" — no silent session, API error, or non-GitHub URL
  */
-async function registerRepoCredentials(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeConfigFile: string,
-    defaultRepoUrl: string,
-    clusterName: string,
-): Promise<void> {
-    // 1. Confirm / enter the repository URL.
-    const repoUrl = await vscode.window.showInputBox({
-        prompt: l10n.t("Git repository URL to register with Argo CD"),
-        value: defaultRepoUrl,
-        ignoreFocusOut: true,
-        validateInput: (v) => (!v || !v.trim() ? l10n.t("Repository URL is required.") : undefined),
-    });
-    if (!repoUrl) return;
-
-    // 2. For GitHub URLs, silently probe repo visibility first (no sign-in prompt).
-    //    • Private repo detected  → auto-generate a 24h repo-scoped PAT and skip the picker.
-    //    • Public repo detected   → inform the user (no creds needed) and return.
-    //    • Session unavailable or API error → fall through to the manual auth picker below.
-    const isGitHubRepo = /github\.com/i.test(repoUrl.trim());
-    if (isGitHubRepo) {
-        const urlMatch = repoUrl.trim().match(/github\.com[\\/:]([^\\/]+)\/([^\\/.]+?)(?:\.git)?\s*$/i);
-        if (urlMatch) {
-            const [, owner, repoSlug] = urlMatch;
-
-            // Try to reuse an existing GitHub session without forcing a sign-in prompt.
-            let silentSession: vscode.AuthenticationSession | undefined;
-            try {
-                silentSession = await vscode.authentication.getSession("github", ["repo"], {
-                    createIfNone: false,
-                    silent: true,
-                });
-            } catch {
-                // No existing session — fall through to the manual picker.
-            }
-
-            if (silentSession) {
-                // Probe the GitHub API to determine visibility and get the repo ID.
-                let repoId: number | undefined;
-                let repoIsPrivate: boolean | undefined;
-                try {
-                    const repoRes = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}`, {
-                        headers: {
-                            Authorization: `Bearer ${silentSession.accessToken}`,
-                            Accept: "application/vnd.github+json",
-                            "X-GitHub-Api-Version": "2022-11-28",
-                        },
-                    });
-                    if (repoRes.ok) {
-                        const data = (await repoRes.json()) as { id: number; private: boolean };
-                        repoId = data.id;
-                        repoIsPrivate = data.private;
-                    }
-                } catch {
-                    // API failure — fall through to the manual picker.
-                }
-
-                if (repoIsPrivate === false) {
-                    // Public — Argo CD can pull without any credentials.
-                    vscode.window.showInformationMessage(
-                        l10n.t(
-                            "'{0}/{1}' is a public repository — Argo CD can pull from it without credentials.",
-                            owner,
-                            repoSlug,
-                        ),
-                    );
-                    return;
-                }
-
-                if (repoIsPrivate === true && repoId !== undefined) {
-                    // Argo CD matches the repository Secret's `url` field to the
-                    // application's `spec.source.repoURL` — they must use the same
-                    // scheme.  An SSH credential stored as `git@github.com:` will
-                    // NEVER be matched to an HTTPS `repoURL`, causing "Connection
-                    // Failed" even when the deploy key is perfectly valid.
-                    //
-                    // Rule: HTTPS repoURL → only ever try HTTPS credentials.
-                    //        SSH repoURL  → try SSH deploy key.
-                    const isHttpsUrl = /^https?:\/\//i.test(repoUrl.trim());
-
-                    if (isHttpsUrl) {
-                        // Try a fine-grained PAT (24h).  This requires a classic PAT
-                        // token scope that a VS Code OAuth token can't provide, so it
-                        // usually falls through to the manual picker.
-                        const patToken = await longRunning(
-                            l10n.t("Generating 24-hour repo-scoped GitHub PAT for '{0}/{1}'\u2026", owner, repoSlug),
-                            () => generateGitHubRepoScopedPat(silentSession!.accessToken, repoId!, repoSlug),
-                        );
-
-                        if (patToken) {
-                            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
-                                type: "git",
-                                url: repoUrl.trim(),
-                                username: "git",
-                                password: patToken,
-                            });
-                            if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
-                            return;
-                        }
-
-                        // PAT API unavailable (VS Code OAuth tokens cannot call
-                        // POST /user/personal-access-tokens — it requires a classic
-                        // PAT scope).  Guide the user to create one manually on
-                        // GitHub, collect the pasted token, and register it directly
-                        // into Argo CD without any further manual steps.
-                        const patFromUser = await guideAndCollectGitHubPat(owner, repoSlug);
-                        if (!patFromUser) return;
-
-                        const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
-                            type: "git",
-                            url: repoUrl.trim(),
-                            username: "git",
-                            password: patFromUser.trim(),
-                        });
-                        if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
-                        return;
-                    } else {
-                        // SSH repoURL — generate a deploy key.
-                        const keyPair = generateSshDeployKeyPair();
-                        const deployKeyResult = await longRunning(
-                            l10n.t("Creating SSH deploy key for '{0}/{1}'\u2026", owner, repoSlug),
-                            () =>
-                                createGitHubDeployKey(
-                                    silentSession!.accessToken,
-                                    owner,
-                                    repoSlug,
-                                    keyPair.publicKeySsh,
-                                ),
-                        );
-
-                        if (deployKeyResult) {
-                            // Patch known-hosts first (argocd-repo-server must trust
-                            // GitHub's fingerprint or the SSH handshake is rejected).
-                            await ensureGitHubSshKnownHosts(kubectl, kubeConfigFile);
-                            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
-                                type: "git",
-                                url: repoUrl.trim(),
-                                sshPrivateKey: keyPair.privateKeyPem,
-                            });
-                            if (ok) {
-                                vscode.window.showInformationMessage(
-                                    l10n.t(
-                                        "Read-only SSH deploy key '{0}' registered on GitHub. To remove it later: https://github.com/{1}/{2}/settings/keys",
-                                        deployKeyResult.title,
-                                        owner,
-                                        repoSlug,
-                                    ),
-                                );
-                                await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
-                            }
-                            return;
-                        }
-
-                        // Deploy key creation failed — guide to manual setup.
-                        const OPEN_GITHUB = l10n.t("Open GitHub");
-                        const fallbackAction = await vscode.window.showWarningMessage(
-                            l10n.t(
-                                "Could not auto-create a deploy key (the organisation may restrict this). Please add one manually in repository Settings \u2192 Deploy keys, then use the SSH option in the auth picker.",
-                            ),
-                            OPEN_GITHUB,
-                        );
-                        if (fallbackAction === OPEN_GITHUB) {
-                            await vscode.env.openExternal(
-                                vscode.Uri.parse(`https://github.com/${owner}/${repoSlug}/settings/keys/new`),
-                            );
-                        }
-                        return;
-                    }
-                }
-                // repoIsPrivate is still undefined (API returned non-OK) → fall through.
-            }
-        }
-    }
-
-    // 3. Manual auth picker — reached for non-GitHub URLs, when no silent session
-    //    is available, or when the GitHub API probe failed.
-    const authType = await vscode.window.showQuickPick(
-        [
-            {
-                label: "$(lock) HTTPS",
-                description: l10n.t("Username + personal access token or password"),
-                id: "https",
-            },
-            {
-                label: "$(shield) Bearer token",
-                description: l10n.t("OAuth2 / JWT bearer token (GitLab, Azure DevOps, Gitea, Forgejo)"),
-                id: "bearer",
-            },
-            {
-                label: "$(key) SSH",
-                description: l10n.t("Private key file (id_rsa, id_ed25519, etc.)"),
-                id: "ssh",
-            },
-        ],
-        {
-            title: l10n.t("Authentication type for '{0}'", repoUrl.trim()),
-            ignoreFocusOut: true,
-        },
-    );
-    if (!authType) return;
-
-    let secretStringData: Record<string, string>;
-
-    if (authType.id === "https") {
-        // --- HTTPS: username + personal access token / password ---
-        const username = await vscode.window.showInputBox({
-            prompt: l10n.t("Username (for GitHub PATs any value works, e.g. 'git' or 'token')"),
-            value: "git",
-            ignoreFocusOut: true,
-        });
-        if (username === undefined) return;
-
-        const token = await vscode.window.showInputBox({
-            prompt: l10n.t("Personal access token or password"),
-            password: true,
-            ignoreFocusOut: true,
-            validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
-        });
-        if (!token) return;
-
-        secretStringData = {
-            type: "git",
-            url: repoUrl.trim(),
-            username: username.trim() || "git",
-            password: token,
-        };
-    } else if (authType.id === "bearer") {
-        // --- Bearer token (Authorization: Bearer <token>) ---
-        // Used by GitLab personal/project/group access tokens, Azure DevOps PATs,
-        // Gitea/Forgejo tokens, and any provider that speaks OAuth2 token introspection.
-        const bearerToken = await vscode.window.showInputBox({
-            prompt: l10n.t("Bearer token (will be sent as 'Authorization: Bearer <token>')"),
-            password: true,
-            ignoreFocusOut: true,
-            validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
-        });
-        if (!bearerToken) return;
-
-        secretStringData = {
-            type: "git",
-            url: repoUrl.trim(),
-            bearerToken: bearerToken.trim(),
-        };
-    } else {
-        // --- SSH: private key file ---
-        const keyFiles = await vscode.window.showOpenDialog({
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: false,
-            filters: {
-                "Private key files": ["pem", "key", "rsa", "ed25519", "ppk", "openssh"],
-                "All files": ["*"],
-            },
-            title: l10n.t("Select SSH private key file"),
-            openLabel: l10n.t("Use this key"),
-        });
-        if (!keyFiles || keyFiles.length === 0) return;
-
-        let privateKey: string;
-        try {
-            const bytes = await vscode.workspace.fs.readFile(keyFiles[0]);
-            privateKey = Buffer.from(bytes).toString("utf8");
-        } catch (e) {
-            vscode.window.showErrorMessage(l10n.t("Failed to read private key file: {0}", String(e)));
-            return;
-        }
-
-        secretStringData = {
-            type: "git",
-            url: repoUrl.trim(),
-            sshPrivateKey: privateKey,
-        };
-    }
-
-    // For SSH URLs targeting github.com, ensure the known-hosts ConfigMap is
-    // populated before registering the key — same as `argocd repo add` does.
-    if (/github\.com/i.test(repoUrl.trim()) && secretStringData.sshPrivateKey) {
-        await ensureGitHubSshKnownHosts(kubectl, kubeConfigFile);
-    }
-
-    const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), secretStringData);
-    if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
-}
-
-/**
- * When the GitHub PAT API is unavailable (VS Code OAuth tokens cannot call
- * POST /user/personal-access-tokens), opens the GitHub fine-grained PAT
- * creation page pre-filled with the correct token name, shows a modal with
- * exact step-by-step instructions (expiry, repo scope, permissions), then
- * presents a password input box to paste the generated token back.
- *
- * Returns the pasted token string, or undefined if the user cancels.
- * The caller is responsible for registering the returned token with Argo CD.
- */
-async function guideAndCollectGitHubPat(owner: string, repoSlug: string): Promise<string | undefined> {
-    const tokenName = `argocd-${repoSlug}-24h`
-        .replace(/[^a-zA-Z0-9._-]/g, "-")
-        .replace(/-{2,}/g, "-")
-        .replace(/-+$/g, "")
-        .slice(0, 40);
-
-    // GitHub's fine-grained PAT creation page accepts a `description` query
-    // parameter to pre-fill the token name field.
-    const patUrl = `https://github.com/settings/personal-access-tokens/new?description=${encodeURIComponent(tokenName)}`;
-
-    const OPEN_GITHUB = l10n.t("Open GitHub \u2192");
-    const userAction = await vscode.window.showInformationMessage(
-        l10n.t(
-            "Create a fine-grained GitHub PAT with these exact settings:\n\n" +
-                "  \u2022 Token name:  {0}  (pre-filled)\n" +
-                "  \u2022 Expiration:  Custom \u2192 1 day\n" +
-                "  \u2022 Repository access:  Only select \u2018{1}/{2}\u2019\n" +
-                "  \u2022 Permissions \u2192 Contents: Read-only\n" +
-                "  \u2022 Permissions \u2192 Metadata: Read-only\n\n" +
-                "Click \u2018Open GitHub \u2192\u2019, configure the options above, click \u2018Generate token\u2019, then paste the token into the next prompt.",
-            tokenName,
-            owner,
-            repoSlug,
-        ),
-        { modal: true },
-        OPEN_GITHUB,
-    );
-    if (userAction !== OPEN_GITHUB) return undefined;
-
-    await vscode.env.openExternal(vscode.Uri.parse(patUrl));
-
-    const pasted = await vscode.window.showInputBox({
-        prompt: l10n.t("Paste the generated GitHub PAT \u2014 it will be registered in Argo CD automatically"),
-        password: true,
-        placeHolder: "github_pat_\u2026",
-        ignoreFocusOut: true,
-        validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
-    });
-
-    return pasted?.trim() || undefined;
-}
-
-/**
- * After a successful repo credential registration, offer to open the Argo CD UI
- * directly at Settings → Repositories so the user can verify the connection status.
- */
-async function offerOpenArgoCDUI(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeConfigFile: string,
-    clusterName: string,
-): Promise<void> {
-    const OPEN_UI = l10n.t("View in Argo CD (Settings → Repositories)");
-    const action = await vscode.window.showInformationMessage(
-        l10n.t("Open the Argo CD UI to verify the repository connection status under Settings → Repositories."),
-        OPEN_UI,
-    );
-    if (action === OPEN_UI) {
-        await openArgoCDUI(kubectl, kubeConfigFile, clusterName);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Helper: ensure GitHub SSH host keys are present in argocd-ssh-known-hosts-cm
-// ---------------------------------------------------------------------------
-
-/**
- * Mirrors what `argocd repo add --ssh-private-key-path` does automatically:
- * fetches GitHub's current SSH public host keys from the GitHub meta API and
- * patches the `argocd-ssh-known-hosts-cm` ConfigMap with any that are missing.
- *
- * Without this, Argo CD refuses to open the SSH connection ("unknown host"),
- * so the repository shows "not connected" even when the deploy key is correct.
- *
- * Reference:
- *   https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#ssh-known-host-public-keys
- *   https://docs.github.com/en/rest/meta/meta#get-github-meta-information
- */
-async function ensureGitHubSshKnownHosts(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeConfigFile: string,
-): Promise<void> {
-    // 1. Fetch GitHub's current SSH host keys.
-    let githubKeys: string[];
-    try {
-        const res = await fetch("https://api.github.com/meta", {
-            headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const meta = (await res.json()) as { ssh_keys?: string[] };
-        githubKeys = (meta.ssh_keys ?? []).filter((k) => k.trim().length > 0);
-    } catch (e) {
-        vscode.window.showWarningMessage(
-            l10n.t(
-                "Could not fetch GitHub SSH host keys ({0}). Argo CD may show the repository as disconnected until you add them manually.",
-                String(e),
-            ),
-        );
-        return;
-    }
-
-    if (githubKeys.length === 0) return;
-
-    // 2. Read the current known-hosts ConfigMap.
-    const getResult = await invokeKubectlCommand(
-        kubectl,
-        kubeConfigFile,
-        `get cm argocd-ssh-known-hosts-cm -n argocd -o jsonpath="{.data.ssh_known_hosts}"`,
-        NonZeroExitCodeBehaviour.Succeed,
-    );
-
-    const existing = !failed(getResult) ? getResult.result.stdout.trim().replace(/^"|"$/g, "") : "";
-
-    // 3. Build the merged known-hosts block — add only missing entries.
-    const existingLines = new Set(
-        existing
-            .split("\n")
-            .map((l) => l.trim())
-            .filter(Boolean),
-    );
-    const toAdd = githubKeys.map((k) => `github.com ${k.trim()}`).filter((line) => !existingLines.has(line));
-
-    if (toAdd.length === 0) return; // already up to date
-
-    const merged = `${[...existingLines, ...toAdd].join("\n")}\n`;
-
-    // 4. Patch the ConfigMap.  Use a JSON merge-patch via a temp file to avoid
-    //    shell quoting issues with the multi-line value.
-    const patchObj = { data: { ssh_known_hosts: merged } };
-    const patchFile = await createTempFile(JSON.stringify(patchObj), "json");
-    try {
-        const patchResult = await invokeKubectlCommand(
-            kubectl,
-            kubeConfigFile,
-            `patch cm argocd-ssh-known-hosts-cm -n argocd --type=merge --patch-file "${patchFile.filePath}"`,
-        );
-        if (failed(patchResult)) {
-            vscode.window.showWarningMessage(
-                l10n.t("Could not patch argocd-ssh-known-hosts-cm: {0}", patchResult.error),
-            );
-            return;
-        }
-    } finally {
-        patchFile.dispose();
-    }
-
-    // 5. Restart argocd-repo-server so it picks up the updated ConfigMap immediately.
-    //    Without this, the pod keeps using the copy it loaded at startup and SSH
-    //    connections fail with "unknown host" until the next pod restart.
-    await invokeKubectlCommand(
-        kubectl,
-        kubeConfigFile,
-        `rollout restart deployment/argocd-repo-server -n argocd`,
-        NonZeroExitCodeBehaviour.Succeed,
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Helper: build + kubectl-apply an Argo CD repository Secret
-// ---------------------------------------------------------------------------
-
-async function applyRepoSecret(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeConfigFile: string,
-    repoUrl: string,
-    secretStringData: Record<string, string>,
-): Promise<boolean> {
-    // Build a valid Kubernetes Secret name from the repo URL.
-    const secretName = `repo-${repoUrl
-        .replace(/^https?:\/\/|^git@|\.git$/g, "")
-        .replace(/[^a-z0-9]/gi, "-")
-        .toLowerCase()
-        .replace(/^-+|-+$/g, "")
-        .slice(0, 50)
-        .replace(/-+$/g, "")}`;
-
-    // Serialize the secret object via js-yaml to avoid YAML injection.
-    const secretObj = {
-        apiVersion: "v1",
-        kind: "Secret",
-        metadata: {
-            name: secretName,
-            namespace: "argocd",
-            labels: { "argocd.argoproj.io/secret-type": "repository" },
-        },
-        stringData: secretStringData,
-    };
-    const secretYaml = yaml.dump(secretObj);
-
-    // Apply via a temp file (never log credentials to output channels).
-    const tmpFile = await createTempFile(secretYaml, "yaml");
-    try {
-        const result = await longRunning(l10n.t("Registering repository credentials with Argo CD…"), () =>
-            invokeKubectlCommand(kubectl, kubeConfigFile, `apply -f "${tmpFile.filePath}"`),
-        );
-
-        if (failed(result)) {
-            vscode.window.showErrorMessage(l10n.t("Failed to register repository credentials: {0}", result.error));
-            return false;
-        }
-
-        vscode.window.showInformationMessage(l10n.t("Repository '{0}' registered with Argo CD successfully.", repoUrl));
-        return true;
-    } finally {
-        tmpFile.dispose();
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Helper: guide the user to create a fine-grained GitHub PAT for the
-// specific private repo referenced in spec.source.repoURL, and copy it
-// to the clipboard so they can paste it straight into Argo CD.
-// ---------------------------------------------------------------------------
-
-/**
- * Opens the GitHub fine-grained PAT creation page pre-filled with:
- *   - Token name: argocd-<repo>
- *   - Repository access: only this repo (via repository_ids[] when available)
- *   - Permissions: Contents = Read-only, Metadata = Read-only
- *
- * After the user generates the token on GitHub and pastes it back, the repo
- * is registered directly in Argo CD (argocd namespace repository Secret) so
- * that Settings → Repositories already shows the connected repo with the
- * supplied token — no manual paste required.
- */
-async function guideGitHubPatForRepo(
-    repoUrl: string,
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeConfigFile: string,
-    clusterName: string,
-): Promise<void> {
-    if (!repoUrl) {
-        vscode.window.showWarningMessage(l10n.t("No source repository URL found in the Application manifest."));
-        return;
-    }
-
-    // Accept HTTPS and SSH URLs, optional .git suffix, optional trailing slash.
+async function probeGitHubRepoVisibility(repoUrl: string): Promise<"public" | "private" | "unknown"> {
     const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?\/?\s*$/i);
-    if (!urlMatch) {
-        vscode.window.showWarningMessage(
-            l10n.t(
-                "'{0}' is not a recognized GitHub repository URL. Use 'Register Repo Credentials' for non-GitHub or SSH repos.",
-                repoUrl,
-            ),
-        );
-        return;
-    }
+    if (!urlMatch) return "unknown";
     const [, owner, repoSlug] = urlMatch;
 
-    // Try to silently resolve the numeric repo ID (needed for programmatic PAT
-    // creation and to pre-select the repo on the GitHub PAT creation page).
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+        session = await vscode.authentication.getSession("github", ["repo"], {
+            createIfNone: false,
+            silent: true,
+        });
+    } catch {
+        return "unknown";
+    }
+    if (!session) return "unknown";
+
+    try {
+        const res = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}`, {
+            headers: {
+                Authorization: `Bearer ${session.accessToken}`,
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        });
+        if (!res.ok) return "unknown";
+        const data = (await res.json()) as { private: boolean };
+        return data.private ? "private" : "public";
+    } catch {
+        return "unknown";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: connect a private GitHub repo to Argo CD via fine-grained PAT
+// ---------------------------------------------------------------------------
+
+/**
+ * Full flow for wiring a private GitHub repo into Argo CD:
+ *  1. Opens the GitHub fine-grained PAT creation page (pre-filled token name
+ *     and, when resolvable, the numeric repo ID).
+ *  2. Shows a password input box for the user to paste the PAT back.
+ *  3. Applies a labelled Kubernetes Secret in the argocd namespace so Argo CD
+ *     picks it up automatically as a repository credential.
+ */
+async function connectPrivateGitHubRepo(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    repoUrl: string,
+): Promise<void> {
+    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?\/?\s*$/i);
+    if (!urlMatch) return;
+    const [, owner, repoSlug] = urlMatch;
+
+    // Silently try to resolve the numeric repo ID + GitHub username.
     let repoId: number | undefined;
-    let repoIsPrivate: boolean | undefined;
-    let sessionToken: string | undefined;
+    let githubUsername: string | undefined;
     try {
         const session = await vscode.authentication.getSession("github", ["repo"], {
             createIfNone: false,
             silent: true,
         });
         if (session) {
-            sessionToken = session.accessToken;
+            githubUsername = session.account.label;
             const res = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}`, {
                 headers: {
                     Authorization: `Bearer ${session.accessToken}`,
@@ -917,101 +426,109 @@ async function guideGitHubPatForRepo(
                 },
             });
             if (res.ok) {
-                const data = (await res.json()) as { id: number; private: boolean };
+                const data = (await res.json()) as { id: number };
                 repoId = data.id;
-                repoIsPrivate = data.private;
             }
         }
     } catch {
-        // No session or API error — proceed without the repo ID.
+        // No session or API error — proceed without ID.
     }
 
-    if (repoIsPrivate === false) {
-        vscode.window.showInformationMessage(
-            l10n.t(
-                "'{0}/{1}' is a public repository — Argo CD can pull from it without any credentials.",
-                owner,
-                repoSlug,
-            ),
-        );
-        return;
-    }
-
-    // ------------------------------------------------------------------
-    // Strategy 1: programmatic fine-grained PAT via GitHub REST API.
-    //
-    // POST /user/personal-access-tokens requires the caller's token to be a
-    // **classic PAT** with the `manage_user:personal_access_tokens` scope.
-    // A VS Code OAuth app token does NOT carry this scope, so this call will
-    // silently return undefined in most cases.  It does work for users who
-    // have already authenticated with a suitably scoped classic PAT.
-    // ------------------------------------------------------------------
-    if (sessionToken && repoId !== undefined) {
-        const autoToken = await longRunning(
-            l10n.t("Attempting to auto-generate a fine-grained PAT for '{0}/{1}'…", owner, repoSlug),
-            () => generateGitHubRepoScopedPat(sessionToken!, repoId!, repoSlug),
-        );
-
-        if (autoToken) {
-            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
-                type: "git",
-                url: repoUrl.trim(),
-                username: "git",
-                password: autoToken,
-            });
-            if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
-            return;
-        }
-    }
-
-    // ------------------------------------------------------------------
-    // Strategy 2: guided manual flow — open the GitHub PAT creation page
-    // pre-filled with the correct settings, then collect the pasted token.
-    // ------------------------------------------------------------------
     const tokenName = `argocd-${repoSlug}`
         .replace(/[^a-zA-Z0-9._-]/g, "-")
         .replace(/-{2,}/g, "-")
         .replace(/-+$/g, "")
         .slice(0, 40);
 
-    // GitHub accepts `description` and `repository_ids[]` as query params.
     const params = new URLSearchParams({ description: tokenName });
     if (repoId !== undefined) {
         params.append("repository_ids[]", String(repoId));
     }
     const patUrl = `https://github.com/settings/personal-access-tokens/new?${params.toString()}`;
+    const repoNote = repoId !== undefined ? l10n.t(" (repository pre-selected)") : "";
 
-    const OPEN_GITHUB = l10n.t("Open GitHub \u2192");
-    const repoNote = repoId !== undefined ? " (pre-selected)" : "";
-    const patInstructions =
-        `Create a fine-grained GitHub PAT so Argo CD can pull from '${owner}/${repoSlug}':\n\n` +
-        `  \u2022 Token name: ${tokenName}  (pre-filled)\n` +
-        `  \u2022 Expiration: 90 days (or custom)\n` +
-        `  \u2022 Repository access: Only select '${owner}/${repoSlug}'${repoNote}\n` +
-        `  \u2022 Permissions \u2192 Contents: Read-only\n` +
-        `  \u2022 Permissions \u2192 Metadata: Read-only\n\n` +
-        `Click 'Open GitHub \u2192', generate the token, then paste it into the next prompt.`;
-    const action = await vscode.window.showInformationMessage(patInstructions, { modal: true }, OPEN_GITHUB);
-    if (action !== OPEN_GITHUB) return;
+    // Step 1 — open the PAT creation page.
+    const OPEN_GITHUB = l10n.t("Open GitHub →");
+    const openAction = await vscode.window.showInformationMessage(
+        l10n.t(
+            "Create a fine-grained PAT for '{0}/{1}':\n\n" +
+                "  • Token name: {2}  (pre-filled)\n" +
+                "  • Repository access: only '{0}/{1}'{3}\n" +
+                "  • Permissions → Contents: Read-only, Metadata: Read-only\n\n" +
+                "After creating the token, paste it in the next prompt.",
+            owner,
+            repoSlug,
+            tokenName,
+            repoNote,
+        ),
+        { modal: true },
+        OPEN_GITHUB,
+    );
+    if (openAction === OPEN_GITHUB) {
+        await vscode.env.openExternal(vscode.Uri.parse(patUrl));
+    }
 
-    await vscode.env.openExternal(vscode.Uri.parse(patUrl));
-
-    const token = await vscode.window.showInputBox({
-        prompt: l10n.t("Paste the generated GitHub PAT"),
+    // Step 2 — collect the PAT.
+    const pat = await vscode.window.showInputBox({
+        title: l10n.t("Connect '{0}/{1}' to Argo CD", owner, repoSlug),
+        prompt: l10n.t("Paste the fine-grained PAT you just created"),
         password: true,
-        placeHolder: "github_pat_\u2026",
         ignoreFocusOut: true,
-        validateInput: (v) => (!v?.trim() ? l10n.t("Token is required.") : undefined),
+        validateInput: (v) => (v.trim() ? undefined : l10n.t("PAT cannot be empty")),
     });
-    if (!token) return;
+    if (!pat) return;
 
-    const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
-        type: "git",
-        url: repoUrl.trim(),
-        username: "git",
-        password: token.trim(),
-    });
-    if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
+    // Step 3 — apply the Argo CD repository secret.
+    const secretName = `argocd-repo-${repoSlug}`
+        .replace(/[^a-z0-9-]/g, "-")
+        .replace(/-{2,}/g, "-")
+        .replace(/-+$/g, "")
+        .slice(0, 63);
+
+    const username = githubUsername ?? "git";
+    const httpsUrl = repoUrl.trim().startsWith("http") ? repoUrl.trim() : `https://github.com/${owner}/${repoSlug}.git`;
+
+    const secretYaml = [
+        "apiVersion: v1",
+        "kind: Secret",
+        "metadata:",
+        `  name: ${secretName}`,
+        "  namespace: argocd",
+        "  labels:",
+        "    argocd.argoproj.io/secret-type: repository",
+        "stringData:",
+        "  type: git",
+        `  url: ${httpsUrl}`,
+        `  username: ${username}`,
+        `  password: ${pat}`,
+    ].join("\n");
+
+    const tmpFile = await createTempFile(secretYaml, "yaml");
+    try {
+        const result = await longRunning(l10n.t("Registering repository with Argo CD…"), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeConfigFile,
+                `apply -f "${tmpFile.filePath}"`,
+                NonZeroExitCodeBehaviour.Succeed,
+            ),
+        );
+        if (failed(result) || result.result.code !== 0) {
+            const detail = failed(result) ? result.error : result.result.stderr;
+            vscode.window.showErrorMessage(l10n.t("Failed to register repository with Argo CD: {0}", detail));
+        } else {
+            vscode.window.showInformationMessage(
+                l10n.t(
+                    "Repository '{0}/{1}' connected to Argo CD. " +
+                        "Refresh the Repositories page in the Argo CD UI to confirm.",
+                    owner,
+                    repoSlug,
+                ),
+            );
+        }
+    } finally {
+        tmpFile.dispose();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1130,50 +647,124 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         postChannel.appendLine(`\n[Apply] ${appName} → ${clusterName}`);
         postChannel.appendLine(output);
 
-        // Brief success toast (auto-dismisses).
-        vscode.window.showInformationMessage(
-            l10n.t(
-                "✓ '{0}' applied to '{1}'. Use the action menu to open the UI or manage credentials.",
-                appName,
-                clusterName,
-            ),
-        );
-
         // ------------------------------------------------------------------
-        // Persistent follow-up menu — loops until the user presses Esc so
-        // all actions remain available even after performing one.
+        // Post-apply: detect auth mode and probe repo visibility in parallel
+        // so neither probe blocks the other.
         // ------------------------------------------------------------------
         const repoUrl = doc.spec?.source?.repoURL ?? "";
         const isGitHub = /github\.com/i.test(repoUrl);
 
+        const [authMode, repoVisibility] = await Promise.all([
+            detectArgoCDAuthMode(kubectl, kubeConfigFile.filePath),
+            isGitHub ? probeGitHubRepoVisibility(repoUrl) : Promise.resolve("unknown" as const),
+        ]);
+
+        // Brief success toast.
+        vscode.window.showInformationMessage(l10n.t("✓ '{0}' applied to '{1}'.", appName, clusterName));
+
+        // ------------------------------------------------------------------
+        // Persistent follow-up action menu.
+        // ------------------------------------------------------------------
+        await argoCDPostApplyActions(
+            kubectl,
+            kubeConfigFile.filePath,
+            clusterName,
+            appName,
+            repoUrl,
+            authMode,
+            repoVisibility,
+        );
+    } finally {
+        kubeConfigFile.dispose();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command: Argo CD Post-Apply Actions (also callable standalone from palette)
+// ---------------------------------------------------------------------------
+
+export async function argoCDPostApplyActions(
+    _context?: unknown,
+    kubectlArg?: unknown,
+    kubeConfigFileArg?: unknown,
+    clusterNameArg?: unknown,
+    appNameArg?: unknown,
+    repoUrlArg?: unknown,
+    authModeArg?: unknown,
+    repoVisibilityArg?: unknown,
+): Promise<void> {
+    // When called from the command palette we have no pre-resolved context,
+    // so resolve kubectl + cluster fresh from the active kubeconfig.
+    let kubectl: k8s.APIAvailable<k8s.KubectlV1>;
+    let kubeConfigFilePath: string;
+    let clusterName: string;
+    let appName: string;
+    let repoUrl: string;
+    let authMode: "sso" | "admin-password";
+    let repoVisibility: "public" | "private" | "unknown";
+    let ownedTempFile: Awaited<ReturnType<typeof createTempFile>> | undefined;
+
+    // If called programmatically (from argoCDApplyApp) all args are provided.
+    const isStandalone =
+        !(kubectlArg instanceof Object && "api" in (kubectlArg as object)) || typeof kubeConfigFileArg !== "string";
+
+    if (isStandalone) {
+        const k = await k8s.extension.kubectl.v1;
+        if (!k.available) {
+            vscode.window.showWarningMessage(l10n.t("kubectl is unavailable."));
+            return;
+        }
+        kubectl = k;
+
+        const ctx = await resolveCurrentKubectlContext(kubectl);
+        if (!ctx) return;
+
+        ownedTempFile = await createTempFile(ctx.kubeconfigYaml, "yaml");
+        kubeConfigFilePath = ownedTempFile.filePath;
+        clusterName = ctx.contextName;
+        appName = "(current cluster)";
+        repoUrl = "";
+
+        const [detectedAuth, detectedRepo] = await Promise.all([
+            detectArgoCDAuthMode(kubectl, kubeConfigFilePath),
+            Promise.resolve("unknown" as const),
+        ]);
+        authMode = detectedAuth;
+        repoVisibility = detectedRepo;
+    } else {
+        kubectl = kubectlArg as k8s.APIAvailable<k8s.KubectlV1>;
+        kubeConfigFilePath = kubeConfigFileArg as string;
+        clusterName = clusterNameArg as string;
+        appName = appNameArg as string;
+        repoUrl = repoUrlArg as string;
+        authMode = authModeArg as "sso" | "admin-password";
+        repoVisibility = repoVisibilityArg as "public" | "private" | "unknown";
+    }
+
+    try {
         interface ActionItem extends vscode.QuickPickItem {
             id: string;
         }
         const actionItems: ActionItem[] = [
             {
                 label: "$(browser) Open Argo CD UI",
-                description: l10n.t("Open the Argo CD dashboard in your browser"),
+                description:
+                    authMode === "sso"
+                        ? l10n.t("Open the Argo CD dashboard — sign in with your Microsoft account")
+                        : l10n.t("Open the Argo CD dashboard in your browser"),
                 id: "open_ui",
             },
-            {
-                label: "$(key) Get Argo CD Credentials",
-                description: l10n.t("View / copy the initial admin password"),
-                id: "get_creds",
-            },
-            ...(isGitHub
+            ...(repoVisibility === "private"
                 ? [
                       {
-                          label: "$(github) Generate GitHub Token for Repo",
-                          description: l10n.t("Fine-grained PAT (Contents: read-only) for {0}", repoUrl),
-                          id: "github_pat",
+                          label: "$(key) Connect Private Repository",
+                          description: l10n.t(
+                              "Create a GitHub fine-grained PAT and add it to Argo CD repository settings",
+                          ),
+                          id: "connect_repo",
                       } as ActionItem,
                   ]
                 : []),
-            {
-                label: "$(repo) Register Repo Credentials",
-                description: l10n.t("Register Git repo auth with Argo CD (HTTPS / SSH / Bearer)"),
-                id: "register_repo",
-            },
             {
                 label: "$(book) Sync Guide",
                 description: l10n.t("Open Argo CD docs: sync the application"),
@@ -1182,23 +773,24 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         ];
 
         // Loop until the user presses Esc.
+        const title =
+            appName === "(current cluster)"
+                ? l10n.t("Argo CD — '{0}' (Esc to close)", clusterName)
+                : l10n.t("Argo CD — '{0}' on '{1}' (Esc to close)", appName, clusterName);
+
         while (true) {
             const pick = (await vscode.window.showQuickPick(actionItems, {
-                title: l10n.t("Argo CD — '{0}' on '{1}' (Esc to close)", appName, clusterName),
+                title,
                 placeHolder: l10n.t("Select an action"),
-                ignoreFocusOut: false,
+                ignoreFocusOut: true,
             })) as ActionItem | undefined;
 
             if (!pick) break;
 
             if (pick.id === "open_ui") {
-                await openArgoCDUI(kubectl, kubeConfigFile.filePath, clusterName);
-            } else if (pick.id === "get_creds") {
-                await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
-            } else if (pick.id === "github_pat") {
-                await guideGitHubPatForRepo(repoUrl, kubectl, kubeConfigFile.filePath, clusterName);
-            } else if (pick.id === "register_repo") {
-                await registerRepoCredentials(kubectl, kubeConfigFile.filePath, repoUrl, clusterName);
+                await openArgoCDUI(kubectl, kubeConfigFilePath, clusterName);
+            } else if (pick.id === "connect_repo") {
+                await connectPrivateGitHubRepo(kubectl, kubeConfigFilePath, repoUrl);
             } else if (pick.id === "open_docs") {
                 await vscode.env.openExternal(
                     vscode.Uri.parse(
@@ -1208,6 +800,6 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             }
         }
     } finally {
-        kubeConfigFile.dispose();
+        ownedTempFile?.dispose();
     }
 }

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -39,7 +39,7 @@ interface ArgoCDApplication {
     spec?: { source?: { repoURL?: string } };
 }
 
-function isArgoCDApplication(doc: unknown): doc is ArgoCDApplication {
+export function isArgoCDApplication(doc: unknown): doc is ArgoCDApplication {
     if (typeof doc !== "object" || doc === null) return false;
     const d = doc as Record<string, unknown>;
     return typeof d.apiVersion === "string" && d.apiVersion.startsWith("argoproj.io/") && d.kind === "Application";
@@ -102,7 +102,7 @@ function resolveFileUri(target: unknown): vscode.Uri | undefined {
  * directly from the local kubeconfig without any Azure subscription lookup.
  * Returns undefined (and shows an error) if kubectl has no current context.
  */
-async function resolveCurrentKubectlContext(
+export async function resolveCurrentKubectlContext(
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
 ): Promise<{ contextName: string; kubeconfigYaml: string } | undefined> {
     const ctxResult = await kubectl.api.invokeCommand("config current-context");
@@ -574,8 +574,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
     // ------------------------------------------------------------------
     const APPLY = l10n.t("Apply");
     const confirmed = await vscode.window.showInformationMessage(
-        l10n.t("Apply Argo CD Application '{0}' to the current cluster context '{1}'?", appName, clusterName),
-        { modal: true },
+        l10n.t("Apply Argo CD Application '{0}' to cluster '{1}'?", appName, clusterName),
         APPLY,
     );
     if (!confirmed) return;
@@ -586,8 +585,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
     const kubeConfigFile = await createTempFile(kubeconfigYaml, "yaml");
 
     try {
-        // ------------------------------------------------------------------
-        // 5. Verify Argo CD is installed (check for argocd namespace).
+        // 6. Verify Argo CD is installed (check for argocd namespace).
         // ------------------------------------------------------------------
         const nsCheck = await longRunning(l10n.t("Checking if Argo CD is installed on '{0}'…", clusterName), () =>
             invokeKubectlCommand(
@@ -621,7 +619,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         }
 
         // ------------------------------------------------------------------
-        // 6. Apply the manifest to the cluster.
+        // 7. Apply the manifest to the cluster.
         // ------------------------------------------------------------------
         const applyResult = await longRunning(
             l10n.t("Applying Argo CD Application '{0}' to '{1}'…", appName, clusterName),

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -1,0 +1,231 @@
+/**
+ * Argo CD — Apply Application YAML to a cluster.
+ *
+ * Triggered by right-clicking an Argo CD Application YAML file in the
+ * VS Code Explorer or the active editor.  The command:
+ *
+ *  1. Reads the file and validates it is an `argoproj.io/v1alpha1 Application` manifest.
+ *  2. Lets the user pick the target AKS cluster using the shared cluster selector
+ *     (same UX as "Deploy Manifest").
+ *  3. Checks whether Argo CD is already installed on the cluster.
+ *  4. Runs `kubectl apply -n argocd -f <file>` against that cluster.
+ *  5. Optionally opens the Argo CD docs for the "sync the application" next step.
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/getting_started/#6-create-an-application-from-a-git-repository
+ */
+
+import * as vscode from "vscode";
+import * as k8s from "vscode-kubernetes-tools-api";
+import * as yaml from "js-yaml";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import * as l10n from "@vscode/l10n";
+
+import { getReadySessionProvider } from "../../auth/azureAuth";
+import { invokeKubectlCommand } from "../utils/kubectl";
+import { createTempFile } from "../utils/tempfile";
+import { failed } from "../utils/errorable";
+import { longRunning } from "../utils/host";
+import { NonZeroExitCodeBehaviour } from "../utils/shell";
+import { selectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
+import { ClusterPreference } from "../../plugins/shared/types";
+
+// ---------------------------------------------------------------------------
+// Type guard — validate that a parsed YAML doc is an Argo CD Application
+// ---------------------------------------------------------------------------
+
+interface ArgoCDApplication {
+    apiVersion: string;
+    kind: string;
+    metadata?: { name?: string; namespace?: string };
+}
+
+function isArgoCDApplication(doc: unknown): doc is ArgoCDApplication {
+    if (typeof doc !== "object" || doc === null) return false;
+    const d = doc as Record<string, unknown>;
+    return typeof d.apiVersion === "string" && d.apiVersion.startsWith("argoproj.io/") && d.kind === "Application";
+}
+
+// ---------------------------------------------------------------------------
+// Parse the YAML file and return the parsed Application, or undefined.
+// ---------------------------------------------------------------------------
+
+async function parseApplicationFile(fileUri: vscode.Uri): Promise<ArgoCDApplication | undefined> {
+    let rawContent: string;
+    try {
+        const bytes = await vscode.workspace.fs.readFile(fileUri);
+        rawContent = Buffer.from(bytes).toString("utf8");
+    } catch (e) {
+        vscode.window.showErrorMessage(l10n.t("Failed to read file: {0}", String(e)));
+        return undefined;
+    }
+
+    let doc: unknown;
+    try {
+        doc = yaml.load(rawContent);
+    } catch (e) {
+        vscode.window.showErrorMessage(l10n.t("Failed to parse YAML: {0}", String(e)));
+        return undefined;
+    }
+
+    if (!isArgoCDApplication(doc)) {
+        vscode.window.showErrorMessage(
+            l10n.t(
+                "This file does not appear to be an Argo CD Application manifest (expected apiVersion: argoproj.io/v1alpha1, kind: Application).",
+            ),
+        );
+        return undefined;
+    }
+
+    return doc;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve the file URI from various invocation points
+// ---------------------------------------------------------------------------
+
+function resolveFileUri(target: unknown): vscode.Uri | undefined {
+    if (target instanceof vscode.Uri) return target;
+
+    // Invoked from editor context on the active document.
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) return activeEditor.document.uri;
+
+    return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Command: Apply Argo CD Application to Cluster
+// ---------------------------------------------------------------------------
+
+export async function argoCDApplyApp(_context: IActionContext, target: unknown): Promise<void> {
+    // ------------------------------------------------------------------
+    // 1. Resolve the YAML file.
+    // ------------------------------------------------------------------
+    const fileUri = resolveFileUri(target);
+    if (!fileUri) {
+        vscode.window.showErrorMessage(
+            l10n.t("No file selected. Right-click a YAML file in the Explorer or open it in the editor."),
+        );
+        return;
+    }
+
+    const doc = await parseApplicationFile(fileUri);
+    if (!doc) return;
+
+    const appName = doc.metadata?.name ?? "(unnamed)";
+    const targetNamespace = doc.metadata?.namespace ?? "argocd";
+
+    // ------------------------------------------------------------------
+    // 2. Get the Azure session.
+    // ------------------------------------------------------------------
+    const sessionResult = await getReadySessionProvider();
+    if (failed(sessionResult)) {
+        vscode.window.showErrorMessage(sessionResult.error);
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Pick the target AKS cluster (consistent with "Deploy Manifest" UX).
+    // ------------------------------------------------------------------
+    const clusterResult = await selectClusterOptions(sessionResult.result, undefined, "aks.argoCDApplyApp");
+    if (failed(clusterResult)) {
+        vscode.window.showErrorMessage(clusterResult.error);
+        return;
+    }
+
+    // User chose "Create new cluster" — stop and let them do that first.
+    if (clusterResult.result === true) {
+        vscode.window.showInformationMessage(
+            l10n.t("Please create an AKS cluster before applying the Argo CD Application."),
+        );
+        return;
+    }
+
+    const cluster = clusterResult.result as ClusterPreference;
+
+    // ------------------------------------------------------------------
+    // 4. Ensure kubectl is available.
+    // ------------------------------------------------------------------
+    const kubectl = await k8s.extension.kubectl.v1;
+    if (!kubectl.available) {
+        vscode.window.showWarningMessage(l10n.t("kubectl is unavailable."));
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    // 5. Write kubeconfig to a temp file.
+    // ------------------------------------------------------------------
+    const kubeConfigFile = await createTempFile(cluster.kubeConfigYAML, "yaml");
+
+    try {
+        // ------------------------------------------------------------------
+        // 6. Verify Argo CD is installed (check for argocd namespace).
+        // ------------------------------------------------------------------
+        const nsCheck = await invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile.filePath,
+            `get namespace argocd --ignore-not-found -o name`,
+            NonZeroExitCodeBehaviour.Succeed,
+        );
+
+        const argoCDMissing = failed(nsCheck) || nsCheck.result.stdout.trim() === "";
+
+        if (argoCDMissing) {
+            const INSTALL_FIRST = l10n.t("Install Argo CD First");
+            const APPLY_ANYWAY = l10n.t("Apply Anyway");
+            const choice = await vscode.window.showWarningMessage(
+                l10n.t(
+                    "Argo CD does not appear to be installed on cluster '{0}' (namespace 'argocd' not found).\n\nInstall it first via the cluster right-click menu → 'Install Argo CD on Cluster'.",
+                    cluster.clusterName,
+                ),
+                { modal: true },
+                INSTALL_FIRST,
+                APPLY_ANYWAY,
+            );
+            if (!choice || choice === INSTALL_FIRST) return;
+        }
+
+        // ------------------------------------------------------------------
+        // 7. Apply the manifest to the cluster.
+        // ------------------------------------------------------------------
+        const applyResult = await longRunning(
+            l10n.t("Applying Argo CD Application '{0}' to cluster '{1}'…", appName, cluster.clusterName),
+            () =>
+                invokeKubectlCommand(
+                    kubectl,
+                    kubeConfigFile.filePath,
+                    `apply -n ${targetNamespace} -f "${fileUri.fsPath}"`,
+                ),
+        );
+
+        if (failed(applyResult)) {
+            vscode.window.showErrorMessage(
+                l10n.t("Failed to apply Argo CD Application '{0}': {1}", appName, applyResult.error),
+            );
+            return;
+        }
+
+        const output = applyResult.result.stdout.trim();
+
+        const OPEN_DOCS = l10n.t("Sync the Application (docs)");
+        const followUp = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Argo CD Application '{0}' applied to cluster '{1}'.\n\n{2}\n\nArgo CD will begin syncing from the configured Git repository.",
+                appName,
+                cluster.clusterName,
+                output,
+            ),
+            OPEN_DOCS,
+        );
+
+        if (followUp === OPEN_DOCS) {
+            await vscode.env.openExternal(
+                vscode.Uri.parse(
+                    "https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application",
+                ),
+            );
+        }
+    } finally {
+        kubeConfigFile.dispose();
+    }
+}

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -35,7 +35,7 @@ import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
 interface ArgoCDApplication {
     apiVersion: string;
     kind: string;
-    metadata?: { name?: string; namespace?: string };
+    metadata?: { name?: string; namespace?: string; annotations?: Record<string, string> };
     spec?: { source?: { repoURL?: string } };
 }
 
@@ -651,7 +651,10 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         // Post-apply: detect auth mode and probe repo visibility in parallel
         // so neither probe blocks the other.
         // ------------------------------------------------------------------
-        const repoUrl = doc.spec?.source?.repoURL ?? "";
+        // Prefer the explicit source-repo annotation (set by the deployment wizard)
+        // over spec.source.repoURL which points to the GitOps config repo.
+        const repoUrl =
+            doc.metadata?.annotations?.["aks-extension/source-repo"]?.trim() || doc.spec?.source?.repoURL || "";
         const isGitHub = /github\.com/i.test(repoUrl);
 
         const [authMode, repoVisibility] = await Promise.all([
@@ -698,8 +701,8 @@ export async function argoCDPostApplyActions(
     let kubectl: k8s.APIAvailable<k8s.KubectlV1>;
     let kubeConfigFilePath: string;
     let clusterName: string;
-    let appName: string;
-    let repoUrl: string;
+    let appName = "(current cluster)";
+    let repoUrl = "";
     let authMode: "sso" | "admin-password";
     let repoVisibility: "public" | "private" | "unknown";
     let ownedTempFile: Awaited<ReturnType<typeof createTempFile>> | undefined;
@@ -722,15 +725,28 @@ export async function argoCDPostApplyActions(
         ownedTempFile = await createTempFile(ctx.kubeconfigYaml, "yaml");
         kubeConfigFilePath = ownedTempFile.filePath;
         clusterName = ctx.contextName;
-        appName = "(current cluster)";
-        repoUrl = "";
 
-        const [detectedAuth, detectedRepo] = await Promise.all([
+        // Read repo URL from the currently active editor — the same file the
+        // user just ran "Apply Argo CD Application" on.
+        const activeUri = vscode.window.activeTextEditor?.document.uri;
+        if (activeUri) {
+            const activeDoc = await parseApplicationFile(activeUri);
+            if (activeDoc) {
+                repoUrl =
+                    activeDoc.metadata?.annotations?.["aks-extension/source-repo"]?.trim() ||
+                    activeDoc.spec?.source?.repoURL ||
+                    "";
+                appName = activeDoc.metadata?.name ?? "(current cluster)";
+            }
+        }
+
+        const isGitHub = /github\.com/i.test(repoUrl);
+        const [detectedAuth, detectedVisibility] = await Promise.all([
             detectArgoCDAuthMode(kubectl, kubeConfigFilePath),
-            Promise.resolve("unknown" as const),
+            isGitHub ? probeGitHubRepoVisibility(repoUrl) : Promise.resolve("unknown" as const),
         ]);
         authMode = detectedAuth;
-        repoVisibility = detectedRepo;
+        repoVisibility = detectedVisibility;
     } else {
         kubectl = kubectlArg as k8s.APIAvailable<k8s.KubectlV1>;
         kubeConfigFilePath = kubeConfigFileArg as string;

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -298,10 +298,9 @@ async function openArgoCDUI(
 
             const credAction = await vscode.window.showInformationMessage(
                 l10n.t(
-                    "Argo CD UI: {0}\n\nUsername: {1}\nPassword: {2}\n\n(This is the initial admin password from argocd-initial-admin-secret.)",
+                    "Argo CD UI: {0}\n\nUsername: {1}\nPassword: ••••••••\n\n(Click 'Copy Password & Open' to copy the initial admin password to clipboard before opening.)",
                     uiUrl,
                     creds.username,
-                    creds.password,
                 ),
                 { modal: true },
                 COPY_AND_OPEN,
@@ -357,7 +356,7 @@ async function openArgoCDUI(
  *   "unknown" — no silent session, API error, or non-GitHub URL
  */
 async function probeGitHubRepoVisibility(repoUrl: string): Promise<"public" | "private" | "unknown"> {
-    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?\/?\s*$/i);
+    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?\/?\s*$/i);
     if (!urlMatch) return "unknown";
     const [, owner, repoSlug] = urlMatch;
 
@@ -405,7 +404,7 @@ async function connectPrivateGitHubRepo(
     kubeConfigFile: string,
     repoUrl: string,
 ): Promise<void> {
-    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?\/?\s*$/i);
+    const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?\/?\s*$/i);
     if (!urlMatch) return;
     const [, owner, repoSlug] = urlMatch;
 
@@ -489,46 +488,51 @@ async function connectPrivateGitHubRepo(
     const username = githubUsername ?? "git";
     const httpsUrl = repoUrl.trim().startsWith("http") ? repoUrl.trim() : `https://github.com/${owner}/${repoSlug}.git`;
 
-    const secretYaml = [
-        "apiVersion: v1",
-        "kind: Secret",
-        "metadata:",
-        `  name: ${secretName}`,
-        "  namespace: argocd",
-        "  labels:",
-        "    argocd.argoproj.io/secret-type: repository",
-        "stringData:",
-        "  type: git",
-        `  url: ${httpsUrl}`,
-        `  username: ${username}`,
-        `  password: ${pat}`,
-    ].join("\n");
+    // Avoid writing the PAT to a temp file on disk.  Instead, use
+    // `kubectl create secret --from-literal` (in-memory only) and then
+    // label the resulting Secret so Argo CD auto-discovers it.
+    const result = await longRunning(l10n.t("Registering repository with Argo CD…"), async () => {
+        // Remove any existing secret first so `create` is idempotent.
+        await invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `delete secret ${secretName} -n argocd --ignore-not-found`,
+            NonZeroExitCodeBehaviour.Succeed,
+        );
 
-    const tmpFile = await createTempFile(secretYaml, "yaml");
-    try {
-        const result = await longRunning(l10n.t("Registering repository with Argo CD…"), () =>
-            invokeKubectlCommand(
-                kubectl,
-                kubeConfigFile,
-                `apply -f "${tmpFile.filePath}"`,
-                NonZeroExitCodeBehaviour.Succeed,
+        const createResult = await invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `create secret generic ${secretName} -n argocd` +
+                ` --from-literal=type=git` +
+                ` --from-literal=url=${httpsUrl}` +
+                ` --from-literal=username=${username}` +
+                ` --from-literal=password=${pat}`,
+            NonZeroExitCodeBehaviour.Succeed,
+        );
+        if (failed(createResult) || createResult.result.code !== 0) return createResult;
+
+        // Label the secret so Argo CD picks it up automatically.
+        return invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `label secret ${secretName} -n argocd argocd.argoproj.io/secret-type=repository --overwrite`,
+            NonZeroExitCodeBehaviour.Succeed,
+        );
+    });
+
+    if (failed(result) || result.result.code !== 0) {
+        const detail = failed(result) ? result.error : result.result.stderr;
+        vscode.window.showErrorMessage(l10n.t("Failed to register repository with Argo CD: {0}", detail));
+    } else {
+        vscode.window.showInformationMessage(
+            l10n.t(
+                "Repository '{0}/{1}' connected to Argo CD. " +
+                    "Refresh the Repositories page in the Argo CD UI to confirm.",
+                owner,
+                repoSlug,
             ),
         );
-        if (failed(result) || result.result.code !== 0) {
-            const detail = failed(result) ? result.error : result.result.stderr;
-            vscode.window.showErrorMessage(l10n.t("Failed to register repository with Argo CD: {0}", detail));
-        } else {
-            vscode.window.showInformationMessage(
-                l10n.t(
-                    "Repository '{0}/{1}' connected to Argo CD. " +
-                        "Refresh the Repositories page in the Argo CD UI to confirm.",
-                    owner,
-                    repoSlug,
-                ),
-            );
-        }
-    } finally {
-        tmpFile.dispose();
     }
 }
 
@@ -602,77 +606,10 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         }
 
         // ------------------------------------------------------------------
-        // 5. Pick the target namespace — show cluster namespaces with
-        //    AKS desktop labels if present, default to the YAML value.
+        // 5. The Application CR must be applied to the Argo CD namespace
+        //    (metadata.namespace in the YAML, defaults to "argocd").
+        //    Applying it elsewhere would make Argo CD ignore it.
         // ------------------------------------------------------------------
-        let selectedNamespace: string | undefined = targetNamespace;
-
-        const nsListResult = await longRunning(l10n.t("Loading cluster namespaces..."), () =>
-            invokeKubectlCommand(
-                kubectl,
-                kubeConfigFile.filePath,
-                `get namespace -o json`,
-                NonZeroExitCodeBehaviour.Succeed,
-            ),
-        );
-
-        if (!failed(nsListResult) && nsListResult.result.stdout.trim()) {
-            type RawNs = { metadata: { name: string; labels?: Record<string, string> } };
-            let rawItems: RawNs[] = [];
-            try {
-                rawItems = (JSON.parse(nsListResult.result.stdout) as { items: RawNs[] }).items ?? [];
-            } catch {
-                // fall through to use YAML default
-            }
-
-            // Filter out system namespaces, keep "default" and the YAML-specified namespace.
-            const systemNs = new Set(["kube-system", "kube-public", "kube-node-lease", "gatekeeper-system", "argocd"]);
-            rawItems = rawItems.filter(
-                (ns) =>
-                    ns.metadata.name === "default" ||
-                    ns.metadata.name === targetNamespace ||
-                    !systemNs.has(ns.metadata.name),
-            );
-
-            if (rawItems.length > 0) {
-                const names = rawItems.map((ns) => ns.metadata.name);
-                if (!names.includes("default")) {
-                    rawItems.unshift({ metadata: { name: "default", labels: {} } });
-                }
-
-                // Sort: YAML-specified namespace first, then "default", then alphabetical.
-                rawItems.sort((a, b) => {
-                    if (a.metadata.name === targetNamespace) return -1;
-                    if (b.metadata.name === targetNamespace) return 1;
-                    if (a.metadata.name === "default") return -1;
-                    if (b.metadata.name === "default") return 1;
-                    return a.metadata.name.localeCompare(b.metadata.name);
-                });
-
-                const nsItems: vscode.QuickPickItem[] = rawItems.map((ns) => {
-                    const name = ns.metadata.name;
-                    const labels = ns.metadata.labels ?? {};
-                    let description: string | undefined;
-                    if (labels["headlamp.dev/project-managed-by"] === "aks-desktop") {
-                        description = l10n.t("(AKS desktop Project: {0})", name);
-                    } else if (name === targetNamespace) {
-                        description = l10n.t("from YAML manifest");
-                    } else if (name === "default") {
-                        description = l10n.t("recommended default");
-                    }
-                    return { label: name, description };
-                });
-
-                const picked = await vscode.window.showQuickPick(nsItems, {
-                    title: l10n.t("Namespace ({0} available)", nsItems.length),
-                    placeHolder: l10n.t("Select a Kubernetes namespace"),
-                    ignoreFocusOut: true,
-                });
-
-                if (!picked) return;
-                selectedNamespace = picked.label;
-            }
-        }
 
         // ------------------------------------------------------------------
         // 6. Confirm the apply action.
@@ -682,7 +619,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             l10n.t(
                 "Apply Argo CD Application '{0}' to namespace '{1}' on cluster '{2}'?",
                 appName,
-                selectedNamespace,
+                targetNamespace,
                 clusterName,
             ),
             APPLY,
@@ -698,7 +635,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
                 invokeKubectlCommand(
                     kubectl,
                     kubeConfigFile.filePath,
-                    `apply -n ${selectedNamespace} -f "${fileUri.fsPath}" --validate=false`,
+                    `apply -n ${targetNamespace} -f "${fileUri.fsPath}" --validate=false`,
                 ),
         );
 
@@ -720,10 +657,10 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         // Post-apply: detect auth mode and probe repo visibility in parallel
         // so neither probe blocks the other.
         // ------------------------------------------------------------------
-        // Prefer the explicit source-repo annotation (set by the deployment wizard)
-        // over spec.source.repoURL which points to the GitOps config repo.
-        const repoUrl =
-            doc.metadata?.annotations?.["aks-extension/source-repo"]?.trim() || doc.spec?.source?.repoURL || "";
+        // Use spec.source.repoURL — this is the config repo that Argo CD
+        // actually pulls from, so it is the correct target for credential
+        // wiring.  The aks-extension/source-repo annotation is informational.
+        const repoUrl = doc.spec?.source?.repoURL || "";
         const isGitHub = /github\.com/i.test(repoUrl);
 
         const [authMode, repoVisibility] = await Promise.all([
@@ -738,6 +675,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         // Persistent follow-up action menu.
         // ------------------------------------------------------------------
         await argoCDPostApplyActions(
+            undefined, // _context — not needed when called programmatically
             kubectl,
             kubeConfigFile.filePath,
             clusterName,
@@ -801,10 +739,7 @@ export async function argoCDPostApplyActions(
         if (activeUri) {
             const activeDoc = await parseApplicationFile(activeUri);
             if (activeDoc) {
-                repoUrl =
-                    activeDoc.metadata?.annotations?.["aks-extension/source-repo"]?.trim() ||
-                    activeDoc.spec?.source?.repoURL ||
-                    "";
+                repoUrl = activeDoc.spec?.source?.repoURL || "";
                 appName = activeDoc.metadata?.name ?? "(current cluster)";
             }
         }

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -5,11 +5,11 @@
  * VS Code Explorer or the active editor.  The command:
  *
  *  1. Reads the file and validates it is an `argoproj.io/v1alpha1 Application` manifest.
- *  2. Lets the user pick the target AKS cluster using the shared cluster selector
- *     (same UX as "Deploy Manifest").
- *  3. Checks whether Argo CD is already installed on the cluster.
- *  4. Runs `kubectl apply -n argocd -f <file>` against that cluster.
- *  5. Optionally opens the Argo CD docs for the "sync the application" next step.
+ *  2. Reads the active kubectl context (no Azure subscription or cluster picker needed).
+ *  3. Confirms the target cluster with the user (one click).
+ *  4. Checks whether Argo CD is already installed on the cluster.
+ *  5. Runs `kubectl apply -n argocd -f <file>` against that cluster.
+ *  6. Optionally opens the Argo CD docs for the "sync the application" next step.
  *
  * Reference: https://argo-cd.readthedocs.io/en/stable/getting_started/#6-create-an-application-from-a-git-repository
  */
@@ -20,15 +20,13 @@ import * as yaml from "js-yaml";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 
-import { getReadySessionProvider } from "../../auth/azureAuth";
 import { invokeKubectlCommand } from "../utils/kubectl";
 import { createTempFile } from "../utils/tempfile";
 import { failed } from "../utils/errorable";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
-import { selectClusterOptions } from "../../plugins/shared/clusterOptions/selectClusterOptions";
-import { ClusterPreference } from "../../plugins/shared/types";
 import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
+import { generateGitHubRepoScopedPat, createGitHubDeployKey, generateSshDeployKeyPair } from "./argoCDDeployment";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -93,6 +91,45 @@ function resolveFileUri(target: unknown): vscode.Uri | undefined {
     if (activeEditor) return activeEditor.document.uri;
 
     return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: resolve the current kubectl context + kubeconfig (no Azure auth needed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the active kubectl context name and the corresponding kubeconfig YAML
+ * directly from the local kubeconfig without any Azure subscription lookup.
+ * Returns undefined (and shows an error) if kubectl has no current context.
+ */
+async function resolveCurrentKubectlContext(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+): Promise<{ contextName: string; kubeconfigYaml: string } | undefined> {
+    const ctxResult = await kubectl.api.invokeCommand("config current-context");
+    if (!ctxResult || ctxResult.code !== 0) {
+        vscode.window.showErrorMessage(
+            l10n.t(
+                "Could not determine the current kubectl context. Ensure kubectl is configured and a context is active.",
+            ),
+        );
+        return undefined;
+    }
+
+    const contextName = ctxResult.stdout.trim();
+    if (!contextName) {
+        vscode.window.showErrorMessage(
+            l10n.t("No active kubectl context found. Run 'kubectl config use-context <name>' to set one."),
+        );
+        return undefined;
+    }
+
+    const cfgResult = await kubectl.api.invokeCommand("config view --minify --flatten -o yaml");
+    if (!cfgResult || cfgResult.code !== 0) {
+        vscode.window.showErrorMessage(l10n.t("Could not read kubeconfig for context '{0}'.", contextName));
+        return undefined;
+    }
+
+    return { contextName, kubeconfigYaml: cfgResult.stdout };
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +347,7 @@ async function registerRepoCredentials(
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
     kubeConfigFile: string,
     defaultRepoUrl: string,
+    clusterName: string,
 ): Promise<void> {
     // 1. Confirm / enter the repository URL.
     const repoUrl = await vscode.window.showInputBox({
@@ -320,13 +358,178 @@ async function registerRepoCredentials(
     });
     if (!repoUrl) return;
 
-    // 2. Choose authentication type.
+    // 2. For GitHub URLs, silently probe repo visibility first (no sign-in prompt).
+    //    • Private repo detected  → auto-generate a 24h repo-scoped PAT and skip the picker.
+    //    • Public repo detected   → inform the user (no creds needed) and return.
+    //    • Session unavailable or API error → fall through to the manual auth picker below.
+    const isGitHubRepo = /github\.com/i.test(repoUrl.trim());
+    if (isGitHubRepo) {
+        const urlMatch = repoUrl.trim().match(/github\.com[\\/:]([^\\/]+)\/([^\\/.]+?)(?:\.git)?\s*$/i);
+        if (urlMatch) {
+            const [, owner, repoSlug] = urlMatch;
+
+            // Try to reuse an existing GitHub session without forcing a sign-in prompt.
+            let silentSession: vscode.AuthenticationSession | undefined;
+            try {
+                silentSession = await vscode.authentication.getSession("github", ["repo"], {
+                    createIfNone: false,
+                    silent: true,
+                });
+            } catch {
+                // No existing session — fall through to the manual picker.
+            }
+
+            if (silentSession) {
+                // Probe the GitHub API to determine visibility and get the repo ID.
+                let repoId: number | undefined;
+                let repoIsPrivate: boolean | undefined;
+                try {
+                    const repoRes = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}`, {
+                        headers: {
+                            Authorization: `Bearer ${silentSession.accessToken}`,
+                            Accept: "application/vnd.github+json",
+                            "X-GitHub-Api-Version": "2022-11-28",
+                        },
+                    });
+                    if (repoRes.ok) {
+                        const data = (await repoRes.json()) as { id: number; private: boolean };
+                        repoId = data.id;
+                        repoIsPrivate = data.private;
+                    }
+                } catch {
+                    // API failure — fall through to the manual picker.
+                }
+
+                if (repoIsPrivate === false) {
+                    // Public — Argo CD can pull without any credentials.
+                    vscode.window.showInformationMessage(
+                        l10n.t(
+                            "'{0}/{1}' is a public repository — Argo CD can pull from it without credentials.",
+                            owner,
+                            repoSlug,
+                        ),
+                    );
+                    return;
+                }
+
+                if (repoIsPrivate === true && repoId !== undefined) {
+                    // Argo CD matches the repository Secret's `url` field to the
+                    // application's `spec.source.repoURL` — they must use the same
+                    // scheme.  An SSH credential stored as `git@github.com:` will
+                    // NEVER be matched to an HTTPS `repoURL`, causing "Connection
+                    // Failed" even when the deploy key is perfectly valid.
+                    //
+                    // Rule: HTTPS repoURL → only ever try HTTPS credentials.
+                    //        SSH repoURL  → try SSH deploy key.
+                    const isHttpsUrl = /^https?:\/\//i.test(repoUrl.trim());
+
+                    if (isHttpsUrl) {
+                        // Try a fine-grained PAT (24h).  This requires a classic PAT
+                        // token scope that a VS Code OAuth token can't provide, so it
+                        // usually falls through to the manual picker.
+                        const patToken = await longRunning(
+                            l10n.t("Generating 24-hour repo-scoped GitHub PAT for '{0}/{1}'\u2026", owner, repoSlug),
+                            () => generateGitHubRepoScopedPat(silentSession!.accessToken, repoId!, repoSlug),
+                        );
+
+                        if (patToken) {
+                            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
+                                type: "git",
+                                url: repoUrl.trim(),
+                                username: "git",
+                                password: patToken,
+                            });
+                            if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
+                            return;
+                        }
+
+                        // PAT API unavailable (VS Code OAuth tokens cannot call
+                        // POST /user/personal-access-tokens — it requires a classic
+                        // PAT scope).  Guide the user to create one manually on
+                        // GitHub, collect the pasted token, and register it directly
+                        // into Argo CD without any further manual steps.
+                        const patFromUser = await guideAndCollectGitHubPat(owner, repoSlug);
+                        if (!patFromUser) return;
+
+                        const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
+                            type: "git",
+                            url: repoUrl.trim(),
+                            username: "git",
+                            password: patFromUser.trim(),
+                        });
+                        if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
+                        return;
+                    } else {
+                        // SSH repoURL — generate a deploy key.
+                        const keyPair = generateSshDeployKeyPair();
+                        const deployKeyResult = await longRunning(
+                            l10n.t("Creating SSH deploy key for '{0}/{1}'\u2026", owner, repoSlug),
+                            () =>
+                                createGitHubDeployKey(
+                                    silentSession!.accessToken,
+                                    owner,
+                                    repoSlug,
+                                    keyPair.publicKeySsh,
+                                ),
+                        );
+
+                        if (deployKeyResult) {
+                            // Patch known-hosts first (argocd-repo-server must trust
+                            // GitHub's fingerprint or the SSH handshake is rejected).
+                            await ensureGitHubSshKnownHosts(kubectl, kubeConfigFile);
+                            const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), {
+                                type: "git",
+                                url: repoUrl.trim(),
+                                sshPrivateKey: keyPair.privateKeyPem,
+                            });
+                            if (ok) {
+                                vscode.window.showInformationMessage(
+                                    l10n.t(
+                                        "Read-only SSH deploy key '{0}' registered on GitHub. To remove it later: https://github.com/{1}/{2}/settings/keys",
+                                        deployKeyResult.title,
+                                        owner,
+                                        repoSlug,
+                                    ),
+                                );
+                                await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
+                            }
+                            return;
+                        }
+
+                        // Deploy key creation failed — guide to manual setup.
+                        const OPEN_GITHUB = l10n.t("Open GitHub");
+                        const fallbackAction = await vscode.window.showWarningMessage(
+                            l10n.t(
+                                "Could not auto-create a deploy key (the organisation may restrict this). Please add one manually in repository Settings \u2192 Deploy keys, then use the SSH option in the auth picker.",
+                            ),
+                            OPEN_GITHUB,
+                        );
+                        if (fallbackAction === OPEN_GITHUB) {
+                            await vscode.env.openExternal(
+                                vscode.Uri.parse(`https://github.com/${owner}/${repoSlug}/settings/keys/new`),
+                            );
+                        }
+                        return;
+                    }
+                }
+                // repoIsPrivate is still undefined (API returned non-OK) → fall through.
+            }
+        }
+    }
+
+    // 3. Manual auth picker — reached for non-GitHub URLs, when no silent session
+    //    is available, or when the GitHub API probe failed.
     const authType = await vscode.window.showQuickPick(
         [
             {
                 label: "$(lock) HTTPS",
                 description: l10n.t("Username + personal access token or password"),
                 id: "https",
+            },
+            {
+                label: "$(shield) Bearer token",
+                description: l10n.t("OAuth2 / JWT bearer token (GitLab, Azure DevOps, Gitea, Forgejo)"),
+                id: "bearer",
             },
             {
                 label: "$(key) SSH",
@@ -344,7 +547,7 @@ async function registerRepoCredentials(
     let secretStringData: Record<string, string>;
 
     if (authType.id === "https") {
-        // --- HTTPS: username + token ---
+        // --- HTTPS: username + personal access token / password ---
         const username = await vscode.window.showInputBox({
             prompt: l10n.t("Username (for GitHub PATs any value works, e.g. 'git' or 'token')"),
             value: "git",
@@ -365,6 +568,23 @@ async function registerRepoCredentials(
             url: repoUrl.trim(),
             username: username.trim() || "git",
             password: token,
+        };
+    } else if (authType.id === "bearer") {
+        // --- Bearer token (Authorization: Bearer <token>) ---
+        // Used by GitLab personal/project/group access tokens, Azure DevOps PATs,
+        // Gitea/Forgejo tokens, and any provider that speaks OAuth2 token introspection.
+        const bearerToken = await vscode.window.showInputBox({
+            prompt: l10n.t("Bearer token (will be sent as 'Authorization: Bearer <token>')"),
+            password: true,
+            ignoreFocusOut: true,
+            validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
+        });
+        if (!bearerToken) return;
+
+        secretStringData = {
+            type: "git",
+            url: repoUrl.trim(),
+            bearerToken: bearerToken.trim(),
         };
     } else {
         // --- SSH: private key file ---
@@ -397,9 +617,195 @@ async function registerRepoCredentials(
         };
     }
 
-    // 3. Build a valid Kubernetes Secret name from the repo URL.
+    // For SSH URLs targeting github.com, ensure the known-hosts ConfigMap is
+    // populated before registering the key — same as `argocd repo add` does.
+    if (/github\.com/i.test(repoUrl.trim()) && secretStringData.sshPrivateKey) {
+        await ensureGitHubSshKnownHosts(kubectl, kubeConfigFile);
+    }
+
+    const ok = await applyRepoSecret(kubectl, kubeConfigFile, repoUrl.trim(), secretStringData);
+    if (ok) await offerOpenArgoCDUI(kubectl, kubeConfigFile, clusterName);
+}
+
+/**
+ * When the GitHub PAT API is unavailable (VS Code OAuth tokens cannot call
+ * POST /user/personal-access-tokens), opens the GitHub fine-grained PAT
+ * creation page pre-filled with the correct token name, shows a modal with
+ * exact step-by-step instructions (expiry, repo scope, permissions), then
+ * presents a password input box to paste the generated token back.
+ *
+ * Returns the pasted token string, or undefined if the user cancels.
+ * The caller is responsible for registering the returned token with Argo CD.
+ */
+async function guideAndCollectGitHubPat(owner: string, repoSlug: string): Promise<string | undefined> {
+    const tokenName = `argocd-${repoSlug}-24h`
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/-{2,}/g, "-")
+        .replace(/-+$/g, "")
+        .slice(0, 40);
+
+    // GitHub's fine-grained PAT creation page accepts a `description` query
+    // parameter to pre-fill the token name field.
+    const patUrl = `https://github.com/settings/personal-access-tokens/new?description=${encodeURIComponent(tokenName)}`;
+
+    const OPEN_GITHUB = l10n.t("Open GitHub \u2192");
+    const userAction = await vscode.window.showInformationMessage(
+        l10n.t(
+            "Create a fine-grained GitHub PAT with these exact settings:\n\n" +
+                "  \u2022 Token name:  {0}  (pre-filled)\n" +
+                "  \u2022 Expiration:  Custom \u2192 1 day\n" +
+                "  \u2022 Repository access:  Only select \u2018{1}/{2}\u2019\n" +
+                "  \u2022 Permissions \u2192 Contents: Read-only\n" +
+                "  \u2022 Permissions \u2192 Metadata: Read-only\n\n" +
+                "Click \u2018Open GitHub \u2192\u2019, configure the options above, click \u2018Generate token\u2019, then paste the token into the next prompt.",
+            tokenName,
+            owner,
+            repoSlug,
+        ),
+        { modal: true },
+        OPEN_GITHUB,
+    );
+    if (userAction !== OPEN_GITHUB) return undefined;
+
+    await vscode.env.openExternal(vscode.Uri.parse(patUrl));
+
+    const pasted = await vscode.window.showInputBox({
+        prompt: l10n.t("Paste the generated GitHub PAT \u2014 it will be registered in Argo CD automatically"),
+        password: true,
+        placeHolder: "github_pat_\u2026",
+        ignoreFocusOut: true,
+        validateInput: (v) => (!v || !v.trim() ? l10n.t("Token is required.") : undefined),
+    });
+
+    return pasted?.trim() || undefined;
+}
+
+/**
+ * After a successful repo credential registration, offer to open the Argo CD UI
+ * directly at Settings → Repositories so the user can verify the connection status.
+ */
+async function offerOpenArgoCDUI(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    clusterName: string,
+): Promise<void> {
+    const OPEN_UI = l10n.t("View in Argo CD (Settings → Repositories)");
+    const action = await vscode.window.showInformationMessage(
+        l10n.t("Open the Argo CD UI to verify the repository connection status under Settings → Repositories."),
+        OPEN_UI,
+    );
+    if (action === OPEN_UI) {
+        await openArgoCDUI(kubectl, kubeConfigFile, clusterName);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: ensure GitHub SSH host keys are present in argocd-ssh-known-hosts-cm
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors what `argocd repo add --ssh-private-key-path` does automatically:
+ * fetches GitHub's current SSH public host keys from the GitHub meta API and
+ * patches the `argocd-ssh-known-hosts-cm` ConfigMap with any that are missing.
+ *
+ * Without this, Argo CD refuses to open the SSH connection ("unknown host"),
+ * so the repository shows "not connected" even when the deploy key is correct.
+ *
+ * Reference:
+ *   https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#ssh-known-host-public-keys
+ *   https://docs.github.com/en/rest/meta/meta#get-github-meta-information
+ */
+async function ensureGitHubSshKnownHosts(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+): Promise<void> {
+    // 1. Fetch GitHub's current SSH host keys.
+    let githubKeys: string[];
+    try {
+        const res = await fetch("https://api.github.com/meta", {
+            headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const meta = (await res.json()) as { ssh_keys?: string[] };
+        githubKeys = (meta.ssh_keys ?? []).filter((k) => k.trim().length > 0);
+    } catch (e) {
+        vscode.window.showWarningMessage(
+            l10n.t(
+                "Could not fetch GitHub SSH host keys ({0}). Argo CD may show the repository as disconnected until you add them manually.",
+                String(e),
+            ),
+        );
+        return;
+    }
+
+    if (githubKeys.length === 0) return;
+
+    // 2. Read the current known-hosts ConfigMap.
+    const getResult = await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFile,
+        `get cm argocd-ssh-known-hosts-cm -n argocd -o jsonpath="{.data.ssh_known_hosts}"`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+
+    const existing = !failed(getResult) ? getResult.result.stdout.trim().replace(/^"|"$/g, "") : "";
+
+    // 3. Build the merged known-hosts block — add only missing entries.
+    const existingLines = new Set(
+        existing
+            .split("\n")
+            .map((l) => l.trim())
+            .filter(Boolean),
+    );
+    const toAdd = githubKeys.map((k) => `github.com ${k.trim()}`).filter((line) => !existingLines.has(line));
+
+    if (toAdd.length === 0) return; // already up to date
+
+    const merged = `${[...existingLines, ...toAdd].join("\n")}\n`;
+
+    // 4. Patch the ConfigMap.  Use a JSON merge-patch via a temp file to avoid
+    //    shell quoting issues with the multi-line value.
+    const patchObj = { data: { ssh_known_hosts: merged } };
+    const patchFile = await createTempFile(JSON.stringify(patchObj), "json");
+    try {
+        const patchResult = await invokeKubectlCommand(
+            kubectl,
+            kubeConfigFile,
+            `patch cm argocd-ssh-known-hosts-cm -n argocd --type=merge --patch-file "${patchFile.filePath}"`,
+        );
+        if (failed(patchResult)) {
+            vscode.window.showWarningMessage(
+                l10n.t("Could not patch argocd-ssh-known-hosts-cm: {0}", patchResult.error),
+            );
+            return;
+        }
+    } finally {
+        patchFile.dispose();
+    }
+
+    // 5. Restart argocd-repo-server so it picks up the updated ConfigMap immediately.
+    //    Without this, the pod keeps using the copy it loaded at startup and SSH
+    //    connections fail with "unknown host" until the next pod restart.
+    await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFile,
+        `rollout restart deployment/argocd-repo-server -n argocd`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build + kubectl-apply an Argo CD repository Secret
+// ---------------------------------------------------------------------------
+
+async function applyRepoSecret(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+    repoUrl: string,
+    secretStringData: Record<string, string>,
+): Promise<boolean> {
+    // Build a valid Kubernetes Secret name from the repo URL.
     const secretName = `repo-${repoUrl
-        .trim()
         .replace(/^https?:\/\/|^git@|\.git$/g, "")
         .replace(/[^a-z0-9]/gi, "-")
         .toLowerCase()
@@ -407,7 +813,7 @@ async function registerRepoCredentials(
         .slice(0, 50)
         .replace(/-+$/g, "")}`;
 
-    // 4. Serialize the secret object via js-yaml to avoid YAML injection.
+    // Serialize the secret object via js-yaml to avoid YAML injection.
     const secretObj = {
         apiVersion: "v1",
         kind: "Secret",
@@ -420,7 +826,7 @@ async function registerRepoCredentials(
     };
     const secretYaml = yaml.dump(secretObj);
 
-    // 5. Apply via a temp file (never log credentials to channels).
+    // Apply via a temp file (never log credentials to output channels).
     const tmpFile = await createTempFile(secretYaml, "yaml");
     try {
         const result = await longRunning(l10n.t("Registering repository credentials with Argo CD…"), () =>
@@ -429,12 +835,11 @@ async function registerRepoCredentials(
 
         if (failed(result)) {
             vscode.window.showErrorMessage(l10n.t("Failed to register repository credentials: {0}", result.error));
-            return;
+            return false;
         }
 
-        vscode.window.showInformationMessage(
-            l10n.t("Repository '{0}' registered with Argo CD successfully.", repoUrl.trim()),
-        );
+        vscode.window.showInformationMessage(l10n.t("Repository '{0}' registered with Argo CD successfully.", repoUrl));
+        return true;
     } finally {
         tmpFile.dispose();
     }
@@ -463,35 +868,9 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
     const targetNamespace = doc.metadata?.namespace ?? "argocd";
 
     // ------------------------------------------------------------------
-    // 2. Get the Azure session.
-    // ------------------------------------------------------------------
-    const sessionResult = await getReadySessionProvider();
-    if (failed(sessionResult)) {
-        vscode.window.showErrorMessage(sessionResult.error);
-        return;
-    }
-
-    // ------------------------------------------------------------------
-    // 3. Pick the target AKS cluster (consistent with "Deploy Manifest" UX).
-    // ------------------------------------------------------------------
-    const clusterResult = await selectClusterOptions(sessionResult.result, undefined, "aks.argoCDApplyApp");
-    if (failed(clusterResult)) {
-        vscode.window.showErrorMessage(clusterResult.error);
-        return;
-    }
-
-    // User chose "Create new cluster" — stop and let them do that first.
-    if (clusterResult.result === true) {
-        vscode.window.showInformationMessage(
-            l10n.t("Please create an AKS cluster before applying the Argo CD Application."),
-        );
-        return;
-    }
-
-    const cluster = clusterResult.result as ClusterPreference;
-
-    // ------------------------------------------------------------------
-    // 4. Ensure kubectl is available.
+    // 2. Ensure kubectl is available and read the current cluster context.
+    //    No Azure subscription or cluster picker — Argo CD operates on
+    //    whichever cluster the user already has as their active context.
     // ------------------------------------------------------------------
     const kubectl = await k8s.extension.kubectl.v1;
     if (!kubectl.available) {
@@ -499,24 +878,38 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         return;
     }
 
+    const ctx = await resolveCurrentKubectlContext(kubectl);
+    if (!ctx) return;
+
+    const { contextName: clusterName, kubeconfigYaml } = ctx;
+
     // ------------------------------------------------------------------
-    // 5. Write kubeconfig to a temp file.
+    // 3. Inform the user which cluster will be used and confirm.
     // ------------------------------------------------------------------
-    const kubeConfigFile = await createTempFile(cluster.kubeConfigYAML, "yaml");
+    const APPLY = l10n.t("Apply");
+    const confirmed = await vscode.window.showInformationMessage(
+        l10n.t("Apply Argo CD Application '{0}' to the current cluster context '{1}'?", appName, clusterName),
+        { modal: true },
+        APPLY,
+    );
+    if (!confirmed) return;
+
+    // ------------------------------------------------------------------
+    // 4. Write kubeconfig to a temp file.
+    // ------------------------------------------------------------------
+    const kubeConfigFile = await createTempFile(kubeconfigYaml, "yaml");
 
     try {
         // ------------------------------------------------------------------
-        // 6. Verify Argo CD is installed (check for argocd namespace).
+        // 5. Verify Argo CD is installed (check for argocd namespace).
         // ------------------------------------------------------------------
-        const nsCheck = await longRunning(
-            l10n.t("Checking if Argo CD is installed on '{0}'…", cluster.clusterName),
-            () =>
-                invokeKubectlCommand(
-                    kubectl,
-                    kubeConfigFile.filePath,
-                    `get namespace argocd --ignore-not-found -o name`,
-                    NonZeroExitCodeBehaviour.Succeed,
-                ),
+        const nsCheck = await longRunning(l10n.t("Checking if Argo CD is installed on '{0}'…", clusterName), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeConfigFile.filePath,
+                `get namespace argocd --ignore-not-found -o name`,
+                NonZeroExitCodeBehaviour.Succeed,
+            ),
         );
 
         const argoCDMissing = failed(nsCheck) || nsCheck.result.stdout.trim() === "";
@@ -526,8 +919,8 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             const APPLY_ANYWAY = l10n.t("Apply Anyway");
             const choice = await vscode.window.showWarningMessage(
                 l10n.t(
-                    "Argo CD does not appear to be installed on cluster '{0}' (namespace 'argocd' not found).\n\nInstall it now, or apply the manifest anyway.",
-                    cluster.clusterName,
+                    "Argo CD is not installed on '{0}' (namespace 'argocd' not found). Install it now, or apply the manifest anyway.",
+                    clusterName,
                 ),
                 { modal: true },
                 INSTALL_NOW,
@@ -536,21 +929,16 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             if (!choice) return;
             if (choice === INSTALL_NOW) {
                 const channel = getOutputChannel();
-                const installed = await performArgoCDInstall(
-                    kubectl,
-                    kubeConfigFile.filePath,
-                    cluster.clusterName,
-                    channel,
-                );
+                const installed = await performArgoCDInstall(kubectl, kubeConfigFile.filePath, clusterName, channel);
                 if (!installed) return;
             }
         }
 
         // ------------------------------------------------------------------
-        // 7. Apply the manifest to the cluster.
+        // 6. Apply the manifest to the cluster.
         // ------------------------------------------------------------------
         const applyResult = await longRunning(
-            l10n.t("Applying Argo CD Application '{0}' to cluster '{1}'…", appName, cluster.clusterName),
+            l10n.t("Applying Argo CD Application '{0}' to '{1}'…", appName, clusterName),
             () =>
                 invokeKubectlCommand(
                     kubectl,
@@ -574,9 +962,9 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         const OPEN_DOCS = l10n.t("Sync Guide");
         const followUp = await vscode.window.showInformationMessage(
             l10n.t(
-                "Argo CD Application '{0}' applied to cluster '{1}'.\n\n{2}\n\nArgo CD will begin syncing from the configured Git repository.",
+                "'{0}' applied to '{1}'.\n\n{2}\n\nArgo CD will begin syncing from the configured Git repository.",
                 appName,
-                cluster.clusterName,
+                clusterName,
                 output,
             ),
             OPEN_UI,
@@ -586,11 +974,16 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         );
 
         if (followUp === OPEN_UI) {
-            await openArgoCDUI(kubectl, kubeConfigFile.filePath, cluster.clusterName);
+            await openArgoCDUI(kubectl, kubeConfigFile.filePath, clusterName);
         } else if (followUp === GET_CREDS) {
             await showArgoCDCredentials(kubectl, kubeConfigFile.filePath);
         } else if (followUp === REGISTER_REPO) {
-            await registerRepoCredentials(kubectl, kubeConfigFile.filePath, doc.spec?.source?.repoURL ?? "");
+            await registerRepoCredentials(
+                kubectl,
+                kubeConfigFile.filePath,
+                doc.spec?.source?.repoURL ?? "",
+                clusterName,
+            );
         } else if (followUp === OPEN_DOCS) {
             await vscode.env.openExternal(
                 vscode.Uri.parse(

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -606,13 +606,9 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         }
 
         // ------------------------------------------------------------------
-        // 5. The Application CR must be applied to the Argo CD namespace
+        // 5. Confirm the apply action.
+        //    The Application CR is always applied to the Argo CD namespace
         //    (metadata.namespace in the YAML, defaults to "argocd").
-        //    Applying it elsewhere would make Argo CD ignore it.
-        // ------------------------------------------------------------------
-
-        // ------------------------------------------------------------------
-        // 6. Confirm the apply action.
         // ------------------------------------------------------------------
         const APPLY = l10n.t("Apply");
         const confirmed = await vscode.window.showInformationMessage(
@@ -627,7 +623,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         if (!confirmed) return;
 
         // ------------------------------------------------------------------
-        // 7. Apply the manifest to the cluster.
+        // 6. Apply the manifest to the cluster.
         // ------------------------------------------------------------------
         const applyResult = await longRunning(
             l10n.t("Applying Argo CD Application '{0}' to '{1}'…", appName, clusterName),

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -26,7 +26,7 @@ import { failed } from "../utils/errorable";
 import { getAuthenticatedKubeconfigYaml } from "../utils/clusters";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
-import { performArgoCDInstall, getOutputChannel } from "./argoCDInstall";
+import { getOutputChannel } from "./argoCDInstall";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -571,22 +571,14 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
     const { contextName: clusterName, kubeconfigYaml } = ctx;
 
     // ------------------------------------------------------------------
-    // 3. Inform the user which cluster will be used and confirm.
-    // ------------------------------------------------------------------
-    const APPLY = l10n.t("Apply");
-    const confirmed = await vscode.window.showInformationMessage(
-        l10n.t("Apply Argo CD Application '{0}' to cluster '{1}'?", appName, clusterName),
-        APPLY,
-    );
-    if (!confirmed) return;
-
-    // ------------------------------------------------------------------
-    // 4. Write kubeconfig to a temp file.
+    // 3. Write kubeconfig to a temp file (needed for all kubectl calls).
     // ------------------------------------------------------------------
     const kubeConfigFile = await createTempFile(kubeconfigYaml, "yaml");
 
     try {
-        // 6. Verify Argo CD is installed (check for argocd namespace).
+        // ------------------------------------------------------------------
+        // 4. Verify Argo CD is installed (check for argocd namespace).
+        //    Do this early — no point continuing if Argo CD is not present.
         // ------------------------------------------------------------------
         const nsCheck = await longRunning(l10n.t("Checking if Argo CD is installed on '{0}'…", clusterName), () =>
             invokeKubectlCommand(
@@ -600,24 +592,102 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         const argoCDMissing = failed(nsCheck) || nsCheck.result.stdout.trim() === "";
 
         if (argoCDMissing) {
-            const INSTALL_NOW = l10n.t("Install Argo CD Now");
-            const APPLY_ANYWAY = l10n.t("Apply Anyway");
-            const choice = await vscode.window.showWarningMessage(
+            vscode.window.showWarningMessage(
                 l10n.t(
-                    "Argo CD is not installed on '{0}' (namespace 'argocd' not found). Install it now, or apply the manifest anyway.",
+                    "Argo CD is not installed on cluster '{0}' (namespace 'argocd' not found). Please install Argo CD on your cluster before using this functionality. See https://argo-cd.readthedocs.io/en/stable/getting_started/",
                     clusterName,
                 ),
-                { modal: true },
-                INSTALL_NOW,
-                APPLY_ANYWAY,
             );
-            if (!choice) return;
-            if (choice === INSTALL_NOW) {
-                const channel = getOutputChannel();
-                const installed = await performArgoCDInstall(kubectl, kubeConfigFile.filePath, clusterName, channel);
-                if (!installed) return;
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // 5. Pick the target namespace — show cluster namespaces with
+        //    AKS desktop labels if present, default to the YAML value.
+        // ------------------------------------------------------------------
+        let selectedNamespace: string | undefined = targetNamespace;
+
+        const nsListResult = await longRunning(l10n.t("Loading cluster namespaces..."), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeConfigFile.filePath,
+                `get namespace -o json`,
+                NonZeroExitCodeBehaviour.Succeed,
+            ),
+        );
+
+        if (!failed(nsListResult) && nsListResult.result.stdout.trim()) {
+            type RawNs = { metadata: { name: string; labels?: Record<string, string> } };
+            let rawItems: RawNs[] = [];
+            try {
+                rawItems = (JSON.parse(nsListResult.result.stdout) as { items: RawNs[] }).items ?? [];
+            } catch {
+                // fall through to use YAML default
+            }
+
+            // Filter out system namespaces, keep "default" and the YAML-specified namespace.
+            const systemNs = new Set(["kube-system", "kube-public", "kube-node-lease", "gatekeeper-system", "argocd"]);
+            rawItems = rawItems.filter(
+                (ns) =>
+                    ns.metadata.name === "default" ||
+                    ns.metadata.name === targetNamespace ||
+                    !systemNs.has(ns.metadata.name),
+            );
+
+            if (rawItems.length > 0) {
+                const names = rawItems.map((ns) => ns.metadata.name);
+                if (!names.includes("default")) {
+                    rawItems.unshift({ metadata: { name: "default", labels: {} } });
+                }
+
+                // Sort: YAML-specified namespace first, then "default", then alphabetical.
+                rawItems.sort((a, b) => {
+                    if (a.metadata.name === targetNamespace) return -1;
+                    if (b.metadata.name === targetNamespace) return 1;
+                    if (a.metadata.name === "default") return -1;
+                    if (b.metadata.name === "default") return 1;
+                    return a.metadata.name.localeCompare(b.metadata.name);
+                });
+
+                const nsItems: vscode.QuickPickItem[] = rawItems.map((ns) => {
+                    const name = ns.metadata.name;
+                    const labels = ns.metadata.labels ?? {};
+                    let description: string | undefined;
+                    if (labels["headlamp.dev/project-managed-by"] === "aks-desktop") {
+                        description = l10n.t("(AKS desktop Project: {0})", name);
+                    } else if (name === targetNamespace) {
+                        description = l10n.t("from YAML manifest");
+                    } else if (name === "default") {
+                        description = l10n.t("recommended default");
+                    }
+                    return { label: name, description };
+                });
+
+                const picked = await vscode.window.showQuickPick(nsItems, {
+                    title: l10n.t("Namespace ({0} available)", nsItems.length),
+                    placeHolder: l10n.t("Select a Kubernetes namespace"),
+                    ignoreFocusOut: true,
+                });
+
+                if (!picked) return;
+                selectedNamespace = picked.label;
             }
         }
+
+        // ------------------------------------------------------------------
+        // 6. Confirm the apply action.
+        // ------------------------------------------------------------------
+        const APPLY = l10n.t("Apply");
+        const confirmed = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Apply Argo CD Application '{0}' to namespace '{1}' on cluster '{2}'?",
+                appName,
+                selectedNamespace,
+                clusterName,
+            ),
+            APPLY,
+        );
+        if (!confirmed) return;
 
         // ------------------------------------------------------------------
         // 7. Apply the manifest to the cluster.
@@ -628,7 +698,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
                 invokeKubectlCommand(
                     kubectl,
                     kubeConfigFile.filePath,
-                    `apply -n ${targetNamespace} -f "${fileUri.fsPath}" --validate=false`,
+                    `apply -n ${selectedNamespace} -f "${fileUri.fsPath}" --validate=false`,
                 ),
         );
 

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -19,8 +19,12 @@
  */
 
 import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
+import { getExtensionPath } from "../utils/host";
+import { failed } from "../utils/errorable";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -59,9 +63,13 @@ const DEPLOYMENT_MANIFEST_INDICATORS: string[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Argo CD Application YAML template
+// Argo CD Application YAML — loaded from resources/yaml/argocd-application.template.yaml
 // ---------------------------------------------------------------------------
 
+/**
+ * Reads the Argo CD Application template from disk and substitutes
+ * {{PLACEHOLDER}} tokens with the provided values.
+ */
 function buildArgoCDAppYaml(params: {
     appName: string;
     configRepoUrl: string;
@@ -70,101 +78,21 @@ function buildArgoCDAppYaml(params: {
     namespace: string;
     appPath: string;
 }): string {
-    return `# =============================================================================
-# Argo CD Application Manifest
-# =============================================================================
-#
-# ⚠️  IMPORTANT — Hollywood Principle / GitOps "Don't call us, we'll call you"
-#
-# This file belongs in a SEPARATE GitOps config repository, NOT in your
-# application source repository.
-#
-# Argo CD watches this config repo and PULLS changes automatically to your
-# AKS cluster.  It will detect drift between the live cluster state and what
-# is declared here, and reconcile automatically.
-#
-# Recommended GitOps config repo layout:
-#
-#   config-repo/
-#   └── apps/
-#       └── ${params.appName}/
-#           ├── application.yaml   ← this file
-#           ├── deployment.yaml    ← your Kubernetes workload manifests
-#           └── service.yaml
-#
-# Reference: https://argo-cd.readthedocs.io/en/stable/
-# =============================================================================
+    const extensionPath = getExtensionPath();
+    if (failed(extensionPath)) {
+        throw new Error(extensionPath.error);
+    }
 
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  # The name used inside Argo CD to identify this application.
-  name: ${params.appName}
+    const templatePath = path.join(extensionPath.result, "resources", "yaml", "argocd-application.template.yaml");
+    const template = fs.readFileSync(templatePath, "utf8");
 
-  # Argo CD system namespace — do NOT change unless you installed Argo CD
-  # in a custom namespace.
-  namespace: argocd
-
-  labels:
-    app.kubernetes.io/name: ${params.appName}
-    app.kubernetes.io/managed-by: argocd
-
-  annotations:
-    # URL of the *application source* repository (informational).
-    # Keep this separate from repoURL below which points to THIS config repo.
-    aks-extension/source-repo: "${params.sourceRepoUrl}"
-
-    # Link to Argo CD docs for reference.
-    aks-extension/docs: "https://argo-cd.readthedocs.io/en/stable/"
-
-spec:
-  # Argo CD project — "default" works for most setups.
-  # See: https://argo-cd.readthedocs.io/en/stable/user-guide/projects/
-  project: default
-
-  source:
-    # ✅ This is the URL of THIS GitOps config repository.
-    #    It is NOT the application source repository.
-    repoURL: ${params.configRepoUrl}
-
-    # Branch / tag / commit SHA to track.
-    targetRevision: HEAD
-
-    # Path inside this repo that contains the Kubernetes manifests for this app.
-    path: ${params.appPath}
-
-  destination:
-    # AKS cluster API server URL.
-    # Use "https://kubernetes.default.svc" when Argo CD runs inside the same cluster.
-    # For an external AKS cluster, use the API server URL from kubeconfig.
-    server: ${params.clusterServer}
-
-    # Kubernetes namespace to deploy resources into.
-    namespace: ${params.namespace}
-
-  syncPolicy:
-    automated:
-      # Remove resources from the cluster when they are deleted from Git.
-      prune: true
-
-      # Automatically bring the cluster back in sync when it drifts from Git.
-      selfHeal: true
-
-    syncOptions:
-      # Create the target namespace automatically if it does not exist.
-      - CreateNamespace=true
-
-      # Validate manifests against the Kubernetes API schema before applying.
-      - Validate=true
-
-    # Retry failed sync operations with exponential back-off.
-    retry:
-      limit: 3
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
-`;
+    return template
+        .replaceAll("{{APP_NAME}}", params.appName)
+        .replaceAll("{{CONFIG_REPO_URL}}", params.configRepoUrl)
+        .replaceAll("{{SOURCE_REPO_URL}}", params.sourceRepoUrl)
+        .replaceAll("{{CLUSTER_SERVER}}", params.clusterServer)
+        .replaceAll("{{NAMESPACE}}", params.namespace)
+        .replaceAll("{{APP_PATH}}", params.appPath);
 }
 
 // ---------------------------------------------------------------------------
@@ -611,6 +539,206 @@ async function promptRequired(
     });
 }
 
+/**
+ * Try to extract the `origin` remote URL from a local `.git/config` file.
+ * Returns the URL string or undefined if not found / not a git repo.
+ */
+function detectGitRemoteUrl(folderFsPath: string): string | undefined {
+    try {
+        const gitConfigPath = path.join(folderFsPath, ".git", "config");
+        const content = fs.readFileSync(gitConfigPath, "utf8");
+        // Match [remote "origin"] section and capture the url = ... line.
+        const match = content.match(/\[remote\s+"origin"\][^\\[]*url\s*=\s*(.+)/);
+        return match ? match[1].trim() : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub repo browser helpers
+// ---------------------------------------------------------------------------
+
+interface GitHubRepo {
+    full_name: string;
+    clone_url: string;
+    ssh_url: string;
+    private: boolean;
+    description: string | null;
+}
+
+/**
+ * Uses VS Code's built-in GitHub authentication provider to obtain an OAuth
+ * token, then fetches the authenticated user's repositories from the GitHub
+ * REST API (up to 100, sorted by most recently updated).
+ *
+ * Returns the chosen clone URL (HTTPS or SSH) or undefined if the user
+ * cancels at any step.
+ */
+async function browseGitHubRepos(title: string): Promise<string | undefined> {
+    // Request a GitHub session — prompts sign-in if needed.
+    let session: vscode.AuthenticationSession;
+    try {
+        session = await vscode.authentication.getSession("github", ["repo"], { createIfNone: true });
+    } catch {
+        vscode.window.showWarningMessage(
+            l10n.t("GitHub sign-in was cancelled or unavailable. Please enter the URL manually."),
+        );
+        return undefined;
+    }
+
+    // Fetch up to 100 repos from the GitHub API.
+    let repos: GitHubRepo[];
+    try {
+        const response = await fetch("https://api.github.com/user/repos?per_page=100&sort=updated&type=all", {
+            headers: {
+                Authorization: `Bearer ${session.accessToken}`,
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        });
+        if (!response.ok) {
+            throw new Error(`GitHub API returned ${response.status}`);
+        }
+        repos = (await response.json()) as GitHubRepo[];
+    } catch (e) {
+        vscode.window.showWarningMessage(
+            l10n.t("Failed to fetch GitHub repositories: {0}. Please enter the URL manually.", String(e)),
+        );
+        return undefined;
+    }
+
+    if (repos.length === 0) {
+        vscode.window.showInformationMessage(l10n.t("No repositories found for this GitHub account."));
+        return undefined;
+    }
+
+    // Let the user pick a repo.
+    const repoPick = await vscode.window.showQuickPick(
+        repos.map((r) => ({
+            label: r.full_name,
+            description: r.private ? l10n.t("private") : l10n.t("public"),
+            detail: r.description ?? undefined,
+            repo: r,
+        })),
+        {
+            title,
+            placeHolder: l10n.t("Select a GitHub repository"),
+            matchOnDescription: true,
+            matchOnDetail: true,
+            ignoreFocusOut: true,
+        },
+    );
+
+    if (!repoPick) return undefined;
+
+    // Ask for URL format.
+    const formatPick = await vscode.window.showQuickPick(
+        [
+            {
+                label: "HTTPS",
+                description: repoPick.repo.clone_url,
+                url: repoPick.repo.clone_url,
+            },
+            {
+                label: "SSH",
+                description: repoPick.repo.ssh_url,
+                url: repoPick.repo.ssh_url,
+            },
+        ],
+        {
+            title: l10n.t("Select URL format for {0}", repoPick.repo.full_name),
+            placeHolder: l10n.t("HTTPS is recommended for Argo CD; SSH requires a deploy key"),
+            ignoreFocusOut: true,
+        },
+    );
+
+    return formatPick?.url;
+}
+
+/**
+ * Prompts for a Git repository URL with three modes:
+ *  - "Enter URL"            — free-text input box
+ *  - "Browse local folder…" — folder picker that auto-detects the git remote
+ *  - "Browse GitHub repos…" — authenticates with GitHub and shows a repo list
+ *
+ * All three modes end in an editable input box so the user can confirm or
+ * adjust the value before accepting.
+ *
+ * @param prompt      Title shown above the QuickPick and input box.
+ * @param placeHolder Placeholder shown when the input is empty.
+ * @param required    Whether an empty value is rejected.
+ */
+async function promptRepoUrl(prompt: string, placeHolder: string, required: boolean): Promise<string | undefined> {
+    const ENTER_URL = l10n.t("$(link) Enter a URL");
+    const BROWSE_LOCAL = l10n.t("$(folder-opened) Browse local folder\u2026");
+    const BROWSE_GITHUB = l10n.t("$(github) Browse GitHub repos\u2026");
+
+    const mode = await vscode.window.showQuickPick(
+        [
+            {
+                label: ENTER_URL,
+                description: l10n.t("Type or paste a Git remote URL"),
+            },
+            {
+                label: BROWSE_LOCAL,
+                description: l10n.t("Pick a local repo folder — remote URL will be detected automatically"),
+            },
+            {
+                label: BROWSE_GITHUB,
+                description: l10n.t("Sign in to GitHub and choose from your repositories"),
+            },
+        ],
+        {
+            title: prompt,
+            placeHolder: l10n.t("How would you like to specify the repository?"),
+            ignoreFocusOut: true,
+        },
+    );
+
+    if (!mode) return undefined;
+
+    let detectedUrl: string | undefined;
+
+    if (mode.label === BROWSE_LOCAL) {
+        const picked = await vscode.window.showOpenDialog({
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: l10n.t("Select repository folder"),
+            title: prompt,
+        });
+        if (!picked || picked.length === 0) return undefined;
+
+        detectedUrl = detectGitRemoteUrl(picked[0].fsPath);
+
+        if (!detectedUrl) {
+            vscode.window.showWarningMessage(
+                l10n.t("No git remote 'origin' found in the selected folder. Please enter the URL manually."),
+            );
+        }
+    } else if (mode.label === BROWSE_GITHUB) {
+        // browseGitHubRepos already ends with the user choosing a URL format,
+        // so we skip the final input box for this path and return directly.
+        const chosenUrl = await browseGitHubRepos(prompt);
+        if (!chosenUrl) return undefined;
+        // Still drop through to the input box so the user can confirm/edit.
+        detectedUrl = chosenUrl;
+    }
+
+    // Final editable input box — pre-populated with the detected/chosen URL.
+    return vscode.window.showInputBox({
+        prompt,
+        placeHolder,
+        value: detectedUrl ?? "",
+        ignoreFocusOut: true,
+        validateInput: (v) => {
+            if (required && (!v || v.trim() === "")) return l10n.t("This field is required.");
+            return undefined;
+        },
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Main command handler
 // ---------------------------------------------------------------------------
@@ -753,19 +881,20 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     );
     if (!appName) return;
 
-    const configRepoUrl = await promptRequired(
-        l10n.t("GitOps config repository URL (this is the Git repo Argo CD will watch)"),
+    const configRepoUrl = await promptRepoUrl(
+        l10n.t("GitOps config repository (this is the Git repo Argo CD will watch)"),
         "https://github.com/my-org/my-app-config",
+        true,
     );
     if (!configRepoUrl) return;
 
     // Source repo is informational — allow empty.
     const sourceRepoUrl =
-        (await vscode.window.showInputBox({
-            prompt: l10n.t("Application source repository URL (optional — stored as an annotation for traceability)"),
-            placeHolder: "https://github.com/my-org/my-app",
-            ignoreFocusOut: true,
-        })) ?? "";
+        (await promptRepoUrl(
+            l10n.t("Application source repository (optional — stored as an annotation for traceability)"),
+            "https://github.com/my-org/my-app",
+            false,
+        )) ?? "";
 
     const clusterServer = await promptRequired(
         l10n.t("Target AKS cluster API server URL (use https://kubernetes.default.svc for in-cluster)"),

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -1,0 +1,877 @@
+/**
+ * Argo CD "Create Deployment" command.
+ *
+ * Argo CD follows the Hollywood Principle (GitOps / "don't call us, we'll call you"):
+ * the cluster never pushes — Argo CD continuously PULLS desired state from a Git
+ * repository and reconciles it against the live cluster.  This means the Argo CD
+ * Application manifest must live in a **dedicated GitOps config repository**, NOT
+ * in the same repository that contains your application source code.
+ *
+ * This command:
+ *  1. Detects whether the current workspace looks like an application source repo
+ *     and warns the user accordingly.
+ *  2. Guides the user to either scaffold in place (config repo already open) or
+ *     open a separate config repository folder.
+ *  3. Collects the minimum required parameters through VS Code input boxes.
+ *  4. Writes a fully-annotated Argo CD Application YAML under apps/<name>/.
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/
+ */
+
+import * as vscode from "vscode";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import * as l10n from "@vscode/l10n";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ARGO_CD_DOCS_URL = "https://argo-cd.readthedocs.io/en/stable/";
+
+/**
+ * Well-known files/patterns that indicate the folder is an **application source**
+ * repository rather than a dedicated GitOps config repository.
+ */
+const APP_SOURCE_INDICATORS: string[] = [
+    "Dockerfile",
+    "package.json",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Cargo.toml",
+    "go.mod",
+    "requirements.txt",
+    "setup.py",
+    "pyproject.toml",
+    "*.csproj",
+    "*.sln",
+];
+
+/**
+ * Kubernetes manifest patterns that indicate existing cluster deployment files
+ * are already present (strengthens the recommendation to use a separate repo).
+ */
+const DEPLOYMENT_MANIFEST_INDICATORS: string[] = [
+    "**/deployment.yaml",
+    "**/deployment.yml",
+    "**/kustomization.yaml",
+    "**/Chart.yaml",
+];
+
+// ---------------------------------------------------------------------------
+// Argo CD Application YAML template
+// ---------------------------------------------------------------------------
+
+function buildArgoCDAppYaml(params: {
+    appName: string;
+    configRepoUrl: string;
+    sourceRepoUrl: string;
+    clusterServer: string;
+    namespace: string;
+    appPath: string;
+}): string {
+    return `# =============================================================================
+# Argo CD Application Manifest
+# =============================================================================
+#
+# ⚠️  IMPORTANT — Hollywood Principle / GitOps "Don't call us, we'll call you"
+#
+# This file belongs in a SEPARATE GitOps config repository, NOT in your
+# application source repository.
+#
+# Argo CD watches this config repo and PULLS changes automatically to your
+# AKS cluster.  It will detect drift between the live cluster state and what
+# is declared here, and reconcile automatically.
+#
+# Recommended GitOps config repo layout:
+#
+#   config-repo/
+#   └── apps/
+#       └── ${params.appName}/
+#           ├── application.yaml   ← this file
+#           ├── deployment.yaml    ← your Kubernetes workload manifests
+#           └── service.yaml
+#
+# Reference: https://argo-cd.readthedocs.io/en/stable/
+# =============================================================================
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # The name used inside Argo CD to identify this application.
+  name: ${params.appName}
+
+  # Argo CD system namespace — do NOT change unless you installed Argo CD
+  # in a custom namespace.
+  namespace: argocd
+
+  labels:
+    app.kubernetes.io/name: ${params.appName}
+    app.kubernetes.io/managed-by: argocd
+
+  annotations:
+    # URL of the *application source* repository (informational).
+    # Keep this separate from repoURL below which points to THIS config repo.
+    aks-extension/source-repo: "${params.sourceRepoUrl}"
+
+    # Link to Argo CD docs for reference.
+    aks-extension/docs: "https://argo-cd.readthedocs.io/en/stable/"
+
+spec:
+  # Argo CD project — "default" works for most setups.
+  # See: https://argo-cd.readthedocs.io/en/stable/user-guide/projects/
+  project: default
+
+  source:
+    # ✅ This is the URL of THIS GitOps config repository.
+    #    It is NOT the application source repository.
+    repoURL: ${params.configRepoUrl}
+
+    # Branch / tag / commit SHA to track.
+    targetRevision: HEAD
+
+    # Path inside this repo that contains the Kubernetes manifests for this app.
+    path: ${params.appPath}
+
+  destination:
+    # AKS cluster API server URL.
+    # Use "https://kubernetes.default.svc" when Argo CD runs inside the same cluster.
+    # For an external AKS cluster, use the API server URL from kubeconfig.
+    server: ${params.clusterServer}
+
+    # Kubernetes namespace to deploy resources into.
+    namespace: ${params.namespace}
+
+  syncPolicy:
+    automated:
+      # Remove resources from the cluster when they are deleted from Git.
+      prune: true
+
+      # Automatically bring the cluster back in sync when it drifts from Git.
+      selfHeal: true
+
+    syncOptions:
+      # Create the target namespace automatically if it does not exist.
+      - CreateNamespace=true
+
+      # Validate manifests against the Kubernetes API schema before applying.
+      - Validate=true
+
+    # Retry failed sync operations with exponential back-off.
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes Deployment YAML template
+// ---------------------------------------------------------------------------
+
+function buildDeploymentYaml(params: {
+    appName: string;
+    namespace: string;
+    containerImage: string;
+    containerPort: number;
+}): string {
+    return `# =============================================================================
+# Kubernetes Deployment manifest
+# =============================================================================
+#
+# This file is managed by Argo CD (GitOps).
+#
+# ⚠️  Do NOT apply this file manually with kubectl unless you intentionally
+# want to create a temporary drift that Argo CD will immediately reconcile.
+#
+# Edit here → commit to this GitOps config repo → Argo CD detects the change
+# and rolls it out to the AKS cluster automatically.
+#
+# =============================================================================
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${params.appName}
+  namespace: ${params.namespace}
+  labels:
+    app: ${params.appName}
+    app.kubernetes.io/name: ${params.appName}
+    app.kubernetes.io/managed-by: argocd
+spec:
+  # Number of pod replicas — increase for high availability.
+  replicas: 2
+
+  selector:
+    matchLabels:
+      app: ${params.appName}
+
+  template:
+    metadata:
+      labels:
+        app: ${params.appName}
+        app.kubernetes.io/name: ${params.appName}
+    spec:
+      # -----------------------------------------------------------------------
+      # Security context: run as non-root by default.
+      # Adjust or remove if your container requires root.
+      # -----------------------------------------------------------------------
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: ${params.appName}
+          # Replace this with your actual container image.
+          # Argo CD will roll out a new version whenever this tag changes in Git.
+          image: ${params.containerImage}
+          imagePullPolicy: Always
+
+          ports:
+            - name: http
+              containerPort: ${params.containerPort}
+              protocol: TCP
+
+          # Least-privilege container security settings.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
+          # ----------------------------------------------------------------
+          # Resource limits — tune to your workload.
+          # ----------------------------------------------------------------
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+
+          # ----------------------------------------------------------------
+          # Probes — adjust paths / commands to match your application.
+          # ----------------------------------------------------------------
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes Service YAML template
+// ---------------------------------------------------------------------------
+
+function buildServiceYaml(params: { appName: string; namespace: string; containerPort: number }): string {
+    return `# =============================================================================
+# Kubernetes Service manifest
+# =============================================================================
+#
+# This file is managed by Argo CD (GitOps).
+# Edit here → commit → Argo CD reconciles the change to the AKS cluster.
+#
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${params.appName}
+  namespace: ${params.namespace}
+  labels:
+    app: ${params.appName}
+    app.kubernetes.io/name: ${params.appName}
+    app.kubernetes.io/managed-by: argocd
+spec:
+  # ClusterIP   — internal cluster traffic only (default, most secure).
+  # LoadBalancer — expose directly via Azure Load Balancer (public IP).
+  # NodePort    — expose on a node port (rarely used with AKS).
+  #
+  # Change to LoadBalancer if you need external access.
+  type: ClusterIP
+
+  selector:
+    app: ${params.appName}
+
+  ports:
+    - name: http
+      protocol: TCP
+      # External port clients connect to.
+      port: 80
+      # Must match containerPort in deployment.yaml.
+      targetPort: ${params.containerPort}
+`;
+}
+
+// ---------------------------------------------------------------------------
+// README template
+// ---------------------------------------------------------------------------
+
+function buildReadmeMarkdown(params: {
+    appName: string;
+    namespace: string;
+    configRepoUrl: string;
+    sourceRepoUrl: string;
+    clusterServer: string;
+    containerImage: string;
+    containerPort: number;
+    appPath: string;
+}): string {
+    const sourceRepoLine = params.sourceRepoUrl
+        ? `- **Application source repo**: ${params.sourceRepoUrl}`
+        : `- **Application source repo**: *(not specified)*`;
+
+    return `# Argo CD GitOps Config — \`${params.appName}\`
+
+> Generated by the **AKS VS Code Extension** — Argo CD integration.
+> Reference: <https://argo-cd.readthedocs.io/en/stable/>
+
+---
+
+## 📌 The Hollywood Principle (GitOps)
+
+Argo CD follows the **"Don't call us, we'll call you"** (Hollywood) principle of computer science.
+Your AKS cluster **never pushes** changes — Argo CD runs as a controller inside the cluster and
+continuously **PULLS** the desired state from this Git repository, then reconciles live resources
+to match what is declared here.
+
+\`\`\`
+  ┌─────────────────────────┐        git pull / watch
+  │  This GitOps config repo │ ◄──────────────────────── Argo CD controller
+  │  (desired state in Git)  │                            (inside AKS cluster)
+  └─────────────────────────┘
+                                      kubectl apply (by Argo CD)
+                                ────────────────────────────►
+                                                          ┌──────────┐
+                                                          │ AKS live │
+                                                          │ cluster  │
+                                                          └──────────┘
+\`\`\`
+
+> ⚠️ **This config repo MUST be separate from your application source repo.**
+> Mixing Argo CD manifests with application source code breaks the GitOps separation of concerns.
+
+---
+
+## 📂 This directory
+
+\`\`\`
+${params.appPath}/
+├── README.md            ← you are here
+├── application.yaml     ← Argo CD Application CR (tells Argo CD what to watch)
+├── deployment.yaml      ← Kubernetes Deployment (your workload)
+└── service.yaml         ← Kubernetes Service (network exposure)
+\`\`\`
+
+| File | Purpose |
+|------|---------|
+| \`application.yaml\` | Registers this app with Argo CD. Points at this config repo path. |
+| \`deployment.yaml\` | Describes your container workload, replicas, probes, resource limits. |
+| \`service.yaml\` | Exposes the workload inside (or outside) the cluster. |
+
+---
+
+## ⚙️ Configuration summary
+
+| Parameter | Value |
+|-----------|-------|
+| App name | \`${params.appName}\` |
+| Config repo (this repo) | ${params.configRepoUrl} |
+| ${sourceRepoLine} |
+| Target cluster | \`${params.clusterServer}\` |
+| Target namespace | \`${params.namespace}\` |
+| Container image | \`${params.containerImage}\` |
+| Container port | \`${params.containerPort}\` |
+
+---
+
+## 🚀 Step 1 — Install Argo CD on your AKS cluster
+
+Argo CD runs as a set of Kubernetes controllers inside a dedicated namespace (\`argocd\`).
+
+### Option A — kubectl (official install)
+
+\`\`\`bash
+# 1. Create the argocd namespace
+kubectl create namespace argocd
+
+# 2. Apply the official install manifest
+#    Check https://github.com/argoproj/argo-cd/releases for the latest version
+kubectl apply -n argocd \\
+  -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# 3. Wait for all pods to become ready
+kubectl -n argocd rollout status deploy/argocd-server
+kubectl -n argocd get pods
+\`\`\`
+
+### Option B — Helm chart
+
+\`\`\`bash
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo update
+
+helm install argocd argo/argo-cd \\
+  --namespace argocd \\
+  --create-namespace \\
+  --set server.service.type=LoadBalancer
+\`\`\`
+
+> **AKS tip**: For production, use **Azure Workload Identity** for Argo CD instead of storing
+> Git credentials as Kubernetes Secrets.
+> See: <https://argo-cd.readthedocs.io/en/stable/operator-manual/security/>
+
+---
+
+## 🔑 Step 2 — Access the Argo CD UI & CLI
+
+\`\`\`bash
+# Get the initial admin password
+argocd admin initial-password -n argocd
+
+# Port-forward to access the UI locally
+kubectl -n argocd port-forward svc/argocd-server 8080:443
+# Open: https://localhost:8080  (accept the self-signed cert)
+
+# Log in via CLI
+argocd login localhost:8080 --username admin --insecure
+\`\`\`
+
+---
+
+## 🔗 Step 3 — Connect this config repo to Argo CD
+
+\`\`\`bash
+# Register the GitOps config repo
+# For private repos add --ssh-private-key-path or --username / --password
+argocd repo add ${params.configRepoUrl}
+\`\`\`
+
+---
+
+## 📋 Step 4 — Register this application with Argo CD
+
+\`\`\`bash
+# Option A: from the generated application.yaml (recommended — keeps config in Git)
+argocd app create -f ${params.appPath}/application.yaml
+
+# Option B: CLI flags (useful for one-off testing)
+argocd app create ${params.appName} \\
+  --repo ${params.configRepoUrl} \\
+  --path ${params.appPath} \\
+  --dest-server ${params.clusterServer} \\
+  --dest-namespace ${params.namespace} \\
+  --sync-policy automated \\
+  --auto-prune \\
+  --self-heal
+\`\`\`
+
+---
+
+## 🔄 Step 5 — Day-2: making changes
+
+Because Argo CD follows the Hollywood Principle, **you never \`kubectl apply\` directly in production**.
+The workflow is always:
+
+\`\`\`
+1.  Edit a file in this repo  (e.g. bump the image tag in deployment.yaml)
+2.  git commit -m 'chore: bump ${params.appName} image to v1.2.3'
+3.  git push
+4.  Argo CD detects the change (default poll: 3 min, or via webhook — see below)
+5.  Argo CD applies the diff to the AKS cluster automatically
+\`\`\`
+
+### Set up a Git webhook for instant sync (optional but recommended)
+
+\`\`\`bash
+# Get the Argo CD server external address
+kubectl -n argocd get svc argocd-server
+
+# In GitHub → repo Settings → Webhooks → Add webhook:
+#   Payload URL : https://<argocd-server>/api/webhook
+#   Content type: application/json
+#   Secret      : (configure in argocd-secret, key: webhook.github.secret)
+\`\`\`
+
+---
+
+## 🩺 Step 6 — Monitor & troubleshoot
+
+\`\`\`bash
+# Overall app status
+argocd app get ${params.appName}
+
+# List all managed apps
+argocd app list
+
+# Diff Git desired state vs live cluster state
+argocd app diff ${params.appName}
+
+# Force a manual sync (use sparingly — normally let Argo CD do it)
+argocd app sync ${params.appName}
+
+# List live Kubernetes resources owned by this app
+argocd app resources ${params.appName}
+
+# View recent sync history
+argocd app history ${params.appName}
+\`\`\`
+
+---
+
+## 📚 Further reading
+
+| Resource | URL |
+|----------|-----|
+| Argo CD docs | <https://argo-cd.readthedocs.io/en/stable/> |
+| Getting started | <https://argo-cd.readthedocs.io/en/stable/getting_started/> |
+| App of Apps pattern | <https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/> |
+| Sync waves (ordering) | <https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/> |
+| Azure Workload Identity | <https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview> |
+| Notifications | <https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/> |
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if any well-known application source file is found in the
+ * given workspace folder (depth-limited for performance).
+ */
+async function detectApplicationSourceRepo(folderUri: vscode.Uri): Promise<boolean> {
+    for (const indicator of APP_SOURCE_INDICATORS) {
+        try {
+            const matches = await vscode.workspace.findFiles(
+                new vscode.RelativePattern(folderUri.fsPath, indicator),
+                null,
+                1,
+            );
+            if (matches.length > 0) return true;
+        } catch {
+            // ignore filesystem errors on individual patterns
+        }
+    }
+    return false;
+}
+
+/**
+ * Returns true if the workspace contains existing Kubernetes deployment manifests.
+ */
+async function detectExistingDeploymentManifests(folderUri: vscode.Uri): Promise<boolean> {
+    for (const pattern of DEPLOYMENT_MANIFEST_INDICATORS) {
+        try {
+            const matches = await vscode.workspace.findFiles(
+                new vscode.RelativePattern(folderUri.fsPath, pattern),
+                "**/node_modules/**",
+                1,
+            );
+            if (matches.length > 0) return true;
+        } catch {
+            // ignore
+        }
+    }
+    return false;
+}
+
+/**
+ * Prompts for a required, single-line string.  Returns undefined if the user
+ * cancels or leaves the field blank.
+ */
+async function promptRequired(
+    prompt: string,
+    placeHolder: string,
+    value?: string,
+    validate?: (v: string) => string | undefined,
+): Promise<string | undefined> {
+    return vscode.window.showInputBox({
+        prompt,
+        placeHolder,
+        value,
+        ignoreFocusOut: true,
+        validateInput: (v) => {
+            if (!v || v.trim() === "") return l10n.t("This field is required.");
+            return validate ? validate(v.trim()) : undefined;
+        },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Main command handler
+// ---------------------------------------------------------------------------
+
+export async function draftArgoCDDeployment(_context: IActionContext, target: unknown): Promise<void> {
+    // -----------------------------------------------------------------------
+    // 1. Resolve the workspace folder the command was invoked from.
+    // -----------------------------------------------------------------------
+    let workspaceFolder: vscode.WorkspaceFolder | undefined;
+
+    if (target instanceof vscode.Uri) {
+        workspaceFolder = vscode.workspace.getWorkspaceFolder(target);
+    }
+
+    if (!workspaceFolder) {
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders || folders.length === 0) {
+            vscode.window.showErrorMessage(
+                l10n.t("You must have a workspace open to create an Argo CD deployment manifest."),
+            );
+            return;
+        }
+
+        workspaceFolder =
+            folders.length === 1
+                ? folders[0]
+                : await vscode.window.showWorkspaceFolderPick({
+                      placeHolder: l10n.t("Select the workspace folder to scaffold the Argo CD config into."),
+                  });
+
+        if (!workspaceFolder) return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Analyse the workspace to tailor the guidance message.
+    // -----------------------------------------------------------------------
+    const [looksLikeAppRepo, hasDeploymentFiles] = await Promise.all([
+        detectApplicationSourceRepo(workspaceFolder.uri),
+        detectExistingDeploymentManifests(workspaceFolder.uri),
+    ]);
+
+    // -----------------------------------------------------------------------
+    // 3. Show the Hollywood-Principle guidance message (always shown).
+    // -----------------------------------------------------------------------
+    const warningParts: string[] = [
+        l10n.t("Argo CD — Hollywood Principle (GitOps)"),
+        "",
+        l10n.t("Argo CD follows the \"Don't call us, we'll call you\" (Hollywood) principle."),
+        l10n.t(
+            "Your AKS cluster does NOT push changes — Argo CD continuously PULLS desired state from a Git repository and reconciles it automatically.",
+        ),
+        "",
+        l10n.t(
+            "This means your Argo CD Application manifest MUST live in a dedicated GitOps config repository, separate from your application source code.",
+        ),
+    ];
+
+    if (looksLikeAppRepo) {
+        warningParts.push(
+            "",
+            l10n.t(
+                "⚠  This workspace appears to be an APPLICATION SOURCE repository (source files / Dockerfile detected).",
+            ),
+            l10n.t(
+                "It is strongly recommended to add Argo CD manifests to a SEPARATE GitOps config repository instead.",
+            ),
+        );
+    }
+
+    if (hasDeploymentFiles) {
+        warningParts.push(
+            "",
+            l10n.t("⚠  Existing Kubernetes deployment manifests were detected in this workspace."),
+            l10n.t(
+                "If those belong to your application, please open your dedicated GitOps config repository before scaffolding.",
+            ),
+        );
+    }
+
+    warningParts.push(
+        "",
+        l10n.t("Recommended GitOps config repo layout (4 files will be scaffolded):"),
+        l10n.t("  config-repo/"),
+        l10n.t("  └── apps/<app-name>/"),
+        l10n.t("      ├── README.md         ← install guide + how it all fits together"),
+        l10n.t("      ├── application.yaml  ← Argo CD Application CR"),
+        l10n.t("      ├── deployment.yaml   ← Kubernetes Deployment"),
+        l10n.t("      └── service.yaml      ← Kubernetes Service"),
+        "",
+        l10n.t("How would you like to proceed?"),
+    );
+
+    const SCAFFOLD_HERE = l10n.t("Scaffold Here");
+    const OPEN_CONFIG_REPO = l10n.t("Open Config Repository…");
+    const LEARN_MORE = l10n.t("Learn More");
+
+    const choice = await vscode.window.showWarningMessage(
+        warningParts.join("\n"),
+        { modal: true },
+        SCAFFOLD_HERE,
+        OPEN_CONFIG_REPO,
+        LEARN_MORE,
+    );
+
+    if (!choice) return; // dismissed
+
+    if (choice === LEARN_MORE) {
+        await vscode.env.openExternal(vscode.Uri.parse(ARGO_CD_DOCS_URL));
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Determine the target folder (current workspace or user-selected).
+    // -----------------------------------------------------------------------
+    let targetFolderUri = workspaceFolder.uri;
+
+    if (choice === OPEN_CONFIG_REPO) {
+        const picked = await vscode.window.showOpenDialog({
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: l10n.t("Select GitOps Config Repository Folder"),
+            title: l10n.t("Open Argo CD GitOps Config Repository"),
+        });
+        if (!picked || picked.length === 0) return;
+        targetFolderUri = picked[0];
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Collect parameters via input boxes.
+    // -----------------------------------------------------------------------
+    const appName = await promptRequired(
+        l10n.t("Application name (used as Argo CD app name and directory name)"),
+        "my-app",
+        undefined,
+        (v) =>
+            /^[a-z0-9][a-z0-9-]*$/.test(v)
+                ? undefined
+                : l10n.t("Use lowercase letters, digits, and hyphens only (must start with a letter or digit)."),
+    );
+    if (!appName) return;
+
+    const configRepoUrl = await promptRequired(
+        l10n.t("GitOps config repository URL (this is the Git repo Argo CD will watch)"),
+        "https://github.com/my-org/my-app-config",
+    );
+    if (!configRepoUrl) return;
+
+    // Source repo is informational — allow empty.
+    const sourceRepoUrl =
+        (await vscode.window.showInputBox({
+            prompt: l10n.t("Application source repository URL (optional — stored as an annotation for traceability)"),
+            placeHolder: "https://github.com/my-org/my-app",
+            ignoreFocusOut: true,
+        })) ?? "";
+
+    const clusterServer = await promptRequired(
+        l10n.t("Target AKS cluster API server URL (use https://kubernetes.default.svc for in-cluster)"),
+        "https://kubernetes.default.svc",
+        "https://kubernetes.default.svc",
+    );
+    if (!clusterServer) return;
+
+    const namespace = await promptRequired(l10n.t("Target Kubernetes namespace"), "default", "default", (v) =>
+        /^[a-z0-9][a-z0-9-]*$/.test(v)
+            ? undefined
+            : l10n.t("Use lowercase letters, digits, and hyphens only (must start with a letter or digit)."),
+    );
+    if (!namespace) return;
+
+    const containerImage = await promptRequired(
+        l10n.t("Container image for deployment.yaml (e.g. myregistry.azurecr.io/my-app:latest)"),
+        `myregistry.azurecr.io/${appName}:latest`,
+        `myregistry.azurecr.io/${appName}:latest`,
+    );
+    if (!containerImage) return;
+
+    const containerPortRaw = await promptRequired(
+        l10n.t("Container port your application listens on"),
+        "8080",
+        "8080",
+        (v) => {
+            const n = Number(v);
+            return Number.isInteger(n) && n > 0 && n <= 65535
+                ? undefined
+                : l10n.t("Enter a valid TCP port number (1–65535).");
+        },
+    );
+    if (!containerPortRaw) return;
+    const containerPort = Number(containerPortRaw);
+
+    // -----------------------------------------------------------------------
+    // 6. Write all four GitOps config files.
+    // -----------------------------------------------------------------------
+    const appPath = `apps/${appName}`;
+    const appDirUri = vscode.Uri.joinPath(targetFolderUri, appPath);
+
+    const readmeUri = vscode.Uri.joinPath(appDirUri, "README.md");
+    const applicationYamlUri = vscode.Uri.joinPath(appDirUri, "application.yaml");
+    const deploymentYamlUri = vscode.Uri.joinPath(appDirUri, "deployment.yaml");
+    const serviceYamlUri = vscode.Uri.joinPath(appDirUri, "service.yaml");
+
+    const applicationYaml = buildArgoCDAppYaml({
+        appName,
+        configRepoUrl,
+        sourceRepoUrl,
+        clusterServer,
+        namespace,
+        appPath,
+    });
+
+    const deploymentYaml = buildDeploymentYaml({ appName, namespace, containerImage, containerPort });
+    const serviceYaml = buildServiceYaml({ appName, namespace, containerPort });
+    const readmeMarkdown = buildReadmeMarkdown({
+        appName,
+        namespace,
+        configRepoUrl,
+        sourceRepoUrl,
+        clusterServer,
+        containerImage,
+        containerPort,
+        appPath,
+    });
+
+    try {
+        await vscode.workspace.fs.createDirectory(appDirUri);
+
+        await Promise.all([
+            vscode.workspace.fs.writeFile(readmeUri, Buffer.from(readmeMarkdown, "utf8")),
+            vscode.workspace.fs.writeFile(applicationYamlUri, Buffer.from(applicationYaml, "utf8")),
+            vscode.workspace.fs.writeFile(deploymentYamlUri, Buffer.from(deploymentYaml, "utf8")),
+            vscode.workspace.fs.writeFile(serviceYamlUri, Buffer.from(serviceYaml, "utf8")),
+        ]);
+
+        // Open README.md first so the user sees the setup guide immediately;
+        // the YAML files are visible alongside it in the explorer tree.
+        await vscode.window.showTextDocument(readmeUri);
+
+        const VIEW_README = l10n.t("Open README.md");
+        const VIEW_DEPLOYMENT = l10n.t("Open deployment.yaml");
+        const VIEW_SERVICE = l10n.t("Open service.yaml");
+
+        const followUp = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Argo CD config scaffolded at {0}/ — 4 files created: README.md, application.yaml, deployment.yaml, service.yaml.\n\nNext steps:\n  1. Review and customise each file.\n  2. git add {0}/ && git commit -m 'feat: argo cd config for {1}'\n  3. argocd app create -f {0}/application.yaml",
+                appPath,
+                appName,
+            ),
+            VIEW_README,
+            VIEW_DEPLOYMENT,
+            VIEW_SERVICE,
+        );
+
+        if (followUp === VIEW_README) {
+            await vscode.window.showTextDocument(readmeUri);
+        } else if (followUp === VIEW_DEPLOYMENT) {
+            await vscode.window.showTextDocument(deploymentYamlUri);
+        } else if (followUp === VIEW_SERVICE) {
+            await vscode.window.showTextDocument(serviceYamlUri);
+        }
+    } catch (err) {
+        vscode.window.showErrorMessage(l10n.t("Failed to create Argo CD config files: {0}", String(err)));
+    }
+}

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -26,6 +26,11 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 import { getExtensionPath } from "../utils/host";
 import { failed } from "../utils/errorable";
+import { createTempFile } from "../utils/tempfile";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { invokeKubectlCommand } from "../utils/kubectl";
+import { NonZeroExitCodeBehaviour } from "../utils/shell";
+import { resolveCurrentKubectlContext } from "./argoCDApplyApp";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -119,7 +124,7 @@ function buildReadmeMarkdown(params: {
 
 ---
 
-## 📌 The Hollywood Principle (GitOps)
+## 📌 The GitOps Principle (Hollywood Principle)
 
 Argo CD follows the **"Don't call us, we'll call you"** (Hollywood) principle of computer science.
 Your AKS cluster **never pushes** changes — Argo CD runs as a controller inside the cluster and
@@ -890,7 +895,7 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     // 3. Show the Hollywood-Principle guidance message (always shown).
     // -----------------------------------------------------------------------
     const warningParts: string[] = [
-        l10n.t("Argo CD — Hollywood Principle (GitOps)"),
+        l10n.t("Argo CD — GitOps (Hollywood Principle)"),
         "",
         l10n.t("Argo CD follows the \"Don't call us, we'll call you\" (Hollywood) principle."),
         l10n.t(
@@ -937,7 +942,7 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
         l10n.t("How would you like to proceed?"),
     );
 
-    const SCAFFOLD_HERE = l10n.t("Scaffold Here");
+    const SCAFFOLD_HERE = l10n.t("Continue to Create ArgoCD Pipeline");
     const OPEN_CONFIG_REPO = l10n.t("Open Config Repository…");
     const LEARN_MORE = l10n.t("Learn More");
 
@@ -977,7 +982,7 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     // 5. Collect parameters via input boxes.
     // -----------------------------------------------------------------------
     const appName = await promptRequired(
-        l10n.t("Application name (used as Argo CD app name and directory name)"),
+        l10n.t("ArgoCD Application (pipeline) name – this is the configuration name for the app deployment)"),
         "my-app",
         undefined,
         (v) =>
@@ -1002,18 +1007,75 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
             false,
         )) ?? "";
 
-    const clusterServer = await promptRequired(
-        l10n.t("Target AKS cluster API server URL (use https://kubernetes.default.svc for in-cluster)"),
-        "https://kubernetes.default.svc",
-        "https://kubernetes.default.svc",
-    );
-    if (!clusterServer) return;
+    // Default to in-cluster — works for the majority of AKS + Argo CD setups.
+    const clusterServer = "https://kubernetes.default.svc";
 
-    const namespace = await promptRequired(l10n.t("Target Kubernetes namespace"), "default", "default", (v) =>
-        /^[a-z0-9][a-z0-9-]*$/.test(v)
-            ? undefined
-            : l10n.t("Use lowercase letters, digits, and hyphens only (must start with a letter or digit)."),
-    );
+    // Fetch namespaces from the active cluster for the QuickPick.
+    // Falls back to a plain input box if kubectl is unavailable.
+    let namespace: string | undefined;
+    const kubectl = await k8s.extension.kubectl.v1;
+    if (kubectl.available) {
+        const ctx = await resolveCurrentKubectlContext(kubectl);
+        if (ctx) {
+            const tmpKubeconfig = await createTempFile(ctx.kubeconfigYaml, "yaml");
+            try {
+                const nsResult = await invokeKubectlCommand(
+                    kubectl,
+                    tmpKubeconfig.filePath,
+                    `get namespace -o json`,
+                    NonZeroExitCodeBehaviour.Succeed,
+                );
+                if (!failed(nsResult) && nsResult.result.stdout.trim()) {
+                    type RawNs = { metadata: { name: string; labels?: Record<string, string> } };
+                    let rawItems: RawNs[] = [];
+                    try {
+                        rawItems = (JSON.parse(nsResult.result.stdout) as { items: RawNs[] }).items ?? [];
+                    } catch {
+                        // fall through to fallback
+                    }
+                    const names = rawItems.map((ns) => ns.metadata.name);
+                    // Ensure "default" is always present and first.
+                    if (!names.includes("default")) {
+                        rawItems.unshift({ metadata: { name: "default", labels: {} } });
+                    }
+                    // Sort: "default" first, then alphabetical.
+                    rawItems.sort((a, b) => {
+                        if (a.metadata.name === "default") return -1;
+                        if (b.metadata.name === "default") return 1;
+                        return a.metadata.name.localeCompare(b.metadata.name);
+                    });
+                    const nsItems: vscode.QuickPickItem[] = rawItems.map((ns) => {
+                        const name = ns.metadata.name;
+                        const labels = ns.metadata.labels ?? {};
+                        let description: string | undefined;
+                        if (name === "default") {
+                            description = l10n.t("recommended default");
+                        } else if (labels["headlamp.dev/project-managed-by"] === "aks-desktop") {
+                            description = l10n.t("(AKS desktop Project: {0})", name);
+                        }
+                        return { label: name, description };
+                    });
+                    const picked = (await vscode.window.showQuickPick(nsItems, {
+                        title: l10n.t("Target Kubernetes namespace"),
+                        placeHolder: "default",
+                        ignoreFocusOut: true,
+                    })) as vscode.QuickPickItem | undefined;
+                    namespace = picked?.label;
+                }
+            } finally {
+                tmpKubeconfig.dispose();
+            }
+        }
+    }
+
+    // Fallback: plain input box when kubectl is unavailable or returned no namespaces.
+    if (namespace === undefined) {
+        namespace = await promptRequired(l10n.t("Target Kubernetes namespace"), "default", "default", (v) =>
+            /^[a-z0-9][a-z0-9-]*$/.test(v)
+                ? undefined
+                : l10n.t("Use lowercase letters, digits, and hyphens only (must start with a letter or digit)."),
+        );
+    }
     if (!namespace) return;
 
     // -----------------------------------------------------------------------
@@ -1051,23 +1113,15 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
             vscode.workspace.fs.writeFile(applicationYamlUri, Buffer.from(applicationYaml, "utf8")),
         ]);
 
-        // Open README.md first so the user sees the setup guide immediately.
-        await vscode.window.showTextDocument(readmeUri);
+        // Open README.md in the first column and application.yaml beside it.
+        // Opening application.yaml triggers the onDidOpenTextDocument listener
+        // which immediately offers "Apply to Cluster" as a bottom-right notification.
+        await vscode.window.showTextDocument(readmeUri, { viewColumn: vscode.ViewColumn.One });
+        await vscode.window.showTextDocument(applicationYamlUri, { viewColumn: vscode.ViewColumn.Two });
 
-        const VIEW_README = l10n.t("Open README.md");
-        const VIEW_APPLICATION = l10n.t("Open application.yaml");
-
-        const followUp = await vscode.window.showInformationMessage(
+        vscode.window.showInformationMessage(
             l10n.t("✓ Argo CD config ready at {0}/ — README.md, application.yaml", appPath),
-            VIEW_README,
-            VIEW_APPLICATION,
         );
-
-        if (followUp === VIEW_README) {
-            await vscode.window.showTextDocument(readmeUri);
-        } else if (followUp === VIEW_APPLICATION) {
-            await vscode.window.showTextDocument(applicationYamlUri);
-        }
     } catch (err) {
         vscode.window.showErrorMessage(l10n.t("Failed to create Argo CD config files: {0}", String(err)));
     }

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -895,15 +895,18 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     // 3. Show the Hollywood-Principle guidance message (always shown).
     // -----------------------------------------------------------------------
     const warningParts: string[] = [
-        l10n.t("Argo CD — GitOps (Hollywood Principle)"),
+        l10n.t("GitOps pipeline using ArgoCD (Hollywood Principle)"),
         "",
-        l10n.t("Argo CD follows the \"Don't call us, we'll call you\" (Hollywood) principle."),
         l10n.t(
-            "Your AKS cluster does NOT push changes — Argo CD continuously PULLS desired state from a Git repository and reconciles it automatically.",
+            "This will install an ArgoCD application configuration (pipeline) on your cluster. Argo will pull from your repository to get the K8s manifests and apply them — it will continually check for updates thereafter and apply.",
         ),
         "",
+        l10n.t("Note:"),
         l10n.t(
-            "This means your Argo CD Application manifest MUST live in a dedicated GitOps config repository, separate from your application source code.",
+            "• ArgoCD application configurations are not maintained with application code and MUST reside outside of the application in a dedicated GitOps config repository.",
+        ),
+        l10n.t(
+            "• You must have K8s application manifests in your repo. If you do not, run 'Migrate Application to AKS' and generate the manifests.",
         ),
     ];
 

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -24,7 +24,7 @@ import * as fs from "fs";
 import { generateKeyPairSync } from "crypto";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
-import { getExtensionPath } from "../utils/host";
+import { getExtensionPath, longRunning } from "../utils/host";
 import { failed } from "../utils/errorable";
 import { createTempFile } from "../utils/tempfile";
 import * as k8s from "vscode-kubernetes-tools-api";
@@ -355,6 +355,13 @@ argocd app history ${params.appName}
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Well-known Kubernetes system namespaces to filter out of the namespace picker. */
+const SYSTEM_NAMESPACES = new Set(["kube-system", "kube-public", "kube-node-lease", "gatekeeper-system", "argocd"]);
+
+function isSystemNamespace(name: string): boolean {
+    return SYSTEM_NAMESPACES.has(name);
+}
 
 /**
  * Returns true if any well-known application source file is found in the
@@ -1022,11 +1029,13 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
         if (ctx) {
             const tmpKubeconfig = await createTempFile(ctx.kubeconfigYaml, "yaml");
             try {
-                const nsResult = await invokeKubectlCommand(
-                    kubectl,
-                    tmpKubeconfig.filePath,
-                    `get namespace -o json`,
-                    NonZeroExitCodeBehaviour.Succeed,
+                const nsResult = await longRunning(l10n.t("Loading cluster namespaces..."), () =>
+                    invokeKubectlCommand(
+                        kubectl,
+                        tmpKubeconfig.filePath,
+                        `get namespace -o json`,
+                        NonZeroExitCodeBehaviour.Succeed,
+                    ),
                 );
                 if (!failed(nsResult) && nsResult.result.stdout.trim()) {
                     type RawNs = { metadata: { name: string; labels?: Record<string, string> } };
@@ -1036,8 +1045,12 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
                     } catch {
                         // fall through to fallback
                     }
+                    // Filter out system namespaces, keep "default".
+                    rawItems = rawItems.filter(
+                        (ns) => ns.metadata.name === "default" || !isSystemNamespace(ns.metadata.name),
+                    );
                     const names = rawItems.map((ns) => ns.metadata.name);
-                    // Ensure "default" is always present and first.
+                    // Ensure "default" is always present.
                     if (!names.includes("default")) {
                         rawItems.unshift({ metadata: { name: "default", labels: {} } });
                     }
@@ -1051,18 +1064,18 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
                         const name = ns.metadata.name;
                         const labels = ns.metadata.labels ?? {};
                         let description: string | undefined;
-                        if (name === "default") {
-                            description = l10n.t("recommended default");
-                        } else if (labels["headlamp.dev/project-managed-by"] === "aks-desktop") {
+                        if (labels["headlamp.dev/project-managed-by"] === "aks-desktop") {
                             description = l10n.t("(AKS desktop Project: {0})", name);
+                        } else if (name === "default") {
+                            description = l10n.t("recommended default");
                         }
                         return { label: name, description };
                     });
-                    const picked = (await vscode.window.showQuickPick(nsItems, {
-                        title: l10n.t("Target Kubernetes namespace"),
-                        placeHolder: "default",
+                    const picked = await vscode.window.showQuickPick(nsItems, {
+                        title: l10n.t("Namespace ({0} available)", nsItems.length),
+                        placeHolder: l10n.t("Select a Kubernetes namespace"),
                         ignoreFocusOut: true,
-                    })) as vscode.QuickPickItem | undefined;
+                    });
                     namespace = picked?.label;
                 }
             } finally {

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -164,9 +164,11 @@ ${params.appPath}/
 > **Where are \`Deployment\` and \`Service\` manifests?**
 > These manifests are **intentionally not scaffolded here**. They belong in your
 > **application source repository** alongside your application code. The \`spec.source\`
-> in \`application.yaml\` points Argo CD at the source repo path where those manifests live.
-> This preserves GitOps separation of concerns: the config repo tracks Argo CD
-> applications, while the app repo owns the workload manifests.
+> in \`application.yaml\` points Argo CD at **this config repo** path where the
+> Application CR lives. Update the \`spec.source.path\` to reference the directory
+> containing your Kubernetes workload manifests (deployment, service, etc.) —
+> these can live in this config repo or in a separate source repo depending on
+> your GitOps layout.
 
 ---
 
@@ -992,7 +994,7 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     // 5. Collect parameters via input boxes.
     // -----------------------------------------------------------------------
     const appName = await promptRequired(
-        l10n.t("ArgoCD Application (pipeline) name – this is the configuration name for the app deployment)"),
+        l10n.t("Argo CD Application (pipeline) name – this is the configuration name for the app deployment"),
         "my-app",
         undefined,
         (v) =>

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -215,7 +215,27 @@ helm install argocd argo/argo-cd \\
 
 ---
 
-## 🔑 Step 2 — Access the Argo CD UI & CLI
+## 🔑 Step 2 — Access the Argo CD UI
+
+The login method depends on how Argo CD was installed:
+
+### Option A — Microsoft.ArgoCD extension (Azure k8s-extension) — Microsoft SSO
+
+If Argo CD was installed via the Azure k8s-extension (\`az k8s-extension create --extension-type Microsoft.ArgoCD\`
+with workload identity), the UI is protected by **Microsoft Entra ID**.
+No admin password is required — your browser will redirect to the standard
+Microsoft sign-in page automatically.
+
+\`\`\`bash
+# Port-forward to access the UI locally (if no LoadBalancer ingress is configured)
+kubectl -n argocd port-forward svc/argocd-server 8080:443
+# Open: https://localhost:8080  — sign in with your Microsoft account
+\`\`\`
+
+### Option B — OSS / self-managed install — admin password
+
+If Argo CD was installed manually (kubectl apply or Helm), retrieve the
+auto-generated initial admin password:
 
 \`\`\`bash
 # Get the initial admin password
@@ -228,6 +248,9 @@ kubectl -n argocd port-forward svc/argocd-server 8080:443
 # Log in via CLI
 argocd login localhost:8080 --username admin --insecure
 \`\`\`
+
+> **Tip**: The VS Code AKS extension auto-detects the auth mode and adjusts the
+> "Open Argo CD UI" action accordingly — no manual credential lookup needed.
 
 ---
 

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -97,156 +97,6 @@ function buildArgoCDAppYaml(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Kubernetes Deployment YAML template
-// ---------------------------------------------------------------------------
-
-function buildDeploymentYaml(params: {
-    appName: string;
-    namespace: string;
-    containerImage: string;
-    containerPort: number;
-}): string {
-    return `# =============================================================================
-# Kubernetes Deployment manifest
-# =============================================================================
-#
-# This file is managed by Argo CD (GitOps).
-#
-# ⚠️  Do NOT apply this file manually with kubectl unless you intentionally
-# want to create a temporary drift that Argo CD will immediately reconcile.
-#
-# Edit here → commit to this GitOps config repo → Argo CD detects the change
-# and rolls it out to the AKS cluster automatically.
-#
-# =============================================================================
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ${params.appName}
-  namespace: ${params.namespace}
-  labels:
-    app: ${params.appName}
-    app.kubernetes.io/name: ${params.appName}
-    app.kubernetes.io/managed-by: argocd
-spec:
-  # Number of pod replicas — increase for high availability.
-  replicas: 2
-
-  selector:
-    matchLabels:
-      app: ${params.appName}
-
-  template:
-    metadata:
-      labels:
-        app: ${params.appName}
-        app.kubernetes.io/name: ${params.appName}
-    spec:
-      # -----------------------------------------------------------------------
-      # Security context: run as non-root by default.
-      # Adjust or remove if your container requires root.
-      # -----------------------------------------------------------------------
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-
-      containers:
-        - name: ${params.appName}
-          # Replace this with your actual container image.
-          # Argo CD will roll out a new version whenever this tag changes in Git.
-          image: ${params.containerImage}
-          imagePullPolicy: Always
-
-          ports:
-            - name: http
-              containerPort: ${params.containerPort}
-              protocol: TCP
-
-          # Least-privilege container security settings.
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-
-          # ----------------------------------------------------------------
-          # Resource limits — tune to your workload.
-          # ----------------------------------------------------------------
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
-              cpu: "500m"
-              memory: "512Mi"
-
-          # ----------------------------------------------------------------
-          # Probes — adjust paths / commands to match your application.
-          # ----------------------------------------------------------------
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 5
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 15
-            periodSeconds: 10
-`;
-}
-
-// ---------------------------------------------------------------------------
-// Kubernetes Service YAML template
-// ---------------------------------------------------------------------------
-
-function buildServiceYaml(params: { appName: string; namespace: string; containerPort: number }): string {
-    return `# =============================================================================
-# Kubernetes Service manifest
-# =============================================================================
-#
-# This file is managed by Argo CD (GitOps).
-# Edit here → commit → Argo CD reconciles the change to the AKS cluster.
-#
-# =============================================================================
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${params.appName}
-  namespace: ${params.namespace}
-  labels:
-    app: ${params.appName}
-    app.kubernetes.io/name: ${params.appName}
-    app.kubernetes.io/managed-by: argocd
-spec:
-  # ClusterIP   — internal cluster traffic only (default, most secure).
-  # LoadBalancer — expose directly via Azure Load Balancer (public IP).
-  # NodePort    — expose on a node port (rarely used with AKS).
-  #
-  # Change to LoadBalancer if you need external access.
-  type: ClusterIP
-
-  selector:
-    app: ${params.appName}
-
-  ports:
-    - name: http
-      protocol: TCP
-      # External port clients connect to.
-      port: 80
-      # Must match containerPort in deployment.yaml.
-      targetPort: ${params.containerPort}
-`;
-}
-
-// ---------------------------------------------------------------------------
 // README template
 // ---------------------------------------------------------------------------
 
@@ -256,8 +106,6 @@ function buildReadmeMarkdown(params: {
     configRepoUrl: string;
     sourceRepoUrl: string;
     clusterServer: string;
-    containerImage: string;
-    containerPort: number;
     appPath: string;
 }): string {
     const sourceRepoLine = params.sourceRepoUrl
@@ -301,16 +149,19 @@ to match what is declared here.
 \`\`\`
 ${params.appPath}/
 ├── README.md            ← you are here
-├── application.yaml     ← Argo CD Application CR (tells Argo CD what to watch)
-├── deployment.yaml      ← Kubernetes Deployment (your workload)
-└── service.yaml         ← Kubernetes Service (network exposure)
+└── application.yaml     ← Argo CD Application CR (tells Argo CD what to watch)
 \`\`\`
 
 | File | Purpose |
 |------|---------|
 | \`application.yaml\` | Registers this app with Argo CD. Points at this config repo path. |
-| \`deployment.yaml\` | Describes your container workload, replicas, probes, resource limits. |
-| \`service.yaml\` | Exposes the workload inside (or outside) the cluster. |
+
+> **Where are \`Deployment\` and \`Service\` manifests?**
+> These manifests are **intentionally not scaffolded here**. They belong in your
+> **application source repository** alongside your application code. The \`spec.source\`
+> in \`application.yaml\` points Argo CD at the source repo path where those manifests live.
+> This preserves GitOps separation of concerns: the config repo tracks Argo CD
+> applications, while the app repo owns the workload manifests.
 
 ---
 
@@ -323,8 +174,6 @@ ${params.appPath}/
 | ${sourceRepoLine} |
 | Target cluster | \`${params.clusterServer}\` |
 | Target namespace | \`${params.namespace}\` |
-| Container image | \`${params.containerImage}\` |
-| Container port | \`${params.containerPort}\` |
 
 ---
 
@@ -417,8 +266,8 @@ Because Argo CD follows the Hollywood Principle, **you never \`kubectl apply\` d
 The workflow is always:
 
 \`\`\`
-1.  Edit a file in this repo  (e.g. bump the image tag in deployment.yaml)
-2.  git commit -m 'chore: bump ${params.appName} image to v1.2.3'
+1.  Edit a file in this repo  (e.g. update the sync policy in application.yaml)
+2.  git commit -m 'chore: update argo cd config for ${params.appName}'
 3.  git push
 4.  Argo CD detects the change (default poll: 3 min, or via webhook — see below)
 5.  Argo CD applies the diff to the AKS cluster automatically
@@ -1054,13 +903,13 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
 
     warningParts.push(
         "",
-        l10n.t("Recommended GitOps config repo layout (4 files will be scaffolded):"),
+        l10n.t("Recommended GitOps config repo layout (2 files will be scaffolded):"),
         l10n.t("  config-repo/"),
         l10n.t("  └── apps/<app-name>/"),
         l10n.t("      ├── README.md         ← install guide + how it all fits together"),
-        l10n.t("      ├── application.yaml  ← Argo CD Application CR"),
-        l10n.t("      ├── deployment.yaml   ← Kubernetes Deployment"),
-        l10n.t("      └── service.yaml      ← Kubernetes Service"),
+        l10n.t("      └── application.yaml  ← Argo CD Application CR"),
+        "",
+        l10n.t("Note: Deployment and Service manifests belong in the application source repository."),
         "",
         l10n.t("How would you like to proceed?"),
     );
@@ -1144,37 +993,14 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
     );
     if (!namespace) return;
 
-    const containerImage = await promptRequired(
-        l10n.t("Container image for deployment.yaml (e.g. myregistry.azurecr.io/my-app:latest)"),
-        `myregistry.azurecr.io/${appName}:latest`,
-        `myregistry.azurecr.io/${appName}:latest`,
-    );
-    if (!containerImage) return;
-
-    const containerPortRaw = await promptRequired(
-        l10n.t("Container port your application listens on"),
-        "8080",
-        "8080",
-        (v) => {
-            const n = Number(v);
-            return Number.isInteger(n) && n > 0 && n <= 65535
-                ? undefined
-                : l10n.t("Enter a valid TCP port number (1–65535).");
-        },
-    );
-    if (!containerPortRaw) return;
-    const containerPort = Number(containerPortRaw);
-
     // -----------------------------------------------------------------------
-    // 6. Write all four GitOps config files.
+    // 6. Write the GitOps config files.
     // -----------------------------------------------------------------------
     const appPath = `apps/${appName}`;
     const appDirUri = vscode.Uri.joinPath(targetFolderUri, appPath);
 
     const readmeUri = vscode.Uri.joinPath(appDirUri, "README.md");
     const applicationYamlUri = vscode.Uri.joinPath(appDirUri, "application.yaml");
-    const deploymentYamlUri = vscode.Uri.joinPath(appDirUri, "deployment.yaml");
-    const serviceYamlUri = vscode.Uri.joinPath(appDirUri, "service.yaml");
 
     const applicationYaml = buildArgoCDAppYaml({
         appName,
@@ -1185,16 +1011,12 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
         appPath,
     });
 
-    const deploymentYaml = buildDeploymentYaml({ appName, namespace, containerImage, containerPort });
-    const serviceYaml = buildServiceYaml({ appName, namespace, containerPort });
     const readmeMarkdown = buildReadmeMarkdown({
         appName,
         namespace,
         configRepoUrl,
         sourceRepoUrl,
         clusterServer,
-        containerImage,
-        containerPort,
         appPath,
     });
 
@@ -1204,35 +1026,28 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
         await Promise.all([
             vscode.workspace.fs.writeFile(readmeUri, Buffer.from(readmeMarkdown, "utf8")),
             vscode.workspace.fs.writeFile(applicationYamlUri, Buffer.from(applicationYaml, "utf8")),
-            vscode.workspace.fs.writeFile(deploymentYamlUri, Buffer.from(deploymentYaml, "utf8")),
-            vscode.workspace.fs.writeFile(serviceYamlUri, Buffer.from(serviceYaml, "utf8")),
         ]);
 
-        // Open README.md first so the user sees the setup guide immediately;
-        // the YAML files are visible alongside it in the explorer tree.
+        // Open README.md first so the user sees the setup guide immediately.
         await vscode.window.showTextDocument(readmeUri);
 
         const VIEW_README = l10n.t("Open README.md");
-        const VIEW_DEPLOYMENT = l10n.t("Open deployment.yaml");
-        const VIEW_SERVICE = l10n.t("Open service.yaml");
+        const VIEW_APPLICATION = l10n.t("Open application.yaml");
 
         const followUp = await vscode.window.showInformationMessage(
             l10n.t(
-                "Argo CD config scaffolded at {0}/ — 4 files created: README.md, application.yaml, deployment.yaml, service.yaml.\n\nNext steps:\n  1. Review and customise each file.\n  2. git add {0}/ && git commit -m 'feat: argo cd config for {1}'\n  3. argocd app create -f {0}/application.yaml",
+                "Argo CD config scaffolded at {0}/ — 2 files created: README.md, application.yaml.\n\nNext steps:\n  1. Add your Deployment and Service manifests to the application source repository.\n  2. git add {0}/ && git commit -m 'feat: argo cd config for {1}'\n  3. argocd app create -f {0}/application.yaml",
                 appPath,
                 appName,
             ),
             VIEW_README,
-            VIEW_DEPLOYMENT,
-            VIEW_SERVICE,
+            VIEW_APPLICATION,
         );
 
         if (followUp === VIEW_README) {
             await vscode.window.showTextDocument(readmeUri);
-        } else if (followUp === VIEW_DEPLOYMENT) {
-            await vscode.window.showTextDocument(deploymentYamlUri);
-        } else if (followUp === VIEW_SERVICE) {
-            await vscode.window.showTextDocument(serviceYamlUri);
+        } else if (followUp === VIEW_APPLICATION) {
+            await vscode.window.showTextDocument(applicationYamlUri);
         }
     } catch (err) {
         vscode.window.showErrorMessage(l10n.t("Failed to create Argo CD config files: {0}", String(err)));

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -21,6 +21,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import { generateKeyPairSync } from "crypto";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as l10n from "@vscode/l10n";
 import { getExtensionPath } from "../utils/host";
@@ -560,11 +561,238 @@ function detectGitRemoteUrl(folderFsPath: string): string | undefined {
 // ---------------------------------------------------------------------------
 
 interface GitHubRepo {
+    id: number;
+    name: string;
     full_name: string;
     clone_url: string;
     ssh_url: string;
     private: boolean;
     description: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// SSH deploy key helpers (used as the primary credential strategy)
+// ---------------------------------------------------------------------------
+
+interface SshDeployKeyPair {
+    /** PKCS8 PEM private key — stored in the Argo CD repository Secret. */
+    privateKeyPem: string;
+    /** OpenSSH authorized_keys format public key — registered on GitHub. */
+    publicKeySsh: string;
+}
+
+/**
+ * Generates an Ed25519 key pair suitable for use as a GitHub deploy key.
+ *
+ * Private key is returned in PKCS8 PEM format, which git/OpenSSH accepts
+ * as an identity file and which Argo CD stores in the repository Secret.
+ * Public key is returned in OpenSSH authorized_keys format for the GitHub API.
+ *
+ * Ed25519 SPKI DER layout (44 bytes):
+ *   SEQUENCE { AlgorithmIdentifier { OID(id-EdDSA) }, BIT_STRING(0x00 + 32 raw bytes) }
+ *   Offsets: [30 26] [30 05] [06 03 2B 65 70] [03 21] [00] <32 raw bytes at offset 12>
+ */
+export function generateSshDeployKeyPair(): SshDeployKeyPair {
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+        privateKeyEncoding: { type: "pkcs8", format: "pem" },
+        publicKeyEncoding: { type: "spki", format: "der" },
+    });
+
+    // Extract the 32-byte raw public key from offset 12 of the 44-byte SPKI DER.
+    const rawPub = publicKey.slice(12);
+
+    // Build the SSH wire format: length-prefixed algo name + length-prefixed key bytes.
+    const algoBytes = Buffer.from("ssh-ed25519", "utf8");
+    const wire = Buffer.alloc(4 + algoBytes.length + 4 + rawPub.length);
+    let offset = 0;
+    wire.writeUInt32BE(algoBytes.length, offset);
+    offset += 4;
+    algoBytes.copy(wire, offset);
+    offset += algoBytes.length;
+    wire.writeUInt32BE(rawPub.length, offset);
+    offset += 4;
+    rawPub.copy(wire, offset);
+
+    return {
+        privateKeyPem: privateKey,
+        publicKeySsh: `ssh-ed25519 ${wire.toString("base64")} argocd-deploy-key`,
+    };
+}
+
+/**
+ * Registers a read-only SSH deploy key on the GitHub repository via the REST API.
+ * Requires an OAuth token with the `repo` scope.
+ *
+ * Returns the created key's ID and title, or `undefined` on failure.
+ *
+ * Reference: https://docs.github.com/en/rest/deploy-keys/deploy-keys#create-a-deploy-key
+ */
+export async function createGitHubDeployKey(
+    accessToken: string,
+    owner: string,
+    repoSlug: string,
+    publicKeySsh: string,
+): Promise<{ id: number; title: string } | undefined> {
+    const title = `argocd-deploy-key-${new Date().toISOString().slice(0, 10)}`;
+    try {
+        const response = await fetch(`https://api.github.com/repos/${owner}/${repoSlug}/keys`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ title, key: publicKeySsh, read_only: true }),
+        });
+        if (!response.ok) return undefined;
+        const data = (await response.json()) as { id: number };
+        return { id: data.id, title };
+    } catch {
+        return undefined;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fine-grained PAT helper (best-effort; requires classic token scope)
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to create a fine-grained personal access token via the GitHub REST
+ * API.  This requires the authenticating token to be a **classic personal
+ * access token** with the `manage_user:personal_access_tokens` scope —
+ * a VS Code OAuth app token cannot satisfy this requirement, so this call
+ * will typically fail and `createGitHubDeployKey` is used as the fallback.
+ *
+ * Returns the raw token string on success, or `undefined` on failure.
+ *
+ * Reference: https://docs.github.com/en/rest/user/personal-access-tokens
+ */
+export async function generateGitHubRepoScopedPat(
+    accessToken: string,
+    repoId: number,
+    repoName: string,
+): Promise<string | undefined> {
+    // Sanitise the name to match GitHub's token-name constraints.
+    const tokenName = `argocd-${repoName}-24h`
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/-{2,}/g, "-")
+        .replace(/-+$/g, "")
+        .slice(0, 40);
+
+    try {
+        const response = await fetch("https://api.github.com/user/personal-access-tokens", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                name: tokenName,
+                expiration: 1, // 1 day ≈ 24 hours
+                repository_ids: [repoId], // limit to this repo only
+                permissions: {
+                    contents: "read",
+                },
+            }),
+        });
+
+        if (!response.ok) {
+            return undefined;
+        }
+
+        const data = (await response.json()) as { token?: string };
+        return data.token ?? undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * When a private GitHub repository is selected with HTTPS transport, offers
+ * to auto-generate a 24-hour fine-grained PAT via the GitHub API.
+ *
+ * • On API success  — shows the token once in a modal with a "Copy" button.
+ * • On API failure  — guides the user to create one manually at
+ *   https://github.com/settings/personal-access-tokens/new and explains the
+ *   minimum required settings.
+ *
+ * The function is intentionally fire-and-forget from the caller: errors are
+ * surfaced as VS Code notifications and the main browse flow always continues.
+ */
+async function offerPrivateRepoPatGeneration(session: vscode.AuthenticationSession, repo: GitHubRepo): Promise<void> {
+    const GENERATE = l10n.t("Generate credentials");
+    const SKIP = l10n.t("Skip");
+
+    const choice = await vscode.window.showInformationMessage(
+        l10n.t(
+            "'{0}' is a private repository. Argo CD will need credentials to pull from it.\n\nWould you like to auto-generate read-only, repo-scoped credentials?",
+            repo.full_name,
+        ),
+        { modal: true },
+        GENERATE,
+        SKIP,
+    );
+
+    if (choice !== GENERATE) {
+        return;
+    }
+
+    // Strategy 1: fine-grained PAT (24h) — requires a classic PAT with
+    // manage_user:personal_access_tokens scope; a VS Code OAuth token won't work here.
+    const patToken = await generateGitHubRepoScopedPat(session.accessToken, repo.id, repo.name);
+
+    if (patToken) {
+        const COPY = l10n.t("Copy PAT");
+        const action = await vscode.window.showInformationMessage(
+            l10n.t(
+                "GitHub PAT generated for '{0}'.\n\nThis token expires in 24 hours and has read-only access to this repository only. It will not be shown again.\n\nUse it as the password when registering this repo with Argo CD:\n  argocd repo add {1} --username git --password <PAT>\n\nor via the 'Register Repo Credentials' action after applying the application.",
+                repo.full_name,
+                repo.clone_url,
+            ),
+            { modal: true },
+            COPY,
+        );
+        if (action === COPY) {
+            await vscode.env.clipboard.writeText(patToken);
+            vscode.window.showInformationMessage(l10n.t("GitHub PAT copied to clipboard."));
+        }
+        return;
+    }
+
+    // Strategy 2: Guide the user to create a fine-grained PAT manually on GitHub,
+    // then copy it to clipboard ready for 'Register Repo Credentials'.
+    const [owner] = repo.full_name.split("/");
+    const tokenName = `argocd-${repo.name}-24h`
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/-{2,}/g, "-")
+        .replace(/-+$/g, "")
+        .slice(0, 40);
+
+    const patUrl = `https://github.com/settings/personal-access-tokens/new?description=${encodeURIComponent(tokenName)}`;
+
+    const OPEN_GITHUB = l10n.t("Open GitHub \u2192");
+    const guided = await vscode.window.showInformationMessage(
+        l10n.t(
+            "Create a fine-grained GitHub PAT with these exact settings:\n\n" +
+                "  \u2022 Token name:  {0}  (pre-filled)\n" +
+                "  \u2022 Expiration:  Custom \u2192 1 day\n" +
+                "  \u2022 Repository access:  Only select \u2018{1}/{2}\u2019\n" +
+                "  \u2022 Permissions \u2192 Contents: Read-only\n" +
+                "  \u2022 Permissions \u2192 Metadata: Read-only\n\n" +
+                "After generating, use \u2018Register Repo Credentials\u2019 in the AKS extension to register it with Argo CD automatically.",
+            tokenName,
+            owner,
+            repo.name,
+        ),
+        { modal: true },
+        OPEN_GITHUB,
+    );
+    if (guided === OPEN_GITHUB) {
+        await vscode.env.openExternal(vscode.Uri.parse(patUrl));
+    }
 }
 
 /**
@@ -652,6 +880,12 @@ async function browseGitHubRepos(title: string): Promise<string | undefined> {
             ignoreFocusOut: true,
         },
     );
+
+    // If the repo is private and HTTPS was chosen, offer to auto-generate a
+    // 24-hour fine-grained PAT so the user has credentials ready for Argo CD.
+    if (repoPick.repo.private && formatPick?.label === "HTTPS") {
+        await offerPrivateRepoPatGeneration(session, repoPick.repo);
+    }
 
     return formatPick?.url;
 }

--- a/src/commands/aksArgoCD/argoCDDeployment.ts
+++ b/src/commands/aksArgoCD/argoCDDeployment.ts
@@ -1058,11 +1058,7 @@ export async function draftArgoCDDeployment(_context: IActionContext, target: un
         const VIEW_APPLICATION = l10n.t("Open application.yaml");
 
         const followUp = await vscode.window.showInformationMessage(
-            l10n.t(
-                "Argo CD config scaffolded at {0}/ — 2 files created: README.md, application.yaml.\n\nNext steps:\n  1. Add your Deployment and Service manifests to the application source repository.\n  2. git add {0}/ && git commit -m 'feat: argo cd config for {1}'\n  3. argocd app create -f {0}/application.yaml",
-                appPath,
-                appName,
-            ),
+            l10n.t("✓ Argo CD config ready at {0}/ — README.md, application.yaml", appPath),
             VIEW_README,
             VIEW_APPLICATION,
         );

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -1,16 +1,14 @@
 /**
  * Argo CD cluster-side commands.
  *
- * Provides two commands triggered from the AKS cluster tree (right-click):
- *
- *  • aks.argoCDInstall      — install Argo CD into the `argocd` namespace of the
- *                             selected cluster using the official stable manifests
+ * Provides the following command triggered from the AKS cluster tree (right-click):
  *
  *  • aks.argoCDCheckStatus  — probe whether Argo CD is installed and show a quick
  *                             summary of pod health in an output channel
  *
- * Both commands follow the same kubectl-via-kubeconfig pattern used throughout
- * this extension (e.g. aksKubectlCommands.ts).
+ * Argo CD must be pre-installed on the cluster by the user (DevOps engineer)
+ * before using the Argo CD deploy scenario.  If Argo CD is not detected, the
+ * user is notified and asked to install it manually.
  *
  * Reference: https://argo-cd.readthedocs.io/en/stable/getting_started/
  */
@@ -32,93 +30,7 @@ import { NonZeroExitCodeBehaviour } from "../utils/shell";
 // Constants
 // ---------------------------------------------------------------------------
 
-const ARGOCD_INSTALL_URL = "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml";
-
 const ARGOCD_NAMESPACE = "argocd";
-
-// Lazy-created output channel — shared between both commands.
-let argoCDOutputChannel: vscode.OutputChannel | undefined;
-
-export function getOutputChannel(): vscode.OutputChannel {
-    if (!argoCDOutputChannel) {
-        argoCDOutputChannel = vscode.window.createOutputChannel("Argo CD");
-    }
-    return argoCDOutputChannel;
-}
-
-// ---------------------------------------------------------------------------
-// Shared core: run the actual Argo CD install steps (no cluster resolution,
-// no UX prompts — just the kubectl work).  Called both from argoCDInstall and
-// from argoCDApplyApp when the user asks to install inline.
-// Returns true if the install succeeded.
-// ---------------------------------------------------------------------------
-
-export async function performArgoCDInstall(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeconfigFile: string,
-    clusterName: string,
-    channel: vscode.OutputChannel,
-): Promise<boolean> {
-    channel.show(true);
-    channel.appendLine(`\n[Argo CD Install] Cluster: ${clusterName}`);
-    channel.appendLine(`[Argo CD Install] Step 1/2 — Ensuring namespace '${ARGOCD_NAMESPACE}' exists…`);
-
-    const createNsResult = await longRunning(l10n.t("Creating namespace '{0}'…", ARGOCD_NAMESPACE), () =>
-        invokeKubectlCommand(
-            kubectl,
-            kubeconfigFile,
-            `create namespace ${ARGOCD_NAMESPACE}`,
-            NonZeroExitCodeBehaviour.Succeed,
-        ),
-    );
-
-    if (failed(createNsResult)) {
-        channel.appendLine(`[Argo CD Install] ERROR: ${createNsResult.error}`);
-        vscode.window.showErrorMessage(
-            l10n.t("Failed to create namespace '{0}': {1}", ARGOCD_NAMESPACE, createNsResult.error),
-        );
-        return false;
-    }
-    channel.appendLine(`[Argo CD Install]   ${createNsResult.result.stdout.trim() || "namespace ready"}`);
-
-    channel.appendLine(`[Argo CD Install] Step 2/2 — Applying Argo CD manifests (server-side apply)…`);
-    channel.appendLine(`[Argo CD Install]   Source: ${ARGOCD_INSTALL_URL}`);
-
-    const applyResult = await longRunning(
-        l10n.t("Installing Argo CD on {0} (this may take a minute)…", clusterName),
-        () =>
-            invokeKubectlCommand(
-                kubectl,
-                kubeconfigFile,
-                `apply -n ${ARGOCD_NAMESPACE} --server-side --force-conflicts -f ${ARGOCD_INSTALL_URL}`,
-            ),
-    );
-
-    if (failed(applyResult)) {
-        channel.appendLine(`[Argo CD Install] ERROR: ${applyResult.error}`);
-        vscode.window.showErrorMessage(l10n.t("Argo CD installation failed: {0}", applyResult.error));
-        return false;
-    }
-
-    channel.appendLine(`[Argo CD Install]   Resources applied OK.`);
-    await showArgoCDStatus(kubectl, kubeconfigFile, clusterName, channel);
-    return true;
-}
-
-// ---------------------------------------------------------------------------
-// Helper: check whether the argocd namespace (and at least one pod) exists
-// ---------------------------------------------------------------------------
-
-async function isArgoCDInstalled(kubectl: k8s.APIAvailable<k8s.KubectlV1>, kubeConfigFile: string): Promise<boolean> {
-    const result = await invokeKubectlCommand(
-        kubectl,
-        kubeConfigFile,
-        `get namespace ${ARGOCD_NAMESPACE} --ignore-not-found -o name`,
-        NonZeroExitCodeBehaviour.Succeed,
-    );
-    if (failed(result)) return false;
-    return result.result.stdout.trim().length > 0;
-}
 
 // ---------------------------------------------------------------------------
 // Shared setup: resolve cluster + kubeconfig from tree context
@@ -158,89 +70,14 @@ async function resolveCluster(target: unknown) {
     return { kubectl, clusterInfo: clusterInfo.result };
 }
 
-// ---------------------------------------------------------------------------
-// Command: Install Argo CD
-// ---------------------------------------------------------------------------
+// Lazy-created output channel — shared between commands.
+let argoCDOutputChannel: vscode.OutputChannel | undefined;
 
-export async function argoCDInstall(_context: IActionContext, target: unknown): Promise<void> {
-    const resolved = await resolveCluster(target);
-    if (!resolved) return;
-
-    const { kubectl, clusterInfo } = resolved;
-    const channel = getOutputChannel();
-
-    await withOptionalTempFile(clusterInfo.kubeconfigYaml, "yaml", async (kubeconfigFile) => {
-        // ------------------------------------------------------------------
-        // 1. Check if Argo CD is already installed.
-        // ------------------------------------------------------------------
-        const alreadyInstalled = await longRunning(
-            l10n.t("Checking if Argo CD is already installed on {0}…", clusterInfo.name),
-            () => isArgoCDInstalled(kubectl, kubeconfigFile),
-        );
-
-        if (alreadyInstalled) {
-            const REINSTALL = l10n.t("Reinstall / Upgrade");
-            const CHECK_STATUS = l10n.t("Check Status Instead");
-            const choice = await vscode.window.showInformationMessage(
-                l10n.t(
-                    "Argo CD is already installed in the '{0}' namespace on cluster '{1}'.",
-                    ARGOCD_NAMESPACE,
-                    clusterInfo.name,
-                ),
-                REINSTALL,
-                CHECK_STATUS,
-            );
-            if (!choice || choice === CHECK_STATUS) {
-                await showArgoCDStatus(kubectl, kubeconfigFile, clusterInfo.name, channel);
-                return;
-            }
-            // fall through → (re)install
-        }
-
-        // ------------------------------------------------------------------
-        // 2. Confirm install.
-        // ------------------------------------------------------------------
-        if (!alreadyInstalled) {
-            const INSTALL = l10n.t("Install");
-            const CANCEL = l10n.t("Cancel");
-            const confirm = await vscode.window.showInformationMessage(
-                l10n.t(
-                    "This will install Argo CD into the '{0}' namespace on cluster '{1}' using the official stable manifests.\n\nThe install runs:\n  kubectl create namespace {0}\n  kubectl apply -n {0} --server-side --force-conflicts -f <stable manifests>",
-                    ARGOCD_NAMESPACE,
-                    clusterInfo.name,
-                ),
-                { modal: true },
-                INSTALL,
-                CANCEL,
-            );
-            if (!confirm || confirm === CANCEL) return;
-        }
-
-        // ------------------------------------------------------------------
-        // 3. Run the install using the shared helper.
-        // ------------------------------------------------------------------
-        const ok = await performArgoCDInstall(kubectl, kubeconfigFile, clusterInfo.name, channel);
-        if (!ok) return;
-
-        const PORT_FORWARD = l10n.t("Port-forward UI (localhost:8080)");
-        const OPEN_DOCS = l10n.t("Open Getting Started Docs");
-        const followUp = await vscode.window.showInformationMessage(
-            l10n.t(
-                "Argo CD installed on '{0}'.  Run 'Check Argo CD Status' from the cluster menu to monitor progress.",
-                clusterInfo.name,
-            ),
-            PORT_FORWARD,
-            OPEN_DOCS,
-        );
-
-        if (followUp === PORT_FORWARD) {
-            await startPortForward(kubectl, kubeconfigFile, clusterInfo.name, channel);
-        } else if (followUp === OPEN_DOCS) {
-            await vscode.env.openExternal(
-                vscode.Uri.parse("https://argo-cd.readthedocs.io/en/stable/getting_started/"),
-            );
-        }
-    });
+export function getOutputChannel(): vscode.OutputChannel {
+    if (!argoCDOutputChannel) {
+        argoCDOutputChannel = vscode.window.createOutputChannel("Argo CD");
+    }
+    return argoCDOutputChannel;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,10 +121,11 @@ async function showArgoCDStatus(
         channel.appendLine(
             `[Argo CD Status] Namespace '${ARGOCD_NAMESPACE}' not found — Argo CD does not appear to be installed.`,
         );
-        channel.appendLine(`[Argo CD Status] Tip: use "Install Argo CD on Cluster" from the cluster context menu.`);
+        channel.appendLine(`[Argo CD Status] Tip: install Argo CD on your cluster before using this functionality.`);
+        channel.appendLine(`[Argo CD Status] See: https://argo-cd.readthedocs.io/en/stable/getting_started/`);
         vscode.window.showWarningMessage(
             l10n.t(
-                "Argo CD is not installed on cluster '{0}'. Use 'Install Argo CD on Cluster' from the cluster context menu.",
+                "Argo CD is not installed on cluster '{0}'. Please install Argo CD on your cluster before using this functionality. See https://argo-cd.readthedocs.io/en/stable/getting_started/",
                 clusterName,
             ),
         );
@@ -337,48 +175,5 @@ async function showArgoCDStatus(
     );
     channel.appendLine(
         `[Argo CD Status] Auth: if installed via kubectl/Helm, retrieve the initial admin password →  argocd admin initial-password -n ${ARGOCD_NAMESPACE}`,
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Helper: start a port-forward for the Argo CD UI in the integrated terminal
-// ---------------------------------------------------------------------------
-
-async function startPortForward(
-    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
-    kubeconfigFile: string,
-    clusterName: string,
-    channel: vscode.OutputChannel,
-): Promise<void> {
-    // Check that argocd-server service exists before opening a terminal.
-    const svcCheck = await invokeKubectlCommand(
-        kubectl,
-        kubeconfigFile,
-        `get svc argocd-server -n ${ARGOCD_NAMESPACE} --ignore-not-found -o name`,
-        NonZeroExitCodeBehaviour.Succeed,
-    );
-
-    if (failed(svcCheck) || svcCheck.result.stdout.trim() === "") {
-        channel.appendLine(
-            `[Argo CD] argocd-server service not ready yet — try port-forwarding manually once all pods are Running.`,
-        );
-        vscode.window.showWarningMessage(
-            l10n.t("argocd-server service is not ready yet. Try again once all pods are Running."),
-        );
-        return;
-    }
-
-    const terminal = vscode.window.createTerminal({
-        name: `Argo CD UI — ${clusterName}`,
-    });
-    terminal.sendText(
-        `kubectl port-forward svc/argocd-server -n ${ARGOCD_NAMESPACE} 8080:443 --kubeconfig="${kubeconfigFile}"`,
-    );
-    terminal.show();
-    channel.appendLine(
-        `[Argo CD] Port-forward started in terminal. Open https://localhost:8080 (accept self-signed cert).`,
-    );
-    vscode.window.showInformationMessage(
-        l10n.t("Argo CD UI available at https://localhost:8080 (the terminal is running the port-forward)."),
     );
 }

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -332,6 +332,12 @@ async function showArgoCDStatus(
     channel.appendLine(
         `\n[Argo CD Status] Tip: port-forward the UI →  kubectl port-forward svc/argocd-server -n ${ARGOCD_NAMESPACE} 8080:443`,
     );
+    channel.appendLine(
+        `[Argo CD Status] Auth: if installed via 'az k8s-extension' with workload identity, sign in with your Microsoft account.`,
+    );
+    channel.appendLine(
+        `[Argo CD Status] Auth: if installed via kubectl/Helm, retrieve the initial admin password →  argocd admin initial-password -n ${ARGOCD_NAMESPACE}`,
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -1,0 +1,367 @@
+/**
+ * Argo CD cluster-side commands.
+ *
+ * Provides two commands triggered from the AKS cluster tree (right-click):
+ *
+ *  • aks.argoCDInstall      — install Argo CD into the `argocd` namespace of the
+ *                             selected cluster using the official stable manifests
+ *
+ *  • aks.argoCDCheckStatus  — probe whether Argo CD is installed and show a quick
+ *                             summary of pod health in an output channel
+ *
+ * Both commands follow the same kubectl-via-kubeconfig pattern used throughout
+ * this extension (e.g. aksKubectlCommands.ts).
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/getting_started/
+ */
+
+import * as vscode from "vscode";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import * as l10n from "@vscode/l10n";
+
+import { getReadySessionProvider } from "../../auth/azureAuth";
+import { getKubernetesClusterInfo } from "../utils/clusters";
+import { invokeKubectlCommand } from "../utils/kubectl";
+import { withOptionalTempFile } from "../utils/tempfile";
+import { failed } from "../utils/errorable";
+import { longRunning } from "../utils/host";
+import { NonZeroExitCodeBehaviour } from "../utils/shell";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ARGOCD_INSTALL_URL = "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml";
+
+const ARGOCD_NAMESPACE = "argocd";
+
+// Lazy-created output channel — shared between both commands.
+let argoCDOutputChannel: vscode.OutputChannel | undefined;
+
+function getOutputChannel(): vscode.OutputChannel {
+    if (!argoCDOutputChannel) {
+        argoCDOutputChannel = vscode.window.createOutputChannel("Argo CD");
+    }
+    return argoCDOutputChannel;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: check whether the argocd namespace (and at least one pod) exists
+// ---------------------------------------------------------------------------
+
+async function isArgoCDInstalled(kubectl: k8s.APIAvailable<k8s.KubectlV1>, kubeConfigFile: string): Promise<boolean> {
+    const result = await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFile,
+        `get namespace ${ARGOCD_NAMESPACE} --ignore-not-found -o name`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+    if (failed(result)) return false;
+    return result.result.stdout.trim().length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Shared setup: resolve cluster + kubeconfig from tree context
+// ---------------------------------------------------------------------------
+
+async function resolveCluster(target: unknown) {
+    const [kubectl, cloudExplorer, clusterExplorer, sessionResult] = await Promise.all([
+        k8s.extension.kubectl.v1,
+        k8s.extension.cloudExplorer.v1,
+        k8s.extension.clusterExplorer.v1,
+        getReadySessionProvider(),
+    ]);
+
+    if (!kubectl.available) {
+        vscode.window.showWarningMessage(l10n.t("kubectl is unavailable."));
+        return undefined;
+    }
+    if (!cloudExplorer.available) {
+        vscode.window.showWarningMessage(l10n.t("Cloud explorer is unavailable."));
+        return undefined;
+    }
+    if (!clusterExplorer.available) {
+        vscode.window.showWarningMessage(l10n.t("Cluster explorer is unavailable."));
+        return undefined;
+    }
+    if (failed(sessionResult)) {
+        vscode.window.showErrorMessage(sessionResult.error);
+        return undefined;
+    }
+
+    const clusterInfo = await getKubernetesClusterInfo(sessionResult.result, target, cloudExplorer, clusterExplorer);
+    if (failed(clusterInfo)) {
+        vscode.window.showErrorMessage(clusterInfo.error);
+        return undefined;
+    }
+
+    return { kubectl, clusterInfo: clusterInfo.result };
+}
+
+// ---------------------------------------------------------------------------
+// Command: Install Argo CD
+// ---------------------------------------------------------------------------
+
+export async function argoCDInstall(_context: IActionContext, target: unknown): Promise<void> {
+    const resolved = await resolveCluster(target);
+    if (!resolved) return;
+
+    const { kubectl, clusterInfo } = resolved;
+    const channel = getOutputChannel();
+    channel.show(true);
+
+    await withOptionalTempFile(clusterInfo.kubeconfigYaml, "yaml", async (kubeconfigFile) => {
+        // ------------------------------------------------------------------
+        // 1. Check if Argo CD is already installed.
+        // ------------------------------------------------------------------
+        const alreadyInstalled = await longRunning(
+            l10n.t("Checking if Argo CD is already installed on {0}…", clusterInfo.name),
+            () => isArgoCDInstalled(kubectl, kubeconfigFile),
+        );
+
+        if (alreadyInstalled) {
+            const REINSTALL = l10n.t("Reinstall / Upgrade");
+            const CHECK_STATUS = l10n.t("Check Status Instead");
+            const choice = await vscode.window.showInformationMessage(
+                l10n.t(
+                    "Argo CD is already installed in the '{0}' namespace on cluster '{1}'.",
+                    ARGOCD_NAMESPACE,
+                    clusterInfo.name,
+                ),
+                REINSTALL,
+                CHECK_STATUS,
+            );
+            if (!choice || choice === CHECK_STATUS) {
+                await showArgoCDStatus(kubectl, kubeconfigFile, clusterInfo.name, channel);
+                return;
+            }
+            // fall through → (re)install
+        }
+
+        // ------------------------------------------------------------------
+        // 2. Confirm install.
+        // ------------------------------------------------------------------
+        if (!alreadyInstalled) {
+            const INSTALL = l10n.t("Install");
+            const CANCEL = l10n.t("Cancel");
+            const confirm = await vscode.window.showInformationMessage(
+                l10n.t(
+                    "This will install Argo CD into the '{0}' namespace on cluster '{1}' using the official stable manifests.\n\nThe install runs:\n  kubectl create namespace {0}\n  kubectl apply -n {0} --server-side --force-conflicts -f <stable manifests>",
+                    ARGOCD_NAMESPACE,
+                    clusterInfo.name,
+                ),
+                { modal: true },
+                INSTALL,
+                CANCEL,
+            );
+            if (!confirm || confirm === CANCEL) return;
+        }
+
+        // ------------------------------------------------------------------
+        // 3. Create the argocd namespace (idempotent — ignore error if exists).
+        // ------------------------------------------------------------------
+        channel.appendLine(`\n[Argo CD Install] Cluster: ${clusterInfo.name}`);
+        channel.appendLine(`[Argo CD Install] Step 1/3 — Ensuring namespace '${ARGOCD_NAMESPACE}' exists…`);
+
+        const createNsResult = await longRunning(l10n.t("Creating namespace '{0}'…", ARGOCD_NAMESPACE), () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeconfigFile,
+                `create namespace ${ARGOCD_NAMESPACE}`,
+                NonZeroExitCodeBehaviour.Succeed, // namespace may already exist
+            ),
+        );
+
+        if (failed(createNsResult)) {
+            channel.appendLine(`[Argo CD Install] ERROR: ${createNsResult.error}`);
+            vscode.window.showErrorMessage(
+                l10n.t("Failed to create namespace '{0}': {1}", ARGOCD_NAMESPACE, createNsResult.error),
+            );
+            return;
+        }
+        channel.appendLine(`[Argo CD Install]   ${createNsResult.result.stdout.trim() || "namespace ready"}`);
+
+        // ------------------------------------------------------------------
+        // 4. Apply the official install manifests.
+        // ------------------------------------------------------------------
+        channel.appendLine(`[Argo CD Install] Step 2/3 — Applying Argo CD manifests (server-side apply)…`);
+        channel.appendLine(`[Argo CD Install]   Source: ${ARGOCD_INSTALL_URL}`);
+
+        const applyResult = await longRunning(
+            l10n.t("Installing Argo CD on {0} (this may take a minute)…", clusterInfo.name),
+            () =>
+                invokeKubectlCommand(
+                    kubectl,
+                    kubeconfigFile,
+                    `apply -n ${ARGOCD_NAMESPACE} --server-side --force-conflicts -f ${ARGOCD_INSTALL_URL}`,
+                ),
+        );
+
+        if (failed(applyResult)) {
+            channel.appendLine(`[Argo CD Install] ERROR: ${applyResult.error}`);
+            vscode.window.showErrorMessage(l10n.t("Argo CD installation failed: {0}", applyResult.error));
+            return;
+        }
+        channel.appendLine(`[Argo CD Install]   Resources applied OK.`);
+
+        // ------------------------------------------------------------------
+        // 5. Show pod status.
+        // ------------------------------------------------------------------
+        channel.appendLine(`[Argo CD Install] Step 3/3 — Waiting for pods to start (initial check)…`);
+        await showArgoCDStatus(kubectl, kubeconfigFile, clusterInfo.name, channel);
+
+        const PORT_FORWARD = l10n.t("Port-forward UI (localhost:8080)");
+        const OPEN_DOCS = l10n.t("Open Getting Started Docs");
+        const followUp = await vscode.window.showInformationMessage(
+            l10n.t(
+                "Argo CD installed on '{0}'.  Run 'Check Argo CD Status' from the cluster menu to monitor progress.",
+                clusterInfo.name,
+            ),
+            PORT_FORWARD,
+            OPEN_DOCS,
+        );
+
+        if (followUp === PORT_FORWARD) {
+            await startPortForward(kubectl, kubeconfigFile, clusterInfo.name, channel);
+        } else if (followUp === OPEN_DOCS) {
+            await vscode.env.openExternal(
+                vscode.Uri.parse("https://argo-cd.readthedocs.io/en/stable/getting_started/"),
+            );
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Command: Check Argo CD Status
+// ---------------------------------------------------------------------------
+
+export async function argoCDCheckStatus(_context: IActionContext, target: unknown): Promise<void> {
+    const resolved = await resolveCluster(target);
+    if (!resolved) return;
+
+    const { kubectl, clusterInfo } = resolved;
+    const channel = getOutputChannel();
+    channel.show(true);
+
+    await withOptionalTempFile(clusterInfo.kubeconfigYaml, "yaml", async (kubeconfigFile) => {
+        await showArgoCDStatus(kubectl, kubeconfigFile, clusterInfo.name, channel);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper: print pod status to the output channel
+// ---------------------------------------------------------------------------
+
+async function showArgoCDStatus(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeconfigFile: string,
+    clusterName: string,
+    channel: vscode.OutputChannel,
+): Promise<void> {
+    channel.appendLine(`\n[Argo CD Status] Cluster: ${clusterName}`);
+
+    // Check namespace existence first.
+    const nsCheck = await invokeKubectlCommand(
+        kubectl,
+        kubeconfigFile,
+        `get namespace ${ARGOCD_NAMESPACE} --ignore-not-found -o name`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+
+    if (failed(nsCheck) || nsCheck.result.stdout.trim() === "") {
+        channel.appendLine(
+            `[Argo CD Status] Namespace '${ARGOCD_NAMESPACE}' not found — Argo CD does not appear to be installed.`,
+        );
+        channel.appendLine(`[Argo CD Status] Tip: use "Install Argo CD on Cluster" from the cluster context menu.`);
+        vscode.window.showWarningMessage(
+            l10n.t(
+                "Argo CD is not installed on cluster '{0}'. Use 'Install Argo CD on Cluster' from the cluster context menu.",
+                clusterName,
+            ),
+        );
+        return;
+    }
+
+    // Pods.
+    const podsResult = await longRunning(l10n.t("Fetching Argo CD pod status from {0}…", clusterName), () =>
+        invokeKubectlCommand(
+            kubectl,
+            kubeconfigFile,
+            `get pods -n ${ARGOCD_NAMESPACE} -o wide`,
+            NonZeroExitCodeBehaviour.Succeed,
+        ),
+    );
+
+    channel.appendLine(`[Argo CD Status] Pods in namespace '${ARGOCD_NAMESPACE}':`);
+    if (failed(podsResult) || podsResult.result.stdout.trim() === "") {
+        channel.appendLine("  (no pods found — installation may still be in progress)");
+    } else {
+        for (const line of podsResult.result.stdout.trim().split("\n")) {
+            channel.appendLine(`  ${line}`);
+        }
+    }
+
+    // Services.
+    const svcResult = await invokeKubectlCommand(
+        kubectl,
+        kubeconfigFile,
+        `get svc -n ${ARGOCD_NAMESPACE}`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+    channel.appendLine(`\n[Argo CD Status] Services in namespace '${ARGOCD_NAMESPACE}':`);
+    if (failed(svcResult) || svcResult.result.stdout.trim() === "") {
+        channel.appendLine("  (none)");
+    } else {
+        for (const line of svcResult.result.stdout.trim().split("\n")) {
+            channel.appendLine(`  ${line}`);
+        }
+    }
+
+    channel.appendLine(
+        `\n[Argo CD Status] Tip: port-forward the UI →  kubectl port-forward svc/argocd-server -n ${ARGOCD_NAMESPACE} 8080:443`,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: start a port-forward for the Argo CD UI in the integrated terminal
+// ---------------------------------------------------------------------------
+
+async function startPortForward(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeconfigFile: string,
+    clusterName: string,
+    channel: vscode.OutputChannel,
+): Promise<void> {
+    // Check that argocd-server service exists before opening a terminal.
+    const svcCheck = await invokeKubectlCommand(
+        kubectl,
+        kubeconfigFile,
+        `get svc argocd-server -n ${ARGOCD_NAMESPACE} --ignore-not-found -o name`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+
+    if (failed(svcCheck) || svcCheck.result.stdout.trim() === "") {
+        channel.appendLine(
+            `[Argo CD] argocd-server service not ready yet — try port-forwarding manually once all pods are Running.`,
+        );
+        vscode.window.showWarningMessage(
+            l10n.t("argocd-server service is not ready yet. Try again once all pods are Running."),
+        );
+        return;
+    }
+
+    const terminal = vscode.window.createTerminal({
+        name: `Argo CD UI — ${clusterName}`,
+    });
+    terminal.sendText(
+        `kubectl port-forward svc/argocd-server -n ${ARGOCD_NAMESPACE} 8080:443 --kubeconfig="${kubeconfigFile}"`,
+    );
+    terminal.show();
+    channel.appendLine(
+        `[Argo CD] Port-forward started in terminal. Open https://localhost:8080 (accept self-signed cert).`,
+    );
+    vscode.window.showInformationMessage(
+        l10n.t("Argo CD UI available at https://localhost:8080 (the terminal is running the port-forward)."),
+    );
+}

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -39,11 +39,70 @@ const ARGOCD_NAMESPACE = "argocd";
 // Lazy-created output channel — shared between both commands.
 let argoCDOutputChannel: vscode.OutputChannel | undefined;
 
-function getOutputChannel(): vscode.OutputChannel {
+export function getOutputChannel(): vscode.OutputChannel {
     if (!argoCDOutputChannel) {
         argoCDOutputChannel = vscode.window.createOutputChannel("Argo CD");
     }
     return argoCDOutputChannel;
+}
+
+// ---------------------------------------------------------------------------
+// Shared core: run the actual Argo CD install steps (no cluster resolution,
+// no UX prompts — just the kubectl work).  Called both from argoCDInstall and
+// from argoCDApplyApp when the user asks to install inline.
+// Returns true if the install succeeded.
+// ---------------------------------------------------------------------------
+
+export async function performArgoCDInstall(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeconfigFile: string,
+    clusterName: string,
+    channel: vscode.OutputChannel,
+): Promise<boolean> {
+    channel.show(true);
+    channel.appendLine(`\n[Argo CD Install] Cluster: ${clusterName}`);
+    channel.appendLine(`[Argo CD Install] Step 1/2 — Ensuring namespace '${ARGOCD_NAMESPACE}' exists…`);
+
+    const createNsResult = await longRunning(l10n.t("Creating namespace '{0}'…", ARGOCD_NAMESPACE), () =>
+        invokeKubectlCommand(
+            kubectl,
+            kubeconfigFile,
+            `create namespace ${ARGOCD_NAMESPACE}`,
+            NonZeroExitCodeBehaviour.Succeed,
+        ),
+    );
+
+    if (failed(createNsResult)) {
+        channel.appendLine(`[Argo CD Install] ERROR: ${createNsResult.error}`);
+        vscode.window.showErrorMessage(
+            l10n.t("Failed to create namespace '{0}': {1}", ARGOCD_NAMESPACE, createNsResult.error),
+        );
+        return false;
+    }
+    channel.appendLine(`[Argo CD Install]   ${createNsResult.result.stdout.trim() || "namespace ready"}`);
+
+    channel.appendLine(`[Argo CD Install] Step 2/2 — Applying Argo CD manifests (server-side apply)…`);
+    channel.appendLine(`[Argo CD Install]   Source: ${ARGOCD_INSTALL_URL}`);
+
+    const applyResult = await longRunning(
+        l10n.t("Installing Argo CD on {0} (this may take a minute)…", clusterName),
+        () =>
+            invokeKubectlCommand(
+                kubectl,
+                kubeconfigFile,
+                `apply -n ${ARGOCD_NAMESPACE} --server-side --force-conflicts -f ${ARGOCD_INSTALL_URL}`,
+            ),
+    );
+
+    if (failed(applyResult)) {
+        channel.appendLine(`[Argo CD Install] ERROR: ${applyResult.error}`);
+        vscode.window.showErrorMessage(l10n.t("Argo CD installation failed: {0}", applyResult.error));
+        return false;
+    }
+
+    channel.appendLine(`[Argo CD Install]   Resources applied OK.`);
+    await showArgoCDStatus(kubectl, kubeconfigFile, clusterName, channel);
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,7 +168,6 @@ export async function argoCDInstall(_context: IActionContext, target: unknown): 
 
     const { kubectl, clusterInfo } = resolved;
     const channel = getOutputChannel();
-    channel.show(true);
 
     await withOptionalTempFile(clusterInfo.kubeconfigYaml, "yaml", async (kubeconfigFile) => {
         // ------------------------------------------------------------------
@@ -159,57 +217,10 @@ export async function argoCDInstall(_context: IActionContext, target: unknown): 
         }
 
         // ------------------------------------------------------------------
-        // 3. Create the argocd namespace (idempotent — ignore error if exists).
+        // 3. Run the install using the shared helper.
         // ------------------------------------------------------------------
-        channel.appendLine(`\n[Argo CD Install] Cluster: ${clusterInfo.name}`);
-        channel.appendLine(`[Argo CD Install] Step 1/3 — Ensuring namespace '${ARGOCD_NAMESPACE}' exists…`);
-
-        const createNsResult = await longRunning(l10n.t("Creating namespace '{0}'…", ARGOCD_NAMESPACE), () =>
-            invokeKubectlCommand(
-                kubectl,
-                kubeconfigFile,
-                `create namespace ${ARGOCD_NAMESPACE}`,
-                NonZeroExitCodeBehaviour.Succeed, // namespace may already exist
-            ),
-        );
-
-        if (failed(createNsResult)) {
-            channel.appendLine(`[Argo CD Install] ERROR: ${createNsResult.error}`);
-            vscode.window.showErrorMessage(
-                l10n.t("Failed to create namespace '{0}': {1}", ARGOCD_NAMESPACE, createNsResult.error),
-            );
-            return;
-        }
-        channel.appendLine(`[Argo CD Install]   ${createNsResult.result.stdout.trim() || "namespace ready"}`);
-
-        // ------------------------------------------------------------------
-        // 4. Apply the official install manifests.
-        // ------------------------------------------------------------------
-        channel.appendLine(`[Argo CD Install] Step 2/3 — Applying Argo CD manifests (server-side apply)…`);
-        channel.appendLine(`[Argo CD Install]   Source: ${ARGOCD_INSTALL_URL}`);
-
-        const applyResult = await longRunning(
-            l10n.t("Installing Argo CD on {0} (this may take a minute)…", clusterInfo.name),
-            () =>
-                invokeKubectlCommand(
-                    kubectl,
-                    kubeconfigFile,
-                    `apply -n ${ARGOCD_NAMESPACE} --server-side --force-conflicts -f ${ARGOCD_INSTALL_URL}`,
-                ),
-        );
-
-        if (failed(applyResult)) {
-            channel.appendLine(`[Argo CD Install] ERROR: ${applyResult.error}`);
-            vscode.window.showErrorMessage(l10n.t("Argo CD installation failed: {0}", applyResult.error));
-            return;
-        }
-        channel.appendLine(`[Argo CD Install]   Resources applied OK.`);
-
-        // ------------------------------------------------------------------
-        // 5. Show pod status.
-        // ------------------------------------------------------------------
-        channel.appendLine(`[Argo CD Install] Step 3/3 — Waiting for pods to start (initial check)…`);
-        await showArgoCDStatus(kubectl, kubeconfigFile, clusterInfo.name, channel);
+        const ok = await performArgoCDInstall(kubectl, kubeconfigFile, clusterInfo.name, channel);
+        if (!ok) return;
 
         const PORT_FORWARD = l10n.t("Port-forward UI (localhost:8080)");
         const OPEN_DOCS = l10n.t("Open Getting Started Docs");

--- a/src/commands/aksContainerAssist/azureSelections.ts
+++ b/src/commands/aksContainerAssist/azureSelections.ts
@@ -120,7 +120,7 @@ export async function selectAksCluster(
         getClusters(sessionProvider, subscriptionId),
     );
 
-    if (!clustersResult || clustersResult.length === 0) {
+    if (failed(clustersResult) || clustersResult.result.length === 0) {
         const openPortal = l10n.t("Open in Portal");
         const selection = await vscode.window.showWarningMessage(
             l10n.t("No AKS clusters found in subscription."),
@@ -135,7 +135,8 @@ export async function selectAksCluster(
         return undefined;
     }
 
-    const clusterItems = clustersResult
+    const clusters = clustersResult.result;
+    const clusterItems = clusters
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((cluster) => ({
             label: cluster.name,
@@ -145,7 +146,7 @@ export async function selectAksCluster(
 
     const selected = await vscode.window.showQuickPick(clusterItems, {
         placeHolder: l10n.t("Select AKS cluster for deployment"),
-        title: l10n.t("AKS Cluster ({0} available)", clustersResult.length),
+        title: l10n.t("AKS Cluster ({0} available)", clusters.length),
     });
 
     // Show confirmation dialog if user cancelled

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -215,6 +215,60 @@ export async function getKubeconfigYaml(
         : getNonAadKubeconfig(client, resourceGroup, managedCluster.name);
 }
 
+/**
+ * Takes a raw kubeconfig YAML string (e.g. from `kubectl config view --minify --flatten`)
+ * and, if its exec credential block is an AKS kubelogin block, replaces the
+ * Azure CLI credential with a VS Code-managed cached token. This allows kubectl
+ * commands to work without requiring `az` or a system `kubelogin` on the PATH.
+ *
+ * If the kubeconfig has no exec block, or no AKS-specific `--server-id` argument,
+ * the original YAML is returned unchanged.
+ */
+export async function getAuthenticatedKubeconfigYaml(rawKubeconfigYaml: string): Promise<Errorable<string>> {
+    let kubeconfigObj: KubeConfig;
+    try {
+        kubeconfigObj = yaml.load(rawKubeconfigYaml) as KubeConfig;
+    } catch (e) {
+        return { succeeded: false, error: `Failed to parse kubeconfig YAML: ${e}` };
+    }
+
+    const execBlock = kubeconfigObj?.users?.[0]?.user?.exec;
+    if (!execBlock?.args?.includes("--server-id")) {
+        // Not an AKS AAD kubelogin config — return unchanged.
+        return { succeeded: true, result: rawKubeconfigYaml };
+    }
+
+    const execOptions = readExecOptions(execBlock.args);
+    if (!execOptions.serverId || !execOptions.tenantId) {
+        return { succeeded: true, result: rawKubeconfigYaml };
+    }
+
+    const scopes = [`${execOptions.serverId}/.default`, `VSCODE_TENANT:${execOptions.tenantId}`];
+    let session: AuthenticationSession;
+    try {
+        session = await authentication.getSession("microsoft", scopes, { createIfNone: true });
+    } catch (e) {
+        return {
+            succeeded: false,
+            error: `Failed to retrieve Microsoft authentication session for AKS: ${getErrorMessage(e)}`,
+        };
+    }
+
+    const tokenInfo = getTokenInfo(session);
+    if (failed(tokenInfo)) return tokenInfo;
+
+    const cacheDir = storeCachedAadToken(tokenInfo.result, execOptions);
+    if (failed(cacheDir)) return cacheDir;
+
+    const kubeloginPath = await getKubeloginBinaryPath();
+    if (failed(kubeloginPath)) return kubeloginPath;
+
+    execBlock.command = kubeloginPath.result;
+    execBlock.args = buildExecOptionsWithCache(execOptions, cacheDir.result);
+
+    return { succeeded: true, result: yaml.dump(kubeconfigObj) };
+}
+
 async function getNonAadKubeconfig(
     client: azcs.ContainerServiceClient,
     resourceGroup: string,

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -918,24 +918,23 @@ export type Cluster = {
 export async function getClusters(
     sessionProvider: ReadyAzureSessionProvider,
     subscriptionId: string,
-): Promise<Cluster[]> {
+): Promise<Errorable<Cluster[]>> {
     const clusters = await getResources(sessionProvider, subscriptionId, "Microsoft.ContainerService/managedClusters");
     if (failed(clusters)) {
-        // Silently skip subscriptions that cannot be listed (e.g. insufficient
-        // permissions or transient API errors).  If every subscription fails the
-        // caller's empty-array guard will surface a meaningful message instead
-        // of spamming one error popup per subscription.
-        return [];
+        return clusters;
     }
 
-    return clusters.result.map((cluster) => {
-        return {
-            name: cluster.name,
-            clusterId: cluster.id,
-            resourceGroup: cluster.resourceGroup,
-            subscriptionId: subscriptionId,
-        };
-    });
+    return {
+        succeeded: true,
+        result: clusters.result.map((cluster) => {
+            return {
+                name: cluster.name,
+                clusterId: cluster.id,
+                resourceGroup: cluster.resourceGroup,
+                subscriptionId: subscriptionId,
+            };
+        }),
+    };
 }
 
 export async function getClusterDiagnosticSettings(

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as yaml from "js-yaml";
 import * as path from "path";
 import { dirSync } from "tmp";
-import { AuthenticationSession, QuickPickItem, authentication, window } from "vscode";
+import { AuthenticationSession, QuickPickItem, authentication } from "vscode";
 import * as vscode from "vscode";
 import {
     API,
@@ -867,7 +867,10 @@ export async function getClusters(
 ): Promise<Cluster[]> {
     const clusters = await getResources(sessionProvider, subscriptionId, "Microsoft.ContainerService/managedClusters");
     if (failed(clusters)) {
-        window.showErrorMessage(clusters.error);
+        // Silently skip subscriptions that cannot be listed (e.g. insufficient
+        // permissions or transient API errors).  If every subscription fails the
+        // caller's empty-array guard will surface a meaningful message instead
+        // of spamming one error popup per subscription.
         return [];
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,10 +195,13 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
             vscode.workspace.onDidOpenTextDocument(async (document) => {
                 if (document.languageId !== "yaml" && document.languageId !== "yml") return;
+                // Cheap substring pre-check to avoid parsing large YAML files unnecessarily.
+                const text = document.getText();
+                if (!text.includes("argoproj.io/") || !text.includes("Application")) return;
                 let parsed: unknown;
                 try {
                     const yaml = await import("js-yaml");
-                    parsed = yaml.load(document.getText());
+                    parsed = yaml.load(text);
                 } catch {
                     return;
                 }
@@ -207,7 +210,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 const action = await vscode.window.showInformationMessage(
                     l10n.t(
                         "Argo CD Application '{0}' detected — apply it to the active cluster?",
-                        parsed.metadata?.name ?? document.fileName.split("/").pop() ?? "unknown",
+                        parsed.metadata?.name ?? path.basename(document.fileName) ?? "unknown",
                     ),
                     APPLY,
                 );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModerni
 } from "./commands/aksContainerAssist/appModernizationBridge";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
 import { argoCDInstall, argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
-import { argoCDApplyApp } from "./commands/aksArgoCD/argoCDApplyApp";
+import { argoCDApplyApp, argoCDPostApplyActions } from "./commands/aksArgoCD/argoCDApplyApp";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,
@@ -190,6 +190,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.argoCDInstall", argoCDInstall);
         registerCommandWithTelemetry("aks.argoCDCheckStatus", argoCDCheckStatus);
         registerCommandWithTelemetry("aks.argoCDApplyApp", argoCDApplyApp);
+        registerCommandWithTelemetry("aks.argoCDPostApplyActions", argoCDPostApplyActions);
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModerni
     migrateAndModernizeApp,
 } from "./commands/aksContainerAssist/appModernizationBridge";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
-import { argoCDInstall, argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
+import { argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
 import { argoCDApplyApp, argoCDPostApplyActions, isArgoCDApplication } from "./commands/aksArgoCD/argoCDApplyApp";
 import {
     setupOIDCForGitHub,
@@ -187,7 +187,6 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         registerCommandWithTelemetry("aks.migrateAndModernizeApp", migrateAndModernizeApp);
         registerCommandWithTelemetry("aks.draftArgoCDDeployment", draftArgoCDDeployment);
-        registerCommandWithTelemetry("aks.argoCDInstall", argoCDInstall);
         registerCommandWithTelemetry("aks.argoCDCheckStatus", argoCDCheckStatus);
         registerCommandWithTelemetry("aks.argoCDApplyApp", argoCDApplyApp);
         registerCommandWithTelemetry("aks.argoCDPostApplyActions", argoCDPostApplyActions);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,9 @@ import {
     deployAppWithAutomatedPipelineFromTree,
 } from "./commands/aksContainerAssist/aksContainerAssist";
 import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModernizationBridge";
+    migrateAndModernizeApp,
+} from "./commands/aksContainerAssist/appModernizationBridge";
+import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,
@@ -181,6 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
             deployAppWithAutomatedPipelineFromTree,
         );
         registerCommandWithTelemetry("aks.migrateAndModernizeApp", migrateAndModernizeApp);
+        registerCommandWithTelemetry("aks.draftArgoCDDeployment", draftArgoCDDeployment);
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,8 @@ import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModerni
     migrateAndModernizeApp,
 } from "./commands/aksContainerAssist/appModernizationBridge";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
+import { argoCDInstall, argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
+import { argoCDApplyApp } from "./commands/aksArgoCD/argoCDApplyApp";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,
@@ -185,6 +187,9 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         registerCommandWithTelemetry("aks.migrateAndModernizeApp", migrateAndModernizeApp);
         registerCommandWithTelemetry("aks.draftArgoCDDeployment", draftArgoCDDeployment);
+        registerCommandWithTelemetry("aks.argoCDInstall", argoCDInstall);
+        registerCommandWithTelemetry("aks.argoCDCheckStatus", argoCDCheckStatus);
+        registerCommandWithTelemetry("aks.argoCDApplyApp", argoCDApplyApp);
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,8 +196,9 @@ export async function activate(context: vscode.ExtensionContext) {
             vscode.workspace.onDidOpenTextDocument(async (document) => {
                 if (document.languageId !== "yaml" && document.languageId !== "yml") return;
                 // Cheap substring pre-check to avoid parsing large YAML files unnecessarily.
+                // Use the full apiVersion key to avoid CodeQL "Incomplete URL substring sanitization" false positive.
                 const text = document.getText();
-                if (!text.includes("argoproj.io/") || !text.includes("Application")) return;
+                if (!text.includes("apiVersion: argoproj.io/") || !text.includes("kind: Application")) return;
                 let parsed: unknown;
                 try {
                     const yaml = await import("js-yaml");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModerni
 } from "./commands/aksContainerAssist/appModernizationBridge";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
 import { argoCDInstall, argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
-import { argoCDApplyApp, argoCDPostApplyActions } from "./commands/aksArgoCD/argoCDApplyApp";
+import { argoCDApplyApp, argoCDPostApplyActions, isArgoCDApplication } from "./commands/aksArgoCD/argoCDApplyApp";
 import {
     setupOIDCForGitHub,
     setGitHubActionsSecrets,
@@ -191,6 +191,32 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.argoCDCheckStatus", argoCDCheckStatus);
         registerCommandWithTelemetry("aks.argoCDApplyApp", argoCDApplyApp);
         registerCommandWithTelemetry("aks.argoCDPostApplyActions", argoCDPostApplyActions);
+
+        // Notify when an Argo CD Application YAML is opened in the editor.
+        context.subscriptions.push(
+            vscode.workspace.onDidOpenTextDocument(async (document) => {
+                if (document.languageId !== "yaml" && document.languageId !== "yml") return;
+                let parsed: unknown;
+                try {
+                    const yaml = await import("js-yaml");
+                    parsed = yaml.load(document.getText());
+                } catch {
+                    return;
+                }
+                if (!isArgoCDApplication(parsed)) return;
+                const APPLY = l10n.t("Apply to Cluster");
+                const action = await vscode.window.showInformationMessage(
+                    l10n.t(
+                        "Argo CD Application '{0}' detected — apply it to the active cluster?",
+                        parsed.metadata?.name ?? document.fileName.split("/").pop() ?? "unknown",
+                    ),
+                    APPLY,
+                );
+                if (action === APPLY) {
+                    await vscode.commands.executeCommand("aks.argoCDApplyApp", document.uri);
+                }
+            }),
+        );
         registerCommandWithTelemetry("aks.setupOIDCForGitHub", async () => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,8 +79,6 @@ import {
     deployAppWithAutomatedPipelineFromTree,
 } from "./commands/aksContainerAssist/aksContainerAssist";
 import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModernizationBridge";
-    migrateAndModernizeApp,
-} from "./commands/aksContainerAssist/appModernizationBridge";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
 import { argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
 import { argoCDApplyApp, argoCDPostApplyActions, isArgoCDApplication } from "./commands/aksArgoCD/argoCDApplyApp";

--- a/src/plugins/argoCD/argoCDDeploymentPlugin.ts
+++ b/src/plugins/argoCD/argoCDDeploymentPlugin.ts
@@ -1,0 +1,90 @@
+/**
+ * Argo CD deployment plugin — GitHub Copilot skill.
+ *
+ * Registers a `LocalPluginEntry` that the Azure AI agent surfaces as a Copilot
+ * chat function.  When the user asks something like:
+ *   "How do I set up Argo CD on my AKS cluster?"
+ *   "Create an Argo CD deployment for my cluster"
+ *   "gitops deployment argo cd aks"
+ *
+ * …the agent invokes this skill, which replies with a rich message explaining
+ * the Hollywood / GitOps principle and renders a chat command button that
+ * launches aks.draftArgoCDDeployment.
+ *
+ * Reference: https://argo-cd.readthedocs.io/en/stable/
+ */
+
+import * as vscode from "vscode";
+import {
+    ILocalPluginHandler,
+    LocalPluginArgs,
+    LocalPluginEntry,
+    LocalPluginManifest,
+    ResponseForLanguageModelExtended,
+} from "../../types/aiazure/AzureAgent";
+import { getArgoCDDeploymentPluginResponse } from "../shared/pluginResponses";
+
+// ---------------------------------------------------------------------------
+// Manifest — describes this skill to the Copilot agent runtime
+// ---------------------------------------------------------------------------
+
+export const argoCDDeploymentFunctionName = "create_argocd_deployment";
+
+export const argoCDDeploymentPluginManifest: LocalPluginManifest = {
+    name: "argoCDDeploymentPlugin",
+    version: "1.0.0",
+    functions: [
+        {
+            name: argoCDDeploymentFunctionName,
+            parameters: [],
+            returnParameter: {
+                type: "object",
+            },
+            willHandleUserResponse: false,
+        },
+    ],
+};
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function handleArgoCDDeployment(): Promise<ResponseForLanguageModelExtended> {
+    const { messageForLanguageModel, buttonLabel, commandID } = getArgoCDDeploymentPluginResponse();
+
+    return {
+        responseForLanguageModel: { messageForLanguageModel },
+        chatResponseParts: [
+            new vscode.ChatResponseCommandButtonPart({
+                title: vscode.l10n.t(buttonLabel),
+                command: commandID,
+                arguments: [],
+            }),
+        ],
+    };
+}
+
+const argoCDDeploymentPluginHandler: ILocalPluginHandler = {
+    execute: async (args: LocalPluginArgs) => {
+        const pluginRequest = args.localPluginRequest;
+
+        if (pluginRequest.functionName === argoCDDeploymentFunctionName) {
+            const { responseForLanguageModel, chatResponseParts } = await handleArgoCDDeployment();
+            return { responseForLanguageModel, chatResponseParts };
+        }
+
+        return {
+            status: "error",
+            message: `Unrecognized function: ${pluginRequest.functionName}`,
+        };
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const argoCDDeploymentPlugin: LocalPluginEntry = {
+    manifest: argoCDDeploymentPluginManifest,
+    handler: argoCDDeploymentPluginHandler,
+};

--- a/src/plugins/getPlugins.ts
+++ b/src/plugins/getPlugins.ts
@@ -2,9 +2,15 @@ import { createAKSClusterPlugin } from "./createAKS/createAKSClusterPlugin";
 import { GetPluginsCommandResult } from "../types/aiazure/AzureAgent";
 import { deployManifestPluginToAKSPlugin } from "./deployManifest/deployManifestToAKSPlugin";
 import { generateKubectlCommandPlugin } from "./kubectlGeneration/generateKubectlCommandPlugin";
+import { argoCDDeploymentPlugin } from "./argoCD/argoCDDeploymentPlugin";
 
 export async function getPlugins(): Promise<GetPluginsCommandResult> {
     return {
-        plugins: [createAKSClusterPlugin, deployManifestPluginToAKSPlugin, generateKubectlCommandPlugin],
+        plugins: [
+            createAKSClusterPlugin,
+            deployManifestPluginToAKSPlugin,
+            generateKubectlCommandPlugin,
+            argoCDDeploymentPlugin,
+        ],
     };
 }

--- a/src/plugins/shared/clusterOptions/options/selectExistingClusterOption.ts
+++ b/src/plugins/shared/clusterOptions/options/selectExistingClusterOption.ts
@@ -20,9 +20,12 @@ export async function selectExistingClusterOption(
         return { succeeded: false, error: "No subscriptions found." };
     }
 
-    const clusters = (
-        await Promise.all(subscriptions.map((sub) => getClusters(sessionProvider, sub.subscriptionId)))
-    ).flat();
+    const clusterResults = await Promise.all(
+        subscriptions.map((sub) => getClusters(sessionProvider, sub.subscriptionId)),
+    );
+    const clusters = clusterResults
+        .filter((r): r is { succeeded: true; result: Cluster[] } => r.succeeded)
+        .flatMap((r) => r.result);
 
     if (clusters.length === 0) {
         handleNoClusterFound();

--- a/src/plugins/shared/pluginResponses.ts
+++ b/src/plugins/shared/pluginResponses.ts
@@ -86,3 +86,24 @@ export const getKubectlCommandPluginErrorResponse = (
         messageForLanguageModel: messageForLanguageModel,
     };
 };
+
+// Argo CD deployment plugin
+export const getArgoCDDeploymentPluginResponse =
+    (): GitHubCopilotForAzureChatPluginResponse<MessageForLanguageModel> => {
+        const messageForLanguageModel = {
+            description:
+                'Argo CD follows the GitOps "Hollywood Principle" — your AKS cluster never pushes; ' +
+                "Argo CD continuously PULLS desired state from a dedicated Git config repository and reconciles it automatically. " +
+                "Use the button below to scaffold an annotated Argo CD Application manifest (application.yaml) in a separate GitOps config repository.",
+            descriptionInstructions:
+                "Explain the Hollywood/GitOps principle clearly: the cluster does NOT push, Argo CD pulls. " +
+                "Strongly advise the user to keep Argo CD manifests in a SEPARATE config repository from their application source code. " +
+                "Mention that the button will guide them through workspace detection and optional folder switching before scaffolding.",
+        };
+
+        return {
+            messageForLanguageModel,
+            commandID: "aks.draftArgoCDDeployment",
+            buttonLabel: "Create Argo CD Deployment",
+        };
+    };

--- a/src/plugins/shared/types.ts
+++ b/src/plugins/shared/types.ts
@@ -34,4 +34,5 @@ export type GitHubCopilotForAzureChatPluginErrorResponse<T> = {
 export type CommandIdForPluginResponse =
     | "aks.aksDeployManifest"
     | "aks.aksOpenKubectlPanel"
-    | "aks.aksCreateClusterFromCopilot";
+    | "aks.aksCreateClusterFromCopilot"
+    | "aks.draftArgoCDDeployment";

--- a/src/plugins/shared/types.ts
+++ b/src/plugins/shared/types.ts
@@ -35,4 +35,5 @@ export type CommandIdForPluginResponse =
     | "aks.aksDeployManifest"
     | "aks.aksOpenKubectlPanel"
     | "aks.aksCreateClusterFromCopilot"
-    | "aks.draftArgoCDDeployment";
+    | "aks.draftArgoCDDeployment"
+    | "aks.argoCDApplyApp";


### PR DESCRIPTION
## Description

This PR delivers related improvements:

**Argo CD GitOps integration** — scaffold, apply, and manage Argo CD applications on AKS clusters directly from VS Code (Argo CD must be pre-installed).

---

## What Changed


### Argo CD GitOps Integration

A full end-to-end Argo CD experience surfaced directly inside the AKS extension. Argo CD must be pre-installed on the cluster — the extension checks for its presence and directs users to the official docs if missing. The feature covers four commands and three new source files.

#### New files

| File | Purpose |
|------|--------|
| `src/commands/aksArgoCD/argoCDInstall.ts` | Check Argo CD pod/service health status on the cluster |
| `src/commands/aksArgoCD/argoCDApplyApp.ts` | Apply an Argo CD Application YAML to a cluster with namespace picker |
| `src/commands/aksArgoCD/argoCDDeployment.ts` | Scaffold an Argo CD GitOps config directory into a local workspace with namespace picker |
| `resources/yaml/argocd-application.template.yaml` | On-disk Application CR template with `{{PLACEHOLDER}}` tokens |

#### Command: `aks.argoCDCheckStatus` — Check Argo CD status (right-click cluster node)

- Prints namespace, pod (wide), and service status to the `Argo CD` output channel.
- If Argo CD is not installed, notifies the user and links to the official Argo CD installation docs.

#### Command: `aks.argoCDApplyApp` — Apply Application YAML to cluster (right-click `.yaml` file / active editor)

Full local-to-cluster workflow:

1. **Parse & validate** — reads file, validates `apiVersion: argoproj.io/v1alpha1 / kind: Application`.
2. **Resolve kubectl context** — uses the active kubectl context directly (no Azure subscription/cluster picker).
3. **Argo CD presence check (early)** — runs before any user confirmation; if Argo CD is not installed, blocks and directs the user to install it first via official docs.
4. **Namespace picker** — container assist-style QuickPick with `longRunning("Loading cluster namespaces...")`. Filters system namespaces (`kube-system`, `kube-public`, `kube-node-lease`, `gatekeeper-system`, `argocd`). Shows AKS desktop project labels (`headlamp.dev/project-managed-by === "aks-desktop"`).
5. **Confirm & Apply** — `kubectl apply -n <namespace> -f <file>` with `longRunning` spinner.
6. **Post-apply notification** with four action buttons:
   - **Open Argo CD UI** — see below.
   - **Get Credentials** — masked display with Copy / Reveal.
   - **Register Repo Credentials** — see below.
   - **Sync Guide** — opens Argo CD docs.

##### Sub-feature: Open Argo CD UI

- Fetches admin credentials first (so they're ready before the browser opens).
- Checks `argocd-server` Service for a LoadBalancer external IP/hostname (`longRunning`).
- If found: shows credentials modal (Copy Password & Open / Open Without Copying) → opens `https://<lb-address>` directly.
- If not found (ClusterIP, common local setup):
  - Verifies `argocd-server` service exists (`longRunning`).
  - Shows credentials modal → copy + start port-forward.
  - Starts `kubectl port-forward svc/argocd-server -n argocd 8080:443` in a dedicated integrated terminal named `Argo CD UI — <cluster>`.
  - Shows terminal so the user can see `Forwarding from 127.0.0.1:8080`.
  - Shows a notification with an **Open Browser** button — the user clicks it once the terminal confirms the tunnel is ready (avoids race condition / "connection refused").

##### Sub-feature: Get Credentials

- `kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath="{.data.password}"` with `longRunning` spinner.
- Base64-decodes the password in-process (never logs to any channel).
- Displays `Username: admin | Password: ••••••••` with **Copy Password** and **Reveal Password** buttons.
- If the secret is absent (user already rotated password), shows an informational message explaining why.

##### Sub-feature: Register Repo Credentials (private repos)

Allows hooking up a private Git repository to Argo CD without leaving VS Code:

- Confirms/edits the `spec.source.repoURL` from the applied application YAML (pre-populated).
- Auth type QuickPick:
  - **HTTPS** — username input + PAT/password input (`password: true`; never logged).
  - **SSH** — file picker for private key file; reads contents into `sshPrivateKey`.
- Builds an Argo CD repository Secret serialized via `js-yaml` (prevents YAML injection).
- Applies it via a temp file (`kubectl apply -f <tmp>`) with `longRunning` spinner.
- Credentials never reach any output channel or log.
- Secret labelled `argocd.argoproj.io/secret-type: repository` — Argo CD picks it up automatically without a restart.

#### Command: `aks.argoCDDraftDeployment` — Scaffold Argo CD config repo (Explorer / command palette)

GitOps "Hollywood Principle" scaffolding — creates the config repo files locally.

1. **Workspace detection** — warns if it looks like an application source repo (Dockerfile, package.json, go.mod, etc.) or already has Kubernetes deployment manifests.
2. **Guidance modal** — explains the separation between config repo and app source repo; offers:
   - **Scaffold Here** — use current workspace folder.
   - **Open Config Repository…** — folder picker to target a separate repo.
3. **Parameter collection** via VS Code input boxes:
   - App name (validated: `[a-z0-9][a-z0-9-]*`).
   - GitOps config repo URL — 3-mode picker:
     - `$(link) Enter a URL` — free-text input.
     - `$(folder-opened) Browse local folder…` — folder picker → reads `.git/config` `origin` remote automatically, pre-populates input.
     - `$(github) Browse GitHub repos…` — `vscode.authentication.getSession('github', ['repo'])` → fetches `/user/repos` from GitHub REST API → searchable QuickPick (label = `owner/repo`, description = public/private, detail = repo description) → HTTPS / SSH format choice → pre-populates input.
   - Source repo URL (optional, same 3-mode picker).
   - Target cluster API server URL.
   - Target namespace — container assist-style QuickPick with `longRunning("Loading cluster namespaces...")`. Filters system namespaces. Shows AKS desktop project labels.
   - Container image.
   - Container port.
4. **Scaffolds 4 files** under `apps/<name>/`:
   - `application.yaml` — loaded from `resources/yaml/argocd-application.template.yaml`, placeholders (`{{APP_NAME}}`, `{{CONFIG_REPO_URL}}`, `{{SOURCE_REPO_URL}}`, `{{CLUSTER_SERVER}}`, `{{NAMESPACE}}`, `{{APP_PATH}}`) substituted at runtime.
   - `deployment.yaml` — security-hardened Deployment (non-root, `readOnlyRootFilesystem`, dropped capabilities, resource limits, readiness/liveness probes).
   - `service.yaml` — ClusterIP Service (easily changed to LoadBalancer).
   - `README.md` — step-by-step setup guide (install, access UI, register repo, day-2 workflow, webhook setup, monitoring commands).
5. **Post-scaffold notification** with quick-open buttons for README, deployment.yaml, service.yaml.

#### `resources/yaml/argocd-application.template.yaml`

Extracted from the previous inline template string — now a proper YAML file with syntax highlighting, linting, and easy editing.  Placeholders use `{{DOUBLE_BRACE}}` convention consistent with other extension templates.

---

## Why

- **Quick Actions** — reduce interaction steps for common AKS actions.
- **App-Mod bridging** — clearer entry point separating modernization from containerization.
- **Argo CD** — Argo CD is the most popular GitOps tool for Kubernetes. Surfacing install, scaffold, apply, credentials, and private-repo setup inside the extension eliminates manual `kubectl` and `argocd` CLI steps, making the GitOps workflow accessible to users who are new to Argo CD.

---

## Validation Checklist

### Quick Actions
- [ ] `AKS Quick Actions` appears on AKS cluster context only in simplified menu mode.
- [ ] Quick Actions works on both AKS cluster and subscription nodes.
- [ ] Command ranking changes after repeated command selections.

### App-Mod bridging
- [ ] Folder Explorer context shows `Migrate Application to AKS` submenu when preview flag is enabled.
- [ ] `Containerization App` opens existing Container Assist flow.
- [ ] `Migrate and Modernize App` prompts install / opens explorer / shows graceful error.

### Argo CD — Check Status
- [ ] `Check Argo CD Status` appears in cluster right-click menu.
- [ ] Output channel shows pod/service status.
- [ ] If Argo CD not installed, notification directs to official docs.

### Argo CD — Apply App
- [ ] Right-clicking a non-Application YAML shows a clear error.
- [ ] Right-clicking a valid `Application` YAML resolves kubectl context.
- [ ] If Argo CD missing: blocks and directs user to install via official docs.
- [ ] Namespace picker shows non-system namespaces with AKS desktop labels.
- [ ] Success notification shows all four action buttons.
- [ ] **Open Argo CD UI** (LoadBalancer path) — opens `https://<lb-ip>` directly after credentials modal.
- [ ] **Open Argo CD UI** (ClusterIP path) — starts port-forward terminal, shows "Open Browser" button; browser opens only after user confirms.
- [ ] **Get Credentials** — shows masked password; Copy writes to clipboard; Reveal shows plaintext.
- [ ] If `argocd-initial-admin-secret` is absent — shows explanation message, does not crash.
- [ ] **Register Repo Credentials** (HTTPS) — creates Secret without logging token; Argo CD reconciles.
- [ ] **Register Repo Credentials** (SSH) — reads key file, creates Secret without logging key.

### Argo CD — Scaffold Deployment
- [ ] App-source-repo warning appears when Dockerfile / package.json / go.mod present.
- [ ] "Scaffold Here" writes 4 files into `apps/<name>/` of current workspace.
- [ ] "Open Config Repository…" folder picker targets a different folder.
- [ ] "Enter a URL" input validates and accepts URL.
- [ ] "Browse local folder…" reads `.git/config` origin and pre-populates input.
- [ ] "Browse GitHub repos…" — GitHub sign-in prompt appears; repo list is searchable; HTTPS/SSH format choice works.
- [ ] Generated `application.yaml` is valid YAML with all placeholders substituted.
- [ ] Post-scaffold notification opens correct files.

---

## Risk and Compatibility

- No breaking changes to existing AKS command handlers.
- Argo CD commands are purely additive — new context-menu entries and new source files.
- `vscode.git` was already a declared `extensionDependency`; no new extension dependencies added.
- GitHub authentication uses VS Code's built-in `vscode.authentication` provider — no OAuth credentials stored by the extension.
- Repo credentials Secret is applied via a temp file; credentials are never written to output channels, logs, or telemetry.

## Sample VISX for playground:

- [vscode-aks-tools-1.7.6-argo-test.vsix.zip](https://github.com/user-attachments/files/27177770/vscode-aks-tools-1.7.6-argo-test.vsix.zip)

