### PR TITLE
Publish release 1.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "1.7.7",
+            "version": "1.7.8",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
This PR publishes release `1.7.8` with following work summary:

- [Add Argo CD GitOps integration for AKS clusters (](https://github.com/Azure/vscode-aks-tools/commit/c099b61a0e1a4a7d17f20151f98b3a0f9a6ae575)[#2070](https://github.com/Azure/vscode-aks-tools/pull/2070)[)](https://github.com/Azure/vscode-aks-tools/commit/c099b61a0e1a4a7d17f20151f98b3a0f9a6ae575)

- [fix: remove excessive logger.debug calls from Container Assist (](https://github.com/Azure/vscode-aks-tools/commit/296b4423ad1bd255c797c42743419134994cb757)[#2062](https://github.com/Azure/vscode-aks-tools/issues/2062)[) (](https://github.com/Azure/vscode-aks-tools/commit/296b4423ad1bd255c797c42743419134994cb757)[#2114](https://github.com/Azure/vscode-aks-tools/pull/2114)[)](https://github.com/Azure/vscode-aks-tools/commit/296b4423ad1bd255c797c42743419134994cb757)

- [feat: gate Argo CD commands behind aks.argoCDEnabled feature flag (](https://github.com/Azure/vscode-aks-tools/commit/0c8975fefa9f0c91c5c51eaa20dc23dbcd6b8a72)[#2115](https://github.com/Azure/vscode-aks-tools/pull/2115)[)](https://github.com/Azure/vscode-aks-tools/commit/0c8975fefa9f0c91c5c51eaa20dc23dbcd6b8a72)

-Dependabots updates.

### VSIX for testing:

[vscode-aks-tools-1.7.8-test.zip](https://github.com/user-attachments/files/27381671/vscode-aks-tools-1.7.8-test.zip)


Gentle fyi: ❤️ @bosesuneha, @tejhan, @davidgamero & @gambtho