### PR TITLE
fix: pass repositoryPath to generateK8sManifests for SDK v1.4.0 compatibility.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "@octokit/rest": "^22.0.1",
                 "@vscode/extension-telemetry": "^1.5.0",
                 "@vscode/l10n": "^0.0.18",
-                "containerization-assist-mcp": "^1.3.2",
+                "containerization-assist-mcp": "^1.4.0",
                 "decompress": "^4.2.1",
                 "js-yaml": "^4.1.1",
                 "libsodium-wrappers": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -1029,7 +1029,7 @@
         "@octokit/rest": "^22.0.1",
         "@vscode/extension-telemetry": "^1.5.0",
         "@vscode/l10n": "^0.0.18",
-        "containerization-assist-mcp": "^1.3.2",
+        "containerization-assist-mcp": "^1.4.0",
         "decompress": "^4.2.1",
         "js-yaml": "^4.1.1",
         "libsodium-wrappers": "^0.8.2",

--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -193,6 +193,7 @@ export class ContainerAssistService {
         imageRepository?: string,
         signal?: AbortSignal,
         token?: vscode.CancellationToken,
+        repositoryPath?: string,
     ): Promise<Errorable<string[]>> {
         const lmResult = await this.lmClient.ensureModel();
         if (failed(lmResult)) {
@@ -204,6 +205,7 @@ export class ContainerAssistService {
 
             const requestParams = {
                 manifestType: "kubernetes" as const,
+                repositoryPath: repositoryPath || modulePath,
                 modulePath,
                 name: appName,
                 namespace: targetNamespace,
@@ -385,6 +387,7 @@ export class ContainerAssistService {
                     imageRepository,
                     signal,
                     token,
+                    folderPath,
                 );
                 if (failed(manifestsResult)) {
                     logger.error(`Workflow failed at manifests step for module: ${module.name}`, manifestsResult.error);


### PR DESCRIPTION
**## Fix: Pass `repositoryPath` to `generateK8sManifests` for SDK v1.4.0 compatibility**

Fixes #2101

### Problem

After bumping `containerization-assist-mcp` from `1.2.0` to `1.3+`, the Kubernetes manifest generation fails with:

> Failed to generate deployment files: Validation failed: acaManifest: Either provide acaManifest (for ACA conversion) or repositoryPath+modulePath (for repository analysis)

The SDK introduced a `superRefine` validation in `generateK8sManifests` that requires either:
- `acaManifest` (for ACA conversion), **or**
- `repositoryPath` + `modulePath` (for repository analysis)

Our code was only passing `modulePath`, which no longer satisfies the schema.

### Fix

- Added `repositoryPath` parameter to `generateManifests()` in `ContainerAssistService`
- Passed `repositoryPath` (falling back to `modulePath`) in the SDK request params
- Threaded `folderPath` from `generateDeploymentFiles()` as the repository path
- Bumped `containerization-assist-mcp` to `^1.4.0`

### Changes

| File | Change |
|------|--------|
| containerAssistService.ts | Add `repositoryPath` param and pass it to SDK |
| package.json | Bump `containerization-assist-mcp` to `^1.4.0` |

### Testing

- Existing test (containerAssistService.test.ts) continues to pass — `repositoryPath` is optional with a safe fallback to `modulePath`
- Manually verified the SDK schema accepts `repositoryPath` + `modulePath` without validation errors

Thanks and gentle cc: @bosesuneha and cc: @gambtho and @davidgamero ❤️ 