### PR TITLE
Bumps `eslint-plugin-react-hooks` from 7.0.1 to 7.1.1 and fixes resulting build breaks.

### DIFF
--- a/src/commands/aksContainerAssist/prompts.ts
+++ b/src/commands/aksContainerAssist/prompts.ts
@@ -150,11 +150,11 @@ export function buildK8sManifestUserPrompt(
     const formattedPlan = formatGenerateK8sManifestsResult(plan);
 
     const ports = repoInfo?.ports || [];
-    const dependencies = repoInfo?.frameworks || [];
+    const dependencyNames = repoInfo?.frameworks?.map((f) => f.name) || [];
     const frameworks = repoInfo?.frameworks?.map((f) => f.name) || [];
 
     const isWebApp = ports.length > 0 || frameworks.some((f) => WEB_FRAMEWORK_REGEX.test(f));
-    const hasExternalDependencies = dependencies.some((d) => EXTERNAL_DEPENDENCY_REGEX.test(d.name));
+    const hasExternalDependencies = dependencyNames.some((d) => EXTERNAL_DEPENDENCY_REGEX.test(d));
 
     const manifestGuidance = buildManifestGuidance(isWebApp, hasExternalDependencies, ports);
 
@@ -173,7 +173,7 @@ Application Details:
 - Framework: ${frameworks.join(", ") || "none"}
 - Ports: ${ports.join(", ") || "none detected — use readProjectFile to check the Dockerfile or source code"}
 - Entry Point: ${repoInfo?.entryPoint || "unknown"}
-- Dependencies: ${dependencies.join(", ") || "none"}
+- Dependencies: ${dependencyNames.join(", ") || "none"}
 ${imageLine ? `${imageLine}` : ""}
 ${manifestGuidance}
 ${buildK8sVerificationHints(ports, repoInfo?.entryPoint)}

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -27,7 +27,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.2.1",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.8",
         "vite-plugin-checker": "^0.12.0",
@@ -2140,10 +2140,11 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -2155,7 +2156,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -7283,9 +7284,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.24.4",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -31,7 +31,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-react": "^7.37.5",
     "typescript": "^6.0.3",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "vite-plugin-checker": "^0.12.0",
     "vite": "^8.0.8",
     "vite-plugin-eslint": "^1.8.1"

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -94,32 +94,7 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
     if (prevInitialResource.isShown !== props.isShown || prevInitialResource.resource !== props.initialGadgetResource) {
         setPrevInitialResource({ isShown: props.isShown, resource: props.initialGadgetResource });
         if (props.isShown && props.initialGadgetResource) {
-            const resource = props.initialGadgetResource;
-            const meta = configuredResources[resource] || null;
-            const extraProps = toExtraPropertyObject(meta?.extraProperties ?? GadgetExtraProperties.None);
-
-            const displayProperties = meta?.defaultProperties || [];
-            const sortSpecifiers = meta?.defaultSort || [];
-            const maxItemCount = extraProps.requiresMaxItemCount
-                ? traceConfig.maxItemCount || defaultMaxItemCount
-                : undefined;
-            const excludeThreads = extraProps.threadExclusionAllowed ? true : undefined;
-            const timeout = extraProps.requiresTimeout ? traceConfig.timeout || defaultTimeoutInSeconds : undefined;
-            const { namespace, podName, containerName, ...rest } = traceConfig.filters!;
-            const filters = extraProps.noK8sResourceFiltering
-                ? { ...rest, namespace: NamespaceSelection.Default }
-                : traceConfig.filters;
-
-            setTraceConfig({
-                ...traceConfig,
-                resource,
-                filters,
-                displayProperties,
-                sortSpecifiers,
-                excludeThreads,
-                maxItemCount,
-                timeout,
-            });
+            onResourceChanged(props.initialGadgetResource);
         }
     }
 

--- a/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
+++ b/webview-ui/src/InspektorGadget/NewTraceDialog.tsx
@@ -85,12 +85,43 @@ export function NewTraceDialog(props: NewTraceDialogProps) {
             timeout,
         });
     }
-    useEffect(() => {
+
+    // Adjust state when props change (React-recommended pattern instead of useEffect + setState)
+    const [prevInitialResource, setPrevInitialResource] = useState<{ isShown: boolean; resource?: string }>({
+        isShown: props.isShown,
+        resource: props.initialGadgetResource,
+    });
+    if (prevInitialResource.isShown !== props.isShown || prevInitialResource.resource !== props.initialGadgetResource) {
+        setPrevInitialResource({ isShown: props.isShown, resource: props.initialGadgetResource });
         if (props.isShown && props.initialGadgetResource) {
-            onResourceChanged(props.initialGadgetResource);
+            const resource = props.initialGadgetResource;
+            const meta = configuredResources[resource] || null;
+            const extraProps = toExtraPropertyObject(meta?.extraProperties ?? GadgetExtraProperties.None);
+
+            const displayProperties = meta?.defaultProperties || [];
+            const sortSpecifiers = meta?.defaultSort || [];
+            const maxItemCount = extraProps.requiresMaxItemCount
+                ? traceConfig.maxItemCount || defaultMaxItemCount
+                : undefined;
+            const excludeThreads = extraProps.threadExclusionAllowed ? true : undefined;
+            const timeout = extraProps.requiresTimeout ? traceConfig.timeout || defaultTimeoutInSeconds : undefined;
+            const { namespace, podName, containerName, ...rest } = traceConfig.filters!;
+            const filters = extraProps.noK8sResourceFiltering
+                ? { ...rest, namespace: NamespaceSelection.Default }
+                : traceConfig.filters;
+
+            setTraceConfig({
+                ...traceConfig,
+                resource,
+                filters,
+                displayProperties,
+                sortSpecifiers,
+                excludeThreads,
+                maxItemCount,
+                timeout,
+            });
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.isShown, props.initialGadgetResource]);
+    }
 
     function handleNodeChanged(node: string | null) {
         const filters = { ...traceConfig.filters, nodeName: node || undefined };


### PR DESCRIPTION
## Summary

Bumps `eslint-plugin-react-hooks` from 7.0.1 to 7.1.1 and fixes resulting build breaks.

## Changes

### package.json / package-lock.json
- Upgrade `eslint-plugin-react-hooks` from `^7.0.1` to `^7.1.1`

### NewTraceDialog.tsx

- The new `react-hooks/set-state-in-effect` rule disallows calling `setState` inside `useEffect`. Replaced the `useEffect`+`setState` pattern with React's recommended ["adjusting state during render"](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern by tracking previous props and updating state synchronously during render.

### `src/commands/aksContainerAssist/prompts.ts`

- Fixed type error where framework objects (with a `.name` property) were being passed directly to `join()` and `EXTERNAL_DEPENDENCY_REGEX.test()` instead of their `.name` strings.

## Testing

- `npm run webpack` completes successfully.