### PR TITLE
refactor: consolidate filesystem scanners (#2109)

### DIFF
--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -55,23 +55,8 @@ export async function checkExistingFiles(folderPath: string): Promise<ExistingFi
     return result;
 }
 
-/**
- * Searches recursively (up to maxDepth levels) for Dockerfiles under rootPath.
- * Returns absolute paths sorted shallowest-first; excluded dirs are skipped.
- */
-export async function scanForDockerfiles(rootPath: string, maxDepth: number = 3): Promise<string[]> {
-    const found: string[] = [];
-    await scanForDockerfilesRecursive(rootPath, found, maxDepth, 0);
-    // Sort shallowest first
-    found.sort((a, b) => {
-        const aDepth = a.split(path.sep).length;
-        const bDepth = b.split(path.sep).length;
-        return aDepth - bDepth;
-    });
-    return found;
-}
-
-const DOCKERFILE_EXCLUDED_DIRS = new Set([
+/** Directories to skip during recursive scans (build artifacts, dependencies, etc.) */
+const EXCLUDED_DIRS = new Set([
     "node_modules",
     ".git",
     "dist",
@@ -89,139 +74,75 @@ const DOCKERFILE_EXCLUDED_DIRS = new Set([
     "bin",
     "obj",
     ".terraform",
+    ".gradle",
+    ".idea",
+    ".settings",
+    ".mvn",
 ]);
 
-async function scanForDockerfilesRecursive(
-    dirPath: string,
-    found: string[],
-    maxDepth: number,
-    currentDepth: number,
-): Promise<void> {
-    if (currentDepth > maxDepth) {
-        return;
-    }
+/** Maximum directory depth for Dockerfile and manifest scanning. */
+const SCAN_MAX_DEPTH = 3;
 
-    try {
-        const dirStat = await vscode.workspace.fs.stat(vscode.Uri.file(dirPath));
-        if (dirStat.type !== vscode.FileType.Directory) {
-            return;
+/**
+ * Searches recursively (up to 3 levels deep) for Dockerfiles under rootPath.
+ * Returns absolute paths sorted shallowest-first; excluded dirs are skipped.
+ */
+export async function scanForDockerfiles(rootPath: string): Promise<string[]> {
+    const found: string[] = [];
+    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, (filePath, name) => {
+        if (name === "Dockerfile") {
+            found.push(filePath);
         }
-
-        const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath));
-
-        for (const [name, type] of entries) {
-            if (type === vscode.FileType.File && name === "Dockerfile") {
-                found.push(path.join(dirPath, name));
-            } else if (type === vscode.FileType.Directory && !DOCKERFILE_EXCLUDED_DIRS.has(name)) {
-                await scanForDockerfilesRecursive(path.join(dirPath, name), found, maxDepth, currentDepth + 1);
-            }
-        }
-    } catch {
-        // Directory doesn't exist or can't be read — skip silently
-    }
+    });
+    // Sort shallowest first
+    found.sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+    return found;
 }
 
 /**
- * Unified scanner for K8s manifests with single-pass directory traversal
- * Searches common locations first, then falls back to shallow recursive scan
+ * Scans for K8s manifests up to 3 levels deep under rootPath.
+ * Validates each .yaml/.yml file has apiVersion + kind to avoid false positives.
+ * Returns absolute paths.
  */
 export async function scanForK8sManifests(rootPath: string): Promise<string[]> {
-    const manifestSet = new Set<string>();
-
-    // Common K8s manifest folders (checked first for performance)
-    const priorityFolders = [
-        getK8sManifestFolder(), // User-configured or default "k8s"
-        "manifests",
-        "kubernetes",
-        "deploy",
-        "deployment",
-        ".kube",
-        "charts",
-        "config",
-        "infra",
-        "infrastructure",
-    ];
-
-    // Check priority folders
-    for (const folder of priorityFolders) {
-        const folderPath = path.join(rootPath, folder);
-        await scanDirectory(folderPath, manifestSet);
-    }
-
-    // Check root directory for loose manifests
-    await scanDirectory(rootPath, manifestSet);
-
-    // If nothing found, do shallow recursive search (max 2 levels)
-    if (manifestSet.size === 0) {
-        await scanDirectoryRecursive(rootPath, manifestSet, 2, 0);
-    }
-
-    return Array.from(manifestSet);
-}
-
-/**
- * Scans a single directory for K8s manifests (non-recursive)
- */
-async function scanDirectory(dirPath: string, manifestSet: Set<string>): Promise<void> {
-    try {
-        const dirStat = await vscode.workspace.fs.stat(vscode.Uri.file(dirPath));
-        if (dirStat.type !== vscode.FileType.Directory) {
-            return;
+    const manifests: string[] = [];
+    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, async (filePath, name) => {
+        if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+            if (await isKubernetesManifest(filePath)) {
+                manifests.push(filePath);
+            }
         }
-
-        const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath));
-
-        const fileChecks = entries
-            .filter(
-                ([name, type]) => type === vscode.FileType.File && (name.endsWith(".yaml") || name.endsWith(".yml")),
-            )
-            .map(async ([name]) => {
-                const fullPath = path.join(dirPath, name);
-                if (await isKubernetesManifest(fullPath)) {
-                    manifestSet.add(fullPath);
-                }
-            });
-
-        await Promise.all(fileChecks);
-    } catch {
-        // Directory doesn't exist or can't be read - skip silently
-    }
+    });
+    return manifests;
 }
 
 /**
- * Recursively scans directories for K8s manifests up to specified depth
+ * Generic depth-limited directory walker. Calls `onFile` for each file found.
+ * Skips excluded directories. The callback can be async.
+ * Handles symlinks via bitwise FileType checks.
  */
