### PR TITLE
fix: remove excessive logger.debug calls from Container Assist (#2062)

### DIFF
--- a/src/commands/aksContainerAssist/aksContainerAssist.ts
+++ b/src/commands/aksContainerAssist/aksContainerAssist.ts
@@ -39,8 +39,6 @@ export async function runContainerAssist(
     defaultActions: ContainerAssistAction[] = [],
 ): Promise<void> {
     try {
-        logger.debug("Command target", target);
-
         const targetUri = getTargetUri(target);
         if (!targetUri) {
             logger.warn("No valid target URI found");
@@ -49,7 +47,6 @@ export async function runContainerAssist(
             );
             return;
         }
-        logger.debug("Target URI", targetUri.fsPath);
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(targetUri);
         if (!workspaceFolder) {
@@ -57,7 +54,6 @@ export async function runContainerAssist(
             vscode.window.showErrorMessage(l10n.t("The selected item is not part of a workspace."));
             return;
         }
-        logger.debug("Workspace folder", workspaceFolder.uri.fsPath);
 
         const containerAssistService = new ContainerAssistService();
         const availabilityCheck = await containerAssistService.isAvailable();
@@ -72,7 +68,6 @@ export async function runContainerAssist(
             const stat = await fs.stat(startPath);
             if (stat.isFile()) {
                 startPath = path.dirname(startPath);
-                logger.debug("Target was a file, using parent directory", startPath);
             }
         } catch (error) {
             logger.error("Failed to stat target path", error);
@@ -108,8 +103,6 @@ export async function runContainerAssistFromTree(
     defaultActions: ContainerAssistAction[] = [],
 ): Promise<void> {
     try {
-        logger.debug("Container Assist from tree, target", target);
-
         // Step 1: Resolve the cluster tree node
         const cloudExplorer = await k8s.extension.cloudExplorer.v1;
         const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
@@ -119,7 +112,6 @@ export async function runContainerAssistFromTree(
         }
 
         const { subscriptionId, resourceGroupName, name: clusterName } = clusterNode.result;
-        logger.debug("Cluster from tree", { subscriptionId, resourceGroupName, clusterName });
 
         // Step 2: Determine workspace folder / project root
         const workspaceFolder = await pickWorkspaceFolder();
@@ -220,7 +212,6 @@ async function findProjectRoot(startPath: string, workspaceRoot: string): Promis
                 const files = await fs.readdir(currentPath);
                 const foundExtension = extensionIndicators.find((ext) => files.some((f) => f.endsWith(ext)));
                 if (foundExtension) {
-                    logger.debug(`Found project root at: ${currentPath} (indicator: *${foundExtension})`);
                     return currentPath;
                 }
             } catch {
@@ -232,7 +223,6 @@ async function findProjectRoot(startPath: string, workspaceRoot: string): Promis
         for (const indicator of fileIndicators) {
             try {
                 await fs.access(path.join(currentPath, indicator));
-                logger.debug(`Found project root at: ${currentPath} (indicator: ${indicator})`);
                 return currentPath;
             } catch {
                 // File doesn't exist, continue
@@ -246,7 +236,6 @@ async function findProjectRoot(startPath: string, workspaceRoot: string): Promis
         currentPath = parentPath;
     }
 
-    logger.debug(`No project root found, using original path: ${startPath}`);
     return startPath;
 }
 
@@ -424,7 +413,6 @@ async function generateDeploymentFiles(
     azureContext: AzureContext,
 ): Promise<ActionResult | undefined> {
     const displayName = path.basename(targetPath);
-    logger.debug("Target path", targetPath);
 
     const acrLoginServer = `${azureContext.acrName}.azurecr.io`;
 
@@ -482,11 +470,9 @@ async function generateDeploymentFiles(
     }
 
     const generatedFiles = result.result.generatedFiles;
-    logger.debug("Generated files", generatedFiles);
 
     if (generatedFiles.length === 0) {
         if (hasBothActions) {
-            logger.debug("No new deployment files generated (files may already exist)");
             return { deploymentFiles: [] };
         }
         logger.warn("No files were generated");
@@ -514,7 +500,6 @@ async function generateWorkflowFile(options: WorkflowGenerationOptions): Promise
 
     if (failed(result)) {
         if (result.error === "cancelled") {
-            logger.debug("Workflow generation cancelled by user");
             return undefined;
         }
         logger.error("GitHub workflow generation failed", result.error);

--- a/src/commands/aksContainerAssist/azureSelections.ts
+++ b/src/commands/aksContainerAssist/azureSelections.ts
@@ -171,7 +171,6 @@ export async function fetchClusterNamespaces(
     const namespacesResult = await longRunning(l10n.t("Loading cluster namespaces..."), () =>
         getClusterNamespacesWithTypes(sessionProvider, kubectl, subscriptionId, cluster.resourceGroup, cluster.name),
     );
-    logger.debug(`Namespaces with types for cluster '${cluster.name}':`, namespacesResult);
 
     if (!namespacesResult.succeeded && !isNamespacesListForbidden(namespacesResult.error)) {
         vscode.window.showErrorMessage(
@@ -181,9 +180,6 @@ export async function fetchClusterNamespaces(
     }
 
     if (!namespacesResult.succeeded) {
-        logger.debug(
-            `Namespace list forbidden for cluster '${cluster.name}'. Falling back to ARM-managed namespaces only.`,
-        );
         return fetchManagedNamespacesWithWarning(sessionProvider, subscriptionId, cluster);
     }
 
@@ -208,7 +204,6 @@ async function fetchManagedNamespacesWithWarning(
         logger.warn(`Failed to load managed namespaces for cluster '${cluster.name}': ${armResult.error}`);
     }
     const managedNames = armResult.succeeded ? armResult.result : [];
-    logger.debug(`Managed namespaces for cluster '${cluster.name}':`, managedNames);
 
     const learnMoreLabel = l10n.t("Learn more");
     void vscode.window
@@ -398,7 +393,6 @@ async function getAttachedAcrs(
     const attachedAcrs: DefinedResourceWithGroup[] = [];
 
     for (const acr of allAcrs) {
-        logger.debug(`Checking role assignments for ACR '${acr.name}' (RG: ${acr.resourceGroup})`);
         const roleAssignments = await getPrincipalRoleAssignmentsForAcr(
             authClient,
             principalId,
@@ -411,10 +405,6 @@ async function getAttachedAcrs(
             continue;
         }
 
-        logger.debug(
-            `ACR '${acr.name}': ${roleAssignments.result.length} role assignment(s) found for principal ${principalId}`,
-        );
-
         const hasAcrPull = roleAssignments.result.some((ra) => {
             if (!ra.roleDefinitionId) return false;
             const roleDefName = ra.roleDefinitionId.split("/").pop();
@@ -423,8 +413,6 @@ async function getAttachedAcrs(
 
         if (hasAcrPull) {
             attachedAcrs.push(acr);
-        } else {
-            logger.debug(`ACR '${acr.name}' is NOT attached to cluster '${cluster.name}' (no AcrPull role)`);
         }
     }
 
@@ -440,7 +428,6 @@ async function getClusterPrincipalId(
     subscriptionId: string,
     cluster: Cluster,
 ): Promise<string | undefined> {
-    logger.debug(`Fetching managed cluster details for '${cluster.name}' in resource group '${cluster.resourceGroup}'`);
     const managedClusterResult = await getManagedCluster(
         sessionProvider,
         subscriptionId,
@@ -454,7 +441,6 @@ async function getClusterPrincipalId(
     }
 
     const managedCluster = managedClusterResult.result;
-    logger.debug(`Cluster identity type: ${managedCluster.identity?.type ?? "none"}`);
 
     // Prefer kubelet identity (managed identity clusters)
     const hasManagedIdentity =
@@ -519,7 +505,6 @@ async function ensureAcrPullForKubelet(
     });
 
     if (hasAcrPull) {
-        logger.debug(`AcrPull already assigned to kubelet identity for ACR '${acr.name}'`);
         return;
     }
 
@@ -612,7 +597,6 @@ export async function promptForWorkflowName(appName: string): Promise<string | u
         return showWizardExitConfirmation(() => promptForWorkflowName(appName));
     }
 
-    logger.debug("Workflow name selected", workflowName);
     return workflowName;
 }
 
@@ -641,7 +625,6 @@ async function collectAzureContextForCluster(
     const namespaceData = await fetchClusterNamespaces(sessionProvider, subscriptionId, cluster);
     const namespaceSelection = await selectClusterNamespace(sessionProvider, subscriptionId, cluster, namespaceData);
     if (!namespaceSelection) return undefined;
-    logger.debug(`Namespace selected: ${namespaceSelection.name} (isManaged: ${namespaceSelection.isManaged})`);
 
     const acr = await selectClusterAcr(sessionProvider, subscriptionId, cluster);
     if (!acr) return undefined;
@@ -679,11 +662,9 @@ export async function collectAzureContext(
 
     const subscription = await selectAzureSubscription(sessionProvider);
     if (!subscription) return undefined;
-    logger.debug("Subscription selected", subscription.name);
 
     const cluster = await selectAksCluster(sessionProvider, subscription.id);
     if (!cluster) return undefined;
-    logger.debug("Cluster selected", cluster.name);
 
     return collectAzureContextForCluster(sessionProvider, subscription.id, cluster, hasWorkflow, projectRoot);
 }

--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -44,7 +44,6 @@ export class ContainerAssistService {
         try {
             const config = vscode.workspace.getConfiguration("aks");
             const isEnabled = config.get<boolean>("containerAssistEnabledPreview", false);
-            logger.debug("containerAssistEnabledPreview setting", isEnabled);
 
             if (!isEnabled) {
                 const errorMsg = l10n.t(
@@ -70,7 +69,6 @@ export class ContainerAssistService {
     async analyzeRepository(folderPath: string, signal?: AbortSignal): Promise<Errorable<AnalyzeRepositoryResult>> {
         try {
             const requestParams = { repositoryPath: folderPath };
-            logger.debug("analyzeRepo request", requestParams);
             logger.toolRequest("analyzeRepo", requestParams);
 
             const result = await analyzeRepo(requestParams, { signal });
@@ -82,7 +80,6 @@ export class ContainerAssistService {
             }
 
             const analysis: RepositoryAnalysis = result.value;
-            logger.debug("analyzeRepo response", analysis);
             logger.toolResponse("analyzeRepo", analysis);
 
             const modules: ModuleAnalysisResult[] = (analysis.modules || []).map((module) => ({
@@ -97,10 +94,6 @@ export class ContainerAssistService {
             }));
 
             const isMonorepo = analysis.isMonorepo ?? modules.length > 1;
-
-            if (modules.length > 0) {
-                logger.debug(`Analyzed ${modules.length} modules`, modules);
-            }
 
             return {
                 succeeded: true,
@@ -130,7 +123,6 @@ export class ContainerAssistService {
                 framework: moduleInfo.framework,
                 detectedDependencies: moduleInfo.dependencies,
             };
-            logger.debug("generateDockerfile request", requestParams);
             logger.toolRequest("generateDockerfile", requestParams);
 
             const result = await sdkGenerateDockerfile(requestParams, { signal });
@@ -142,7 +134,6 @@ export class ContainerAssistService {
             }
 
             const plan: DockerfilePlan = result.value;
-            logger.debug("generateDockerfile response", plan);
             logger.toolResponse("generateDockerfile", plan);
 
             const dockerfileContent = await this.generateDockerfileWithLM(plan, modulePath, token);
@@ -223,7 +214,6 @@ export class ContainerAssistService {
                 detectedDependencies: moduleInfo.dependencies,
                 entryPoint: moduleInfo.entryPoint,
             };
-            logger.debug("generateK8sManifests request", requestParams);
             logger.toolRequest("generateK8sManifests", requestParams);
 
             const result = await sdkGenerateK8sManifests(requestParams, { signal });
@@ -235,7 +225,6 @@ export class ContainerAssistService {
             }
 
             const plan: ManifestPlan = result.value;
-            logger.debug("generateK8sManifests response", plan);
             logger.toolResponse("generateK8sManifests", plan);
 
             const manifestsContent = await this.generateManifestsWithLM(
@@ -260,8 +249,6 @@ export class ContainerAssistService {
                 await writeFile(manifestPath, manifest.content);
                 manifestPaths.push(manifestPath);
             }
-
-            logger.debug("Generated manifest paths", manifestPaths);
 
             return { succeeded: true, result: manifestPaths };
         } catch (error) {
@@ -306,8 +293,6 @@ export class ContainerAssistService {
         onProgress?: (message: string) => void,
     ): Promise<Errorable<DeploymentResult>> {
         const reportProgress = (message: string) => onProgress?.(message);
-
-        logger.debug("Deployment workflow params", { folderPath, acrLoginServer, namespace });
 
         const existingFiles = await this.checkExistingFiles(folderPath);
 
@@ -397,8 +382,6 @@ export class ContainerAssistService {
                 allManifestPaths.push(...manifestsResult.result);
             }
         }
-
-        logger.debug("Generated files", allGeneratedFiles);
 
         const primaryModuleName = modules[0]?.name;
 

--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -39,7 +39,6 @@ export async function checkExistingFiles(folderPath: string): Promise<ExistingFi
         if (dockerfilePaths.length > 0) {
             result.hasDockerfile = true;
             result.dockerfilePath = dockerfilePaths[0];
-            logger.debug("Found existing Dockerfile(s)", dockerfilePaths);
         }
 
         // Check for K8s manifests
@@ -48,8 +47,6 @@ export async function checkExistingFiles(folderPath: string): Promise<ExistingFi
         if (manifests.length > 0) {
             result.hasK8sManifests = true;
             result.k8sManifestPaths = manifests;
-        } else {
-            logger.debug("No K8s manifests found in project");
         }
     } catch (error) {
         logger.error("Error checking existing files", error);
@@ -148,15 +145,14 @@ export async function scanForK8sManifests(rootPath: string): Promise<string[]> {
     // Check priority folders
     for (const folder of priorityFolders) {
         const folderPath = path.join(rootPath, folder);
-        await scanDirectory(folderPath, manifestSet, false);
+        await scanDirectory(folderPath, manifestSet);
     }
 
     // Check root directory for loose manifests
-    await scanDirectory(rootPath, manifestSet, false);
+    await scanDirectory(rootPath, manifestSet);
 
     // If nothing found, do shallow recursive search (max 2 levels)
     if (manifestSet.size === 0) {
-        logger.debug("No manifests in common locations, performing shallow recursive search");
         await scanDirectoryRecursive(rootPath, manifestSet, 2, 0);
     }
 
@@ -166,7 +162,7 @@ export async function scanForK8sManifests(rootPath: string): Promise<string[]> {
 /**
  * Scans a single directory for K8s manifests (non-recursive)
  */
-async function scanDirectory(dirPath: string, manifestSet: Set<string>, isRecursive: boolean): Promise<void> {
+async function scanDirectory(dirPath: string, manifestSet: Set<string>): Promise<void> {
     try {
         const dirStat = await vscode.workspace.fs.stat(vscode.Uri.file(dirPath));
         if (dirStat.type !== vscode.FileType.Directory) {
@@ -183,9 +179,6 @@ async function scanDirectory(dirPath: string, manifestSet: Set<string>, isRecurs
                 const fullPath = path.join(dirPath, name);
                 if (await isKubernetesManifest(fullPath)) {
                     manifestSet.add(fullPath);
-                    if (!isRecursive) {
-                        logger.debug(`Found K8s manifest: ${fullPath}`);
-                    }
                 }
             });
 
@@ -231,8 +224,8 @@ async function scanDirectoryRecursive(
                 await scanDirectoryRecursive(fullPath, manifestSet, maxDepth, currentDepth + 1);
             }
         }
-    } catch (error) {
-        logger.debug(`Skipping directory ${dirPath}:`, error);
+    } catch {
+        // Directory doesn't exist or can't be read — skip silently
     }
 }
 
@@ -260,8 +253,7 @@ async function isKubernetesManifest(filePath: string): Promise<boolean> {
         const kind = kindMatch[1].trim();
 
         return /^[A-Z][a-zA-Z0-9]*$/.test(kind);
-    } catch (error) {
-        logger.debug(`Failed to validate manifest ${filePath}`, error);
+    } catch {
         return false;
     }
 }
@@ -278,7 +270,6 @@ export async function ensureGitHubWorkflowsDirectory(workspacePath: string): Pro
     await ensureDirectory(githubDir);
     await ensureDirectory(workflowsDir);
 
-    logger.debug("Ensured .github/workflows directory", workflowsDir);
     return workflowsDir;
 }
 

--- a/src/commands/aksContainerAssist/gitHubIntegration.ts
+++ b/src/commands/aksContainerAssist/gitHubIntegration.ts
@@ -51,7 +51,6 @@ async function getGitAPI(): Promise<GitAPI | undefined> {
     }
 
     if (!gitExtension.isActive) {
-        logger.debug("Activating Git extension");
         await gitExtension.activate();
     }
 
@@ -79,7 +78,6 @@ export async function getGitRepository(workspaceUri: vscode.Uri): Promise<Reposi
         return undefined;
     }
 
-    logger.debug("Git repository found", repository.rootUri.fsPath);
     return repository;
 }
 
@@ -105,7 +103,6 @@ export async function stageFiles(repository: Repository, generatedFiles: string[
                         await vscode.workspace.fs.stat(vscode.Uri.file(file));
                         const relativePath = path.relative(repository.rootUri.fsPath, file);
                         filesToStage.push(relativePath);
-                        logger.debug(`File exists and will be staged: ${relativePath}`);
                     } catch (error) {
                         logger.warn(
                             `File does not exist, skipping: ${file} - ${error instanceof Error ? error.message : String(error)}`,
@@ -128,7 +125,6 @@ export async function stageFiles(repository: Repository, generatedFiles: string[
                     // Fallback: use git command directly
                     try {
                         const args = ["add", ...filesToStage];
-                        logger.debug(`Running: git ${args.join(" ")}`);
                         await execFilePromise("git", args, { cwd: repository.rootUri.fsPath });
                         logger.info(`Successfully staged ${filesToStage.length} files via git command`);
                     } catch (cmdError) {
@@ -226,7 +222,6 @@ export async function createPullRequest(generatedFiles: string[], appName: strin
         // Activate extension if needed
         if (!githubExtension.isActive) {
             await githubExtension.activate();
-            logger.debug("GitHub extension activated");
         }
 
         // Get configuration
@@ -245,15 +240,15 @@ export async function createPullRequest(generatedFiles: string[], appName: strin
             base: defaultBranch,
         };
 
-        logger.debug("Creating PR with options", options);
-
         // Try to invoke GitHub extension command
         // Note: The exact command signature may vary based on GitHub extension version
         try {
             await vscode.commands.executeCommand("pr.create", options);
         } catch (error) {
             // Fallback: try alternative command
-            logger.debug("First PR command failed, trying alternative", error);
+            logger.warn(
+                `First PR command failed, trying alternative: ${error instanceof Error ? error.message : String(error)}`,
+            );
             await vscode.commands.executeCommand("github.createPullRequest");
 
             // Show helpful message with suggested PR details

--- a/src/commands/aksContainerAssist/lmClient.ts
+++ b/src/commands/aksContainerAssist/lmClient.ts
@@ -82,11 +82,9 @@ export class LMClient {
                 vscode.LanguageModelChatMessage.User(userPrompt),
             ];
 
-            logger.debug("Sending request to Language Model", { model: this.languageModel.name });
             const response = await this.languageModel.sendRequest(messages, {}, token);
             const content = await this.collectResponseText(response);
 
-            logger.debug("Language Model response received", { contentLength: content.length });
             return { succeeded: true, result: content };
         } catch (error) {
             logger.error("Language Model request failed", error);
@@ -118,12 +116,6 @@ export class LMClient {
                 vscode.LanguageModelChatMessage.User(userPrompt),
             ];
 
-            logger.debug("Sending request with tools to Language Model", {
-                model: this.languageModel.name,
-                tools: options.tools.map((t) => t.name),
-                maxRounds,
-            });
-
             for (let round = 0; round < maxRounds; round++) {
                 const response = await this.languageModel.sendRequest(messages, { tools: options.tools }, token);
                 const { textParts, toolCallParts } = await this.consumeStream(response);
@@ -131,7 +123,6 @@ export class LMClient {
                 // If no tool calls, we're done — return accumulated text
                 if (toolCallParts.length === 0) {
                     const content = textParts.map((p) => p.value).join("");
-                    logger.debug("Tool calling complete", { round: round + 1, contentLength: content.length });
                     return { succeeded: true, result: content };
                 }
 
@@ -153,7 +144,6 @@ export class LMClient {
             const finalContent = await this.collectResponseText(finalResponse);
 
             if (finalContent.length > 0) {
-                logger.debug("Final response after max rounds", { contentLength: finalContent.length });
                 return { succeeded: true, result: finalContent };
             }
 
@@ -208,12 +198,6 @@ export class LMClient {
     ): Promise<vscode.LanguageModelToolResultPart[]> {
         return Promise.all(
             toolCallParts.map(async (toolCall) => {
-                logger.debug("Invoking tool", {
-                    name: toolCall.name,
-                    callId: toolCall.callId,
-                    input: JSON.stringify(toolCall.input),
-                });
-
                 let resultText: string;
                 try {
                     resultText = await toolHandler(toolCall);
@@ -221,12 +205,6 @@ export class LMClient {
                     logger.error(`Tool handler error for "${toolCall.name}"`, toolError);
                     resultText = `Error executing tool "${toolCall.name}": ${String(toolError)}`;
                 }
-
-                logger.debug("Tool result", {
-                    name: toolCall.name,
-                    callId: toolCall.callId,
-                    resultLength: resultText.length,
-                });
 
                 return new vscode.LanguageModelToolResultPart(toolCall.callId, [
                     new vscode.LanguageModelTextPart(resultText),
@@ -250,8 +228,6 @@ export class LMClient {
                 logger.error("No Language Models found");
                 return { succeeded: false, error: errorMsg };
             }
-
-            logger.debug(`Found ${allModels.length} available models`);
 
             const preferences = getModelPreferencesFromConfig();
             const preferredModels = allModels.filter((m) => this.isPreferredModel(m, preferences));

--- a/src/commands/aksContainerAssist/logger.ts
+++ b/src/commands/aksContainerAssist/logger.ts
@@ -53,16 +53,6 @@ class ContainerAssistLogger {
         }
     }
 
-    debug(message: string, data?: unknown): void {
-        const config = vscode.workspace.getConfiguration("aks");
-        if (!config.get<boolean>("containerAssistDebugLogging", false)) return;
-
-        this.getChannel().appendLine(`[DEBUG] ${this.timestamp()} ${message}`);
-        if (data !== undefined) {
-            this.getChannel().appendLine(this.formatData(data));
-        }
-    }
-
     toolRequest(toolName: string, payload: unknown): void {
         const config = vscode.workspace.getConfiguration("aks");
         if (!config.get<boolean>("containerAssistDebugLogging", false)) return;

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -72,8 +72,6 @@ export async function setupOIDCForGitHub(
             return;
         }
 
-        logger.debug("GitHub repository info", repoInfo);
-
         // Prompt user for Azure details
         const azureConfig = await promptForAzureConfig(appName, azureContext);
         if (!azureConfig) {
@@ -250,7 +248,6 @@ async function promptForAzureConfig(appName: string, azureContext?: AzureContext
 
     if (azureContext?.subscriptionId) {
         subscriptionId = azureContext.subscriptionId;
-        logger.debug("OIDC: using subscription from AzureContext", subscriptionId);
     } else {
         const subscriptionsResult = await getSubscriptions(sessionProvider, SelectionType.All);
         if (!succeeded(subscriptionsResult)) {
@@ -473,9 +470,8 @@ async function listManagedIdentities(
         }
 
         return result;
-    } catch (error) {
+    } catch {
         // If the resource group doesn't exist yet, return empty array
-        logger.debug("No existing managed identities found:", error);
         return [];
     }
 }
@@ -497,8 +493,6 @@ async function getManagedIdentity(
         if (!identity.clientId || !identity.tenantId || !identity.principalId) {
             throw new Error("Failed to retrieve managed identity: missing required properties");
         }
-
-        logger.debug(`Using existing managed identity: ${identityName}`);
 
         return {
             clientId: identity.clientId,

--- a/src/commands/aksContainerAssist/workflowGenerator.ts
+++ b/src/commands/aksContainerAssist/workflowGenerator.ts
@@ -88,7 +88,6 @@ async function doGenerateGitHubWorkflow(options: WorkflowGenerationOptions): Pro
 
         // Render template and write file
         const workflowContent = renderWorkflowTemplate(config);
-        logger.debug("Workflow template rendered successfully");
 
         const workflowPath = await writeWorkflowFile(workspaceRoot, workflowName, workflowContent);
 
@@ -135,12 +134,10 @@ async function collectWorkflowConfiguration(
     let dockerfilePath: string | undefined;
     if (hasBothActions && detectedDockerfile) {
         dockerfilePath = detectedDockerfile;
-        logger.debug("Dockerfile auto-detected (skipping prompt — deployment just generated)", dockerfilePath);
     } else {
         dockerfilePath = await promptForDockerfilePath(projectRoot, detectedDockerfiles);
     }
     if (!dockerfilePath) return undefined;
-    logger.debug("Dockerfile path selected", dockerfilePath);
 
     // Build context: use the Dockerfile's directory when in a subdirectory, else ".".
     // Auto-derive when both actions were selected; otherwise prompt.
@@ -149,22 +146,16 @@ async function collectWorkflowConfiguration(
     const defaultBuildContext = dockerfileDir !== "." ? dockerfileDir : ".";
     if (hasBothActions) {
         buildContextPath = defaultBuildContext;
-        logger.debug("Build context auto-derived (skipping prompt — deployment just generated)", buildContextPath);
     } else {
         buildContextPath = await promptForBuildContext(defaultBuildContext);
     }
     if (!buildContextPath) return undefined;
-    logger.debug("Build context path selected", buildContextPath);
 
     // Use known manifest paths from deployment (absolute) instead of re-scanning,
     // so manifests in module subdirectories are always found.
     let relativeManifests: string[];
     if (hasBothActions && knownManifestPaths && knownManifestPaths.length > 0) {
         relativeManifests = knownManifestPaths.map((p) => toPosixPath(path.relative(workspaceRoot, p)));
-        logger.debug(
-            `Using ${relativeManifests.length} known manifest path(s) from deployment generation`,
-            relativeManifests,
-        );
     } else {
         const detection = await detectK8sManifests(workspaceRoot, projectRoot);
         if (!detection.succeeded) {
@@ -186,16 +177,11 @@ async function collectWorkflowConfiguration(
     let selectedManifests: string[] | undefined;
     if (hasBothActions && relativeManifests.length > 0) {
         selectedManifests = relativeManifests;
-        logger.debug(
-            `Auto-selected ${selectedManifests.length} manifest(s) (skipping prompt — deployment just generated)`,
-            selectedManifests,
-        );
     } else {
         selectedManifests = await promptForManifestSelection(relativeManifests);
     }
     if (!selectedManifests) return undefined;
     const manifestPath = formatManifestPathForYamlBlock(selectedManifests);
-    logger.debug("Manifest paths selected", selectedManifests);
 
     return {
         workflowName,

--- a/src/tests/suite/containerAssist/oidcSetup.test.ts
+++ b/src/tests/suite/containerAssist/oidcSetup.test.ts
@@ -61,7 +61,6 @@ describe("setGitHubActionsSecrets", () => {
         // Logger — silence all output
         sandbox.stub(logger.logger, "info");
         sandbox.stub(logger.logger, "error");
-        sandbox.stub(logger.logger, "debug");
         sandbox.stub(logger.logger, "warn");
         sandbox.stub(logger.logger, "show");
 


### PR DESCRIPTION
## Remove excessive `logger.debug` calls from Container Assist

Fixes #2062

### Summary

Cleans up verbose `logger.debug` calls that were introduced during early Container Assist development. These calls provided no user-facing value and cluttered the output channel.

### Changes

- Removed all 71 `logger.debug` calls across 8 files in aksContainerAssist
- Removed the `debug()` method from `ContainerAssistLogger`
- Kept `toolRequest`/`toolResponse` methods (structured SDK call logging gated behind `containerAssistDebugLogging` config)
- Converted one debug call to `logger.warn` in `gitHubIntegration.ts` for a PR command fallback error path
- Fixed resulting ESLint unused-variable errors (catch blocks, removed parameter)
- Removed test stub for deleted `debug` method

### Files Modified

| File | Change |
|------|--------|
| logger.ts | Removed `debug()` method |
| `aksContainerAssist.ts` | Removed 13 debug calls |
| `azureSelections.ts` | Removed 13 debug calls |
| `containerAssistService.ts` | Removed 11 debug calls |
| fileOperations.ts | Removed 7 debug calls, fixed unused vars |
| `gitHubIntegration.ts` | Removed 5 debug calls, converted 1 to warn |
| `lmClient.ts` | Removed 7 debug calls |
| oidcSetup.ts | Removed 4 debug calls, fixed unused var |
| `workflowGenerator.ts` | Removed 8 debug calls |
| oidcSetup.test.ts | Removed stub for deleted method |

### Testing

- `npx tsc --noEmit` passes
- `npm run webpack` builds successfully