### PR TITLE
Publish release 1.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR publishes release `1.7.6` with following work summary:

- [Update aksDocsRAGEndpoint URL to new infrastructure endpoint (](https://github.com/Azure/vscode-aks-tools/commit/c65a995a8b75e99db2f150d59c0ae46af9337b33)[#2086](https://github.com/Azure/vscode-aks-tools/pull/2086)[)](https://github.com/Azure/vscode-aks-tools/commit/c65a995a8b75e99db2f150d59c0ae46af9337b33)

- [fix(containerAssist): detect manifests via module paths in workflow generator (](https://github.com/Azure/vscode-aks-tools/commit/31dce9f743c49e26b36da4d5a4a41e48fc9d27c4)[#2071](https://github.com/Azure/vscode-aks-tools/pull/2071)[)](https://github.com/Azure/vscode-aks-tools/commit/31dce9f743c49e26b36da4d5a4a41e48fc9d27c4)

- [feat: split tree-view Container Assist into discrete cluster actions (](https://github.com/Azure/vscode-aks-tools/commit/b339ca597cbb57b03c9f3797465e68b872e36cd8)[#2069](https://github.com/Azure/vscode-aks-tools/pull/2069)[)](https://github.com/Azure/vscode-aks-tools/commit/b339ca597cbb57b03c9f3797465e68b872e36cd8)

- [Fix dependabot dependency bumps (](https://github.com/Azure/vscode-aks-tools/commit/31aac43eaf065dfec7dd4deceb9d8aa0163e271d)[#2089](https://github.com/Azure/vscode-aks-tools/pull/2089)[)](https://github.com/Azure/vscode-aks-tools/commit/31aac43eaf065dfec7dd4deceb9d8aa0163e271d)

- Dependabots updates.

VSIX for testing:

~~[vscode-aks-tools-1.7.6-test.vsix.zip](https://github.com/user-attachments/files/27040327/vscode-aks-tools-1.7.6-test.vsix.zip)~~

Latest:  [vscode-aks-tools-1.7.6-test-latest.vsix.zip](https://github.com/user-attachments/files/27068217/vscode-aks-tools-1.7.6-test-latest.vsix.zip)