-async function scanDirectoryRecursive(
+async function walkDirectory(
     dirPath: string,
-    manifestSet: Set<string>,
     maxDepth: number,
     currentDepth: number,
+    onFile: (filePath: string, name: string) => void | Promise<void>,
 ): Promise<void> {
     if (currentDepth > maxDepth) {
         return;
     }
 
     try {
-        const dirStat = await vscode.workspace.fs.stat(vscode.Uri.file(dirPath));
-        if (dirStat.type !== vscode.FileType.Directory) {
-            return;
-        }
-
         const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath));
 
         for (const [name, type] of entries) {
-            if (DOCKERFILE_EXCLUDED_DIRS.has(name)) {
-                continue;
-            }
-
             const fullPath = path.join(dirPath, name);
+            const isFile = (type & vscode.FileType.File) !== 0;
+            const isDir = (type & vscode.FileType.Directory) !== 0;
 
-            if (type === vscode.FileType.File && (name.endsWith(".yaml") || name.endsWith(".yml"))) {
-                if (await isKubernetesManifest(fullPath)) {
-                    manifestSet.add(fullPath);
-                }
-            } else if (type === vscode.FileType.Directory) {
-                await scanDirectoryRecursive(fullPath, manifestSet, maxDepth, currentDepth + 1);
+            if (isFile) {
+                await onFile(fullPath, name);
+            } else if (isDir && !EXCLUDED_DIRS.has(name)) {
+                await walkDirectory(fullPath, maxDepth, currentDepth + 1, onFile);
             }
         }
     } catch {
@@ -230,7 +151,8 @@ async function scanDirectoryRecursive(
 }
 
 /**
- * Validates if a YAML file is a Kubernetes manifest
+ * Validates if a YAML file is a Kubernetes manifest.
+ * Handles both LF and CRLF line endings.
  */
 async function isKubernetesManifest(filePath: string): Promise<boolean> {
     try {
@@ -238,20 +160,19 @@ async function isKubernetesManifest(filePath: string): Promise<boolean> {
         const previewSize = Math.min(content.length, 1024);
         const text = Buffer.from(content.slice(0, previewSize)).toString("utf-8");
 
-        // Must have both apiVersion and kind
+        // Must have both apiVersion and kind (\r? handles CRLF)
         const hasApiVersion = /^apiVersion:\s*.+$/m.test(text);
         if (!hasApiVersion) {
             return false;
         }
 
         // Extract kind value — must be present and PascalCase
-        const kindMatch = text.match(/^kind:\s*([A-Z]\w*)$/m);
+        const kindMatch = text.match(/^kind:\s*([A-Z]\w*)\r?$/m);
         if (!kindMatch) {
             return false;
         }
 
-        const kind = kindMatch[1].trim();
-
+        const kind = kindMatch[1];
         return /^[A-Z][a-zA-Z0-9]*$/.test(kind);
     } catch {
         return false;

--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -88,15 +88,17 @@ const SCAN_MAX_DEPTH = 3;
  * Returns absolute paths sorted shallowest-first; excluded dirs are skipped.
  */
 export async function scanForDockerfiles(rootPath: string): Promise<string[]> {
-    const found: string[] = [];
-    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, (filePath, name) => {
-        if (name === "Dockerfile") {
-            found.push(filePath);
+    const dockerfiles: string[] = [];
+
+    const isDockerfile = (_filePath: string, fileName: string): boolean => fileName === "Dockerfile";
+
+    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, (filePath, fileName) => {
+        if (isDockerfile(filePath, fileName)) {
+            dockerfiles.push(filePath);
         }
     });
-    // Sort shallowest first
-    found.sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
-    return found;
+
+    return dockerfiles.sort((left, right) => left.split(path.sep).length - right.split(path.sep).length);
 }
 
 /**
@@ -106,13 +108,19 @@ export async function scanForDockerfiles(rootPath: string): Promise<string[]> {
  */
 export async function scanForK8sManifests(rootPath: string): Promise<string[]> {
     const manifests: string[] = [];
-    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, async (filePath, name) => {
-        if (name.endsWith(".yaml") || name.endsWith(".yml")) {
-            if (await isKubernetesManifest(filePath)) {
-                manifests.push(filePath);
-            }
+
+    const isYamlFile = (fileName: string): boolean => fileName.endsWith(".yaml") || fileName.endsWith(".yml");
+
+    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, async (filePath, fileName) => {
+        if (!isYamlFile(fileName)) {
+            return;
+        }
+
+        if (await isKubernetesManifest(filePath)) {
+            manifests.push(filePath);
         }
     });
+
     return manifests;
 }
 

--- a/src/commands/aksContainerAssist/workflowGenerator.ts
+++ b/src/commands/aksContainerAssist/workflowGenerator.ts
@@ -147,7 +147,7 @@ async function collectWorkflowConfiguration(
     if (hasBothActions) {
         buildContextPath = defaultBuildContext;
     } else {
-        buildContextPath = await promptForBuildContext(defaultBuildContext);
+        buildContextPath = await promptForBuildContext(defaultBuildContext, dockerfilePath, projectRoot);
     }
     if (!buildContextPath) return undefined;
 
@@ -167,11 +167,11 @@ async function collectWorkflowConfiguration(
     }
 
     // Resolve build context to an absolute path, then make it workspace-relative for the YAML.
+    const dockerfileAbsolute = path.resolve(projectRoot, dockerfilePath);
     const buildContextAbsolute = buildContextPath === "." ? projectRoot : path.resolve(projectRoot, buildContextPath);
     const buildContextRelToWorkspace = toPosixPath(path.relative(workspaceRoot, buildContextAbsolute)) || ".";
 
     // DOCKER_FILE in `az acr build -f` is relative to the build context, not the repo root.
-    const dockerfileAbsolute = path.resolve(projectRoot, dockerfilePath);
     const dockerfileRelToBuildContext = toPosixPath(path.relative(buildContextAbsolute, dockerfileAbsolute));
 
     let selectedManifests: string[] | undefined;
@@ -282,7 +282,12 @@ async function promptForDockerfilePath(projectRoot: string, detectedPaths: strin
 /**
  * Prompts user to enter build context path
  */
-async function promptForBuildContext(defaultContext: string): Promise<string | undefined> {
+async function promptForBuildContext(
+    defaultContext: string,
+    dockerfilePath: string,
+    projectRoot: string,
+): Promise<string | undefined> {
+    const dockerfileAbsolute = path.resolve(projectRoot, dockerfilePath);
     const result = await vscode.window.showInputBox({
         prompt: l10n.t("Enter build context path (directory containing source code)"),
         placeHolder: ".",
@@ -296,6 +301,11 @@ async function promptForBuildContext(defaultContext: string): Promise<string | u
             // Validate it's a valid relative path
             if (value.startsWith("/") || value.includes("..")) {
                 return l10n.t("Build context must be a relative path within the project");
+            }
+            // `az acr build -f` requires the Dockerfile to be within the build context.
+            const contextAbsolute = value === "." ? projectRoot : path.resolve(projectRoot, value);
+            if (toPosixPath(path.relative(contextAbsolute, dockerfileAbsolute)).startsWith("..")) {
+                return l10n.t("Build context must contain the Dockerfile");
             }
             return undefined;
         },

--- a/src/commands/aksContainerAssist/workflowGenerator.ts
+++ b/src/commands/aksContainerAssist/workflowGenerator.ts
@@ -166,13 +166,13 @@ async function collectWorkflowConfiguration(
         relativeManifests = detection.result.map((p) => toPosixPath(path.relative(workspaceRoot, p)));
     }
 
-    const dockerfileRelToWorkspace = toPosixPath(
-        path.relative(workspaceRoot, path.resolve(projectRoot, dockerfilePath)),
-    );
-    const buildContextRelToWorkspace =
-        buildContextPath === "."
-            ? toPosixPath(path.relative(workspaceRoot, projectRoot)) || "."
-            : toPosixPath(path.relative(workspaceRoot, path.resolve(projectRoot, buildContextPath)));
+    // Resolve build context to an absolute path, then make it workspace-relative for the YAML.
+    const buildContextAbsolute = buildContextPath === "." ? projectRoot : path.resolve(projectRoot, buildContextPath);
+    const buildContextRelToWorkspace = toPosixPath(path.relative(workspaceRoot, buildContextAbsolute)) || ".";
+
+    // DOCKER_FILE in `az acr build -f` is relative to the build context, not the repo root.
+    const dockerfileAbsolute = path.resolve(projectRoot, dockerfilePath);
+    const dockerfileRelToBuildContext = toPosixPath(path.relative(buildContextAbsolute, dockerfileAbsolute));
 
     let selectedManifests: string[] | undefined;
     if (hasBothActions && relativeManifests.length > 0) {
@@ -187,7 +187,7 @@ async function collectWorkflowConfiguration(
         workflowName,
         branchName: "main", // Default to main
         containerName: appName, // Use app name as container name
-        dockerFile: dockerfileRelToWorkspace,
+        dockerFile: dockerfileRelToBuildContext,
         buildContextPath: buildContextRelToWorkspace,
         acrResourceGroup,
         azureContainerRegistry: acrName,

--- a/src/tests/suite/containerAssist/fileOperations.test.ts
+++ b/src/tests/suite/containerAssist/fileOperations.test.ts
@@ -1,0 +1,275 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { scanForDockerfiles, scanForK8sManifests } from "../../../commands/aksContainerAssist/fileOperations";
+
+describe("fileOperations", () => {
+    let tempDir: string;
+
+    before(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fileops-test-"));
+    });
+
+    after(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    describe("scanForDockerfiles", () => {
+        let dockerDir: string;
+
+        before(() => {
+            dockerDir = path.join(tempDir, "docker-scan");
+            fs.mkdirSync(dockerDir);
+        });
+
+        it("finds a Dockerfile at root level", async () => {
+            const dir = path.join(dockerDir, "root-level");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "Dockerfile"), "FROM node:20");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].endsWith("Dockerfile"));
+        });
+
+        it("finds Dockerfiles in subdirectories", async () => {
+            const dir = path.join(dockerDir, "nested");
+            fs.mkdirSync(dir);
+            fs.mkdirSync(path.join(dir, "frontend"), { recursive: true });
+            fs.mkdirSync(path.join(dir, "api"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "frontend", "Dockerfile"), "FROM node:20");
+            fs.writeFileSync(path.join(dir, "api", "Dockerfile"), "FROM python:3.12");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 2);
+            assert.ok(result.some((p) => p.includes("frontend")));
+            assert.ok(result.some((p) => p.includes("api")));
+        });
+
+        it("returns shallowest Dockerfile first", async () => {
+            const dir = path.join(dockerDir, "depth-order");
+            fs.mkdirSync(dir);
+            fs.mkdirSync(path.join(dir, "services", "web"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "services", "web", "Dockerfile"), "FROM node:20");
+            fs.writeFileSync(path.join(dir, "Dockerfile"), "FROM alpine");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 2);
+            // Root Dockerfile should come first (shallowest)
+            assert.ok(result[0].endsWith(path.join("depth-order", "Dockerfile")));
+        });
+
+        it("ignores files in excluded directories", async () => {
+            const dir = path.join(dockerDir, "excluded");
+            fs.mkdirSync(dir);
+            fs.mkdirSync(path.join(dir, "node_modules", "some-pkg"), { recursive: true });
+            fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "node_modules", "some-pkg", "Dockerfile"), "FROM node:20");
+            fs.writeFileSync(path.join(dir, "src", "Dockerfile"), "FROM node:20");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].includes("src"));
+        });
+
+        it("does not match files containing 'Dockerfile' in the name", async () => {
+            const dir = path.join(dockerDir, "exact-match");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "Dockerfile"), "FROM node:20");
+            fs.writeFileSync(path.join(dir, "Dockerfile.bak"), "FROM node:18");
+            fs.writeFileSync(path.join(dir, "README-Dockerfile.md"), "docs");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].endsWith("Dockerfile"));
+        });
+
+        it("returns empty array when no Dockerfiles exist", async () => {
+            const dir = path.join(dockerDir, "empty");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "index.ts"), "console.log('hello')");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("returns empty array for non-existent directory", async () => {
+            const result = await scanForDockerfiles(path.join(dockerDir, "does-not-exist"));
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("does not scan beyond depth 3", async () => {
+            const dir = path.join(dockerDir, "deep");
+            // depth 0: dir, 1: a, 2: b, 3: c, 4: d — Dockerfile at depth 4 should not be found
+            const deepPath = path.join(dir, "a", "b", "c", "d");
+            fs.mkdirSync(deepPath, { recursive: true });
+            fs.writeFileSync(path.join(deepPath, "Dockerfile"), "FROM alpine");
+            // Dockerfile at depth 3 should be found
+            fs.writeFileSync(path.join(dir, "a", "b", "c", "Dockerfile"), "FROM alpine");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].includes(path.join("a", "b", "c", "Dockerfile")));
+            assert.ok(!result[0].includes(path.join("c", "d", "Dockerfile")));
+        });
+
+        it("skips Java/IDE excluded directories", async () => {
+            const dir = path.join(dockerDir, "java-excluded");
+            fs.mkdirSync(dir);
+            for (const excluded of [".gradle", ".idea", ".settings", ".mvn"]) {
+                fs.mkdirSync(path.join(dir, excluded), { recursive: true });
+                fs.writeFileSync(path.join(dir, excluded, "Dockerfile"), "FROM gradle");
+            }
+            fs.mkdirSync(path.join(dir, "app"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "app", "Dockerfile"), "FROM openjdk:21");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].includes("app"));
+        });
+    });
+
+    describe("scanForK8sManifests", () => {
+        let k8sDir: string;
+
+        before(() => {
+            k8sDir = path.join(tempDir, "k8s-scan");
+            fs.mkdirSync(k8sDir);
+        });
+
+        it("finds valid K8s manifests (.yaml)", async () => {
+            const dir = path.join(k8sDir, "yaml-ext");
+            fs.mkdirSync(path.join(dir, "k8s"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "k8s", "deployment.yaml"),
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n",
+            );
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].endsWith("deployment.yaml"));
+        });
+
+        it("finds valid K8s manifests (.yml)", async () => {
+            const dir = path.join(k8sDir, "yml-ext");
+            fs.mkdirSync(path.join(dir, "manifests"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "manifests", "service.yml"),
+                "apiVersion: v1\nkind: Service\nmetadata:\n  name: web\n",
+            );
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].endsWith("service.yml"));
+        });
+
+        it("ignores YAML files that are not K8s manifests", async () => {
+            const dir = path.join(k8sDir, "non-k8s");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "config.yaml"), "database:\n  host: localhost\n  port: 5432\n");
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("ignores YAML with apiVersion but no valid kind", async () => {
+            const dir = path.join(k8sDir, "no-kind");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "bad.yaml"), "apiVersion: v1\ndata:\n  key: value\n");
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("ignores YAML with kind but no apiVersion", async () => {
+            const dir = path.join(k8sDir, "no-api");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "bad.yaml"), "kind: Deployment\nmetadata:\n  name: web\n");
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("handles CRLF line endings", async () => {
+            const dir = path.join(k8sDir, "crlf");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(
+                path.join(dir, "deploy.yaml"),
+                "apiVersion: apps/v1\r\nkind: Deployment\r\nmetadata:\r\n  name: web\r\n",
+            );
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 1);
+        });
+
+        it("returns empty array when no manifests exist", async () => {
+            const dir = path.join(k8sDir, "empty");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "README.md"), "# Hello");
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("returns empty array for non-existent directory", async () => {
+            const result = await scanForK8sManifests(path.join(k8sDir, "does-not-exist"));
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("ignores non-YAML files", async () => {
+            const dir = path.join(k8sDir, "mixed-files");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "readme.md"), "# docs");
+            fs.writeFileSync(path.join(dir, "config.json"), '{"key":"value"}');
+            fs.writeFileSync(
+                path.join(dir, "deploy.yaml"),
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n",
+            );
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].endsWith("deploy.yaml"));
+        });
+
+        it("rejects kind values that are not PascalCase", async () => {
+            const dir = path.join(k8sDir, "bad-kind");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, "lower.yaml"), "apiVersion: v1\nkind: deployment\n");
+            fs.writeFileSync(path.join(dir, "dashed.yaml"), "apiVersion: v1\nkind: My-Resource\n");
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 0);
+        });
+
+        it("finds manifests in directories with spaces in path", async () => {
+            const dir = path.join(k8sDir, "my service");
+            fs.mkdirSync(path.join(dir, "k8s"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "k8s", "deploy.yaml"),
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: svc\n",
+            );
+
+            const result = await scanForK8sManifests(dir);
+
+            assert.strictEqual(result.length, 1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Consolidates 5 filesystem scanning functions into a single generic `walkDirectory` helper with two focused callers (`scanForDockerfiles`, `scanForK8sManifests`), and fixes the DOCKER_FILE path resolution in generated workflows.

## Changes

### fileOperations.ts
- **Replace** `scanForDockerfilesRecursive`, `scanDirectory`, `scanDirectoryRecursive`, and two separate scanner implementations with a single `walkDirectory` helper
- **Unify** `EXCLUDED_DIRS` set — add Java-specific entries (`.gradle`, `.idea`, `.settings`, `.mvn`)
- **Extract** `SCAN_MAX_DEPTH` constant (depth 3 for both scanners)
- **Use bitwise** `FileType` checks (`!== 0`) so symlinked files/directories are correctly traversed
- **Add CRLF handling** in K8s manifest `kind:` regex (`\r?` before `$`)
- **Remove** unused debug logging and the `scanManifestsForModule` wrapper (zero callers)

### workflowGenerator.ts
- **Fix DOCKER_FILE path**: resolve relative to build context, not workspace root — `az acr build -f` expects this

## Testing
- `npx tsc --noEmit` — clean
- `npm run webpack` — compiles successfully

Contributes to #2109