### PR TITLE
feat: gate Argo CD commands behind aks.argoCDEnabled feature flag

### DIFF
--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -27,6 +27,7 @@ Azure Kubernetes Service (AKS) Extension for Visual Studio Code helps enable AKS
 * [Install and Deploy KAITO Models](./features/kaito-install-deploy.md)
 * [Manage and Test KAITO Deployments](./features/kaito-manage-test.md)
 * [Use Simplified AKS Menu Structure (Feature Flag)](./features/simplified-menu-structure.md)
+* [Use Argo CD GitOps Integration (Feature Flag)](./features/argocd-gitops-integration.md)
 * [Create AKS Fleet Manager from VS Code](./features/aks-fleet-manager.md)
 * [Setup AKS MCP Server from VS Code](./features/aks-mcp-server-integration.md)
 

--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -7,6 +7,22 @@ The Argo CD integration brings a complete GitOps workflow to AKS clusters direct
 
 ---
 
+## Feature Flag
+
+All Argo CD commands are gated behind a feature flag and **disabled by default**. To enable:
+
+```json
+{
+  "aks.argoCDEnabled": true
+}
+```
+
+Default value: `false`
+
+After changing this setting, reload the VS Code window (`Developer: Reload Window`).
+
+---
+
 ## Prerequisites
 
 - An AKS cluster with Argo CD installed (via `kubectl`, Helm, or the `az k8s-extension` marketplace add-on).

--- a/package.json
+++ b/package.json
@@ -203,6 +203,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Enable simplified menu structure with grouped commands by role (Develop & Deploy, Troubleshoot & Diagnose, Manage Cluster). Requires reload after changing."
+                },
+                "aks.argoCDEnabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable Argo CD GitOps integration commands (Create Argo CD GitOps Pipeline, Apply Argo CD Application, Check Argo CD Status, Post-Deploy Actions). Requires reload after changing."
                 }
             }
         },
@@ -479,16 +484,20 @@
                 },
                 {
                     "command": "aks.draftArgoCDDeployment",
-                    "when": "workspaceFolderCount >= 1"
+                    "when": "workspaceFolderCount >= 1 && config.aks.argoCDEnabled"
                 },
 
                 {
                     "command": "aks.argoCDCheckStatus",
-                    "when": "never"
+                    "when": "config.aks.argoCDEnabled"
                 },
                 {
                     "command": "aks.argoCDApplyApp",
-                    "when": "resourceExtname == .yaml || resourceExtname == .yml"
+                    "when": "(resourceExtname == .yaml || resourceExtname == .yml) && config.aks.argoCDEnabled"
+                },
+                {
+                    "command": "aks.argoCDPostApplyActions",
+                    "when": "config.aks.argoCDEnabled"
                 },
                 {
                     "command": "aks.draftWorkflow",
@@ -529,7 +538,7 @@
                 },
                 {
                     "command": "aks.draftArgoCDDeployment",
-                    "when": "explorerResourceIsFolder",
+                    "when": "explorerResourceIsFolder && config.aks.argoCDEnabled",
                     "group": "5_cutcopypaste@53"
                 },
                 {
@@ -544,14 +553,14 @@
                 },
                 {
                     "command": "aks.argoCDApplyApp",
-                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
+                    "when": "(resourceExtname == .yaml || resourceExtname == .yml) && config.aks.argoCDEnabled",
                     "group": "5_cutcopypaste@56"
                 }
             ],
             "editor/context": [
                 {
                     "command": "aks.argoCDApplyApp",
-                    "when": "resourceExtname == .yaml || resourceExtname == .yml",
+                    "when": "(resourceExtname == .yaml || resourceExtname == .yml) && config.aks.argoCDEnabled",
                     "group": "1_modification@100"
                 }
             ],
@@ -865,7 +874,8 @@
 
                 {
                     "command": "aks.argoCDCheckStatus",
-                    "group": "2_deploy@5"
+                    "group": "2_deploy@5",
+                    "when": "config.aks.argoCDEnabled"
                 },
                 {
                     "submenu": "aks.kaitoInstallSubMenu",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,8 @@ export async function activate(context: vscode.ExtensionContext) {
         // Notify when an Argo CD Application YAML is opened in the editor.
         context.subscriptions.push(
             vscode.workspace.onDidOpenTextDocument(async (document) => {
+                const argoCDEnabled = vscode.workspace.getConfiguration("aks").get<boolean>("argoCDEnabled", false);
+                if (!argoCDEnabled) return;
                 if (document.languageId !== "yaml" && document.languageId !== "yml") return;
                 // Cheap substring pre-check to avoid parsing large YAML files unnecessarily.
                 // Use the full apiVersion key to avoid CodeQL "Incomplete URL substring sanitization" false positive.


### PR DESCRIPTION
### Summary

Introduces a new feature flag `aks.argoCDEnabled` (default: `false`) that controls the visibility of all Argo CD GitOps integration commands. When disabled, Argo CD commands are completely hidden from the UI. When enabled, the full Argo CD workflow becomes available.

### Motivation

The Argo CD integration is a new capability that should be rolled out progressively. By gating it behind an opt-in feature flag, we can:
- Ship the feature without exposing it to all users by default
- Allow internal validation and early adopter feedback
- Maintain a clean command palette for users who don't use Argo CD

### Changes

| File | Change |
|------|--------|
| package.json | Added `aks.argoCDEnabled` boolean config (default `false`) |
| package.json | Added `config.aks.argoCDEnabled` to `when` clauses for all ArgoCD menu entries (command palette, explorer context, editor context, simplified menu) |
| extension.ts | Check feature flag before showing auto-detect notification for Argo CD Application YAMLs |
| argocd-gitops-integration.md | Added Feature Flag section documenting how to enable |
| whats-new-1.7.0.md | Added ArgoCD to the feature flags table and dedicated section |
| README.md | Added ArgoCD feature link to the book's features list |

### How to test

1. With default settings (`aks.argoCDEnabled: false`):
   - Verify no Argo CD commands appear in the command palette
   - Verify no Argo CD entries in explorer/editor context menus
   - Verify opening an Argo CD Application YAML does **not** trigger the "Apply to Cluster" notification

2. With `aks.argoCDEnabled: true` (reload window after changing):
   - Verify all Argo CD commands appear as expected
   - Verify the auto-detect notification works for Application YAMLs

### Related feature flags

| Setting | Default | Purpose |
|---------|---------|---------|
| `aks.argoCDEnabled` | `false` | Argo CD GitOps integration |