### PR TITLE
Aligns the Argo CD GitOps integration with the Azure-managed Argo CD k8s extension

### DIFF
--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -111,7 +111,15 @@ Shown only when **both** conditions hold:
    - **Azure DevOps** hosts: `dev.azure.com/*`, legacy `*.visualstudio.com`, and the SSH variants `ssh.dev.azure.com` / `vs-ssh.visualstudio.com`.
 2. The cluster is running the Azure-managed Argo CD extension (managed-by label detected) **or** Entra ID SSO is already configured on the `argocd-cm` ConfigMap.
 
-The action opens the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) showing how to federate Argo CD's service account to your Azure identity, removing the need to store long-lived PATs or SSH keys as Kubernetes Secrets. Workload Identity Federation is the recommended credential path when running the Azure-managed Argo CD extension.
+The action behaves differently depending on which install path was detected:
+
+- **Managed extension detected** — runs a guided WIF bootstrap helper directly inside VS Code:
+  1. Auto-detects the Argo CD `ServiceAccount` (`argocd-repo-server` by default) and the cluster's OIDC issuer URL, and prints the federated-credential **subject claim** (`system:serviceaccount:argocd:<sa>`) and **audience** (`api://AzureADTokenExchange`) to the Argo CD output channel — with one-click clipboard copy.
+  2. Opens the Azure Portal directly on **Managed Identities** (or **App registrations**) so you can paste those values into a new federated credential.
+  3. Prints the final wiring steps: the `AcrPull` / `Reader` role assignment and the `azure.workload.identity/client-id` ServiceAccount annotation, plus the `kubectl rollout restart` command. The Microsoft Learn tutorial remains available as a fallback link.
+- **SSO-only (no managed-by label)** — opens the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) directly, since the in-cluster annotations the bootstrap helper relies on may not match an upstream install.
+
+Workload Identity Federation is the recommended credential path when running the Azure-managed Argo CD extension — no long-lived PATs or SSH keys are stored as Kubernetes Secrets.
 
 ### Connect Private Repository (GitHub)
 

--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -32,7 +32,12 @@ The VS Code commands below work with either install path. Pick whichever fits yo
 | **Azure-managed Argo CD extension** (recommended for production) | AKS or Azure Arc-enabled clusters that need Entra ID SSO, Workload Identity Federation to ACR / Azure DevOps, Azure Linux–hardened images, and opt-in automatic patch releases | `az k8s-extension create --extension-type Microsoft.ArgoCD …` — see the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) |
 | **Upstream Argo CD** (manifests / Helm) | Dev clusters, custom builds, strict OSS parity, or non-Azure clusters | [Argo CD getting started](https://argo-cd.readthedocs.io/en/stable/getting_started/) |
 
-The extension auto-detects the managed install at runtime (via the `app.kubernetes.io/managed-by=Microsoft.ArgoCD` pod label and the `argocd-cm` OIDC config) and adapts its post-apply menu accordingly — for example, hinting at Workload Identity Federation when an applied `Application` references an ACR or Azure DevOps source, and preferring SSO sign-in over the OSS admin-password flow.
+The extension uses two independent runtime probes:
+
+- **Install-method detection** — the `app.kubernetes.io/managed-by=Microsoft.ArgoCD` pod label in the `argocd` namespace. Resolves to `managed`, `upstream`, or `unknown` (e.g. RBAC forbidden, transient kubectl failure). The post-apply menu only surfaces the Azure **Workload Identity** hint when this resolves to `managed` (or when SSO is independently detected, see below).
+- **Auth-mode detection** — the `argocd-cm` ConfigMap's `oidc.config` entry. When it references `login.microsoftonline.com`, the UI sign-in is treated as Entra ID **SSO** and the OSS admin-password flow is skipped.
+
+These signals are orthogonal: a managed install can be configured without SSO, and — in principle — an upstream install can be wired to Entra ID by hand. The extension treats them as separate hints rather than collapsing them into one flag.
 
 > **Public preview, Mar 2026.** The Azure-managed extension is in public preview on AKS and Azure Arc-enabled Kubernetes — see the [announcement blog](https://techcommunity.microsoft.com/blog/azurearcblog/announcing-public-preview-of-argo-cd-extension-on-aks-and-azure-arc-enabled-kube/4504497).
 
@@ -99,10 +104,12 @@ The integration provides four commands, all prefixed with **AKS:**
 
 ### Configure Workload Identity for Azure (recommended)
 
-Shown only when `spec.source.repoURL` of the applied Application points at an Azure source:
+Shown only when **both** conditions hold:
 
-- **ACR** hosts: `*.azurecr.io` (OCI Helm chart / manifest sources).
-- **Azure DevOps** hosts: `dev.azure.com/*` and legacy `*.visualstudio.com`.
+1. `spec.source.repoURL` of the applied Application points at an Azure source:
+   - **ACR** hosts: `*.azurecr.io` (OCI Helm chart / manifest sources).
+   - **Azure DevOps** hosts: `dev.azure.com/*`, legacy `*.visualstudio.com`, and the SSH variants `ssh.dev.azure.com` / `vs-ssh.visualstudio.com`.
+2. The cluster is running the Azure-managed Argo CD extension (managed-by label detected) **or** Entra ID SSO is already configured on the `argocd-cm` ConfigMap.
 
 The action opens the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) showing how to federate Argo CD's service account to your Azure identity, removing the need to store long-lived PATs or SSH keys as Kubernetes Secrets. Workload Identity Federation is the recommended credential path when running the Azure-managed Argo CD extension.
 
@@ -129,7 +136,7 @@ For **Azure DevOps** or **ACR** sources, prefer the *Configure Workload Identity
 2. Select **AKS: Check Argo CD Status**.
 3. The **Argo CD** output channel shows:
    - Whether the `argocd` namespace exists.
-   - Whether the **Azure-managed `Microsoft.ArgoCD` extension** is detected (via the `app.kubernetes.io/managed-by` pod label).
+   - Whether the **Azure-managed `Microsoft.ArgoCD` extension** is detected (via the `app.kubernetes.io/managed-by` pod label). Reported as `managed`, `upstream`, or `could not determine` when the label query fails (for example, due to RBAC).
    - Pod status (`kubectl get pods -n argocd -o wide`).
    - Service status (`kubectl get svc -n argocd`).
    - Tips for port-forwarding and authentication (SSO vs. initial admin password).

--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -23,9 +23,24 @@ After changing this setting, reload the VS Code window (`Developer: Reload Windo
 
 ---
 
+## Installation options
+
+The VS Code commands below work with either install path. Pick whichever fits your environment.
+
+| Option | Best for | How to install |
+|---|---|---|
+| **Azure-managed Argo CD extension** (recommended for production) | AKS or Azure Arc-enabled clusters that need Entra ID SSO, Workload Identity Federation to ACR / Azure DevOps, Azure Linux–hardened images, and opt-in automatic patch releases | `az k8s-extension create --extension-type Microsoft.ArgoCD …` — see the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) |
+| **Upstream Argo CD** (manifests / Helm) | Dev clusters, custom builds, strict OSS parity, or non-Azure clusters | [Argo CD getting started](https://argo-cd.readthedocs.io/en/stable/getting_started/) |
+
+The extension auto-detects the managed install at runtime (via the `app.kubernetes.io/managed-by=Microsoft.ArgoCD` pod label and the `argocd-cm` OIDC config) and adapts its post-apply menu accordingly — for example, hinting at Workload Identity Federation when an applied `Application` references an ACR or Azure DevOps source, and preferring SSO sign-in over the OSS admin-password flow.
+
+> **Public preview, Mar 2026.** The Azure-managed extension is in public preview on AKS and Azure Arc-enabled Kubernetes — see the [announcement blog](https://techcommunity.microsoft.com/blog/azurearcblog/announcing-public-preview-of-argo-cd-extension-on-aks-and-azure-arc-enabled-kube/4504497).
+
+---
+
 ## Prerequisites
 
-- An AKS cluster with Argo CD installed (via `kubectl`, Helm, or the `az k8s-extension` marketplace add-on).
+- A Kubernetes cluster with Argo CD installed via **either** of the [Installation options](#installation-options) above.
 - `kubectl` available on your PATH (the extension uses the active kubectl context).
 - A **separate GitOps config repository** — Argo CD manifests should live apart from your application source code.
 
@@ -40,7 +55,7 @@ The integration provides four commands, all prefixed with **AKS:**
 | **AKS: Create Argo CD GitOps Pipeline** | Command Palette, Explorer folder context menu | Scaffold an annotated Argo CD Application manifest in a config repo |
 | **AKS: Apply Argo CD Application to Cluster** | Explorer YAML file context menu, Editor context menu | Apply an Application YAML to the active cluster |
 | **AKS: Check Argo CD Status** | AKS cluster tree right-click menu | Show Argo CD pod and service health in an output channel |
-| **AKS: Argo CD Post-Deploy Actions** | Shown after a successful apply | Open UI, get credentials, register repo credentials, or view sync guide |
+| **AKS: Argo CD Post-Deploy Actions** | Shown after a successful apply, or from the Command Palette | Open UI (SSO-aware), configure Azure Workload Identity (when source is ACR / Azure DevOps), connect a private GitHub repo, or open the Argo CD sync guide |
 
 ---
 
@@ -78,24 +93,29 @@ The integration provides four commands, all prefixed with **AKS:**
 
 ### Open Argo CD UI
 
+- If Argo CD is installed via the **Azure-managed extension** with Entra ID OIDC configured, the dialog prompts you to sign in with your Microsoft account — no admin password is fetched.
 - If the `argocd-server` Service has a **LoadBalancer** with an external IP, the extension opens `https://<address>` directly.
 - If the Service is **ClusterIP** (common for local setups), the extension starts a `kubectl port-forward` in an integrated terminal and shows an **Open Browser** button once the tunnel is ready.
 
-### Get Credentials
+### Configure Workload Identity for Azure (recommended)
 
-- Fetches the initial admin password from the `argocd-initial-admin-secret` Secret.
-- Displays `Username: admin | Password: ••••••••` (masked).
-- Offers **Copy Password** and **Reveal Password** buttons.
-- If the secret has been rotated or deleted, shows an informational message.
+Shown only when `spec.source.repoURL` of the applied Application points at an Azure source:
 
-### Register Repo Credentials (Private Repos)
+- **ACR** hosts: `*.azurecr.io` (OCI Helm chart / manifest sources).
+- **Azure DevOps** hosts: `dev.azure.com/*` and legacy `*.visualstudio.com`.
 
-- Pre-populates `spec.source.repoURL` from the applied Application YAML.
-- Choose an auth type:
-  - **HTTPS** — enter username + PAT/password (input is masked; credentials are never logged).
-  - **SSH** — pick a private key file.
-- Creates a labelled Kubernetes Secret (`argocd.argoproj.io/secret-type: repository`) directly via `kubectl` — credentials never touch disk as temp files.
-- Argo CD picks up the Secret automatically without a restart.
+The action opens the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) showing how to federate Argo CD's service account to your Azure identity, removing the need to store long-lived PATs or SSH keys as Kubernetes Secrets. Workload Identity Federation is the recommended credential path when running the Azure-managed Argo CD extension.
+
+### Connect Private Repository (GitHub)
+
+Shown only when the applied Application's `spec.source.repoURL` is a **private GitHub** repository:
+
+- Pre-populates owner/repo from the YAML and (when a silent VS Code GitHub session exists) resolves the numeric repo ID.
+- Opens the GitHub fine-grained PAT creation page with the token name and repository pre-filled.
+- Prompts for the PAT in a masked input (never logged, never written to disk).
+- Creates a labelled Kubernetes Secret (`argocd.argoproj.io/secret-type: repository`) via `kubectl create secret --from-literal` so Argo CD auto-discovers it without a restart.
+
+For **Azure DevOps** or **ACR** sources, prefer the *Configure Workload Identity* action above instead of creating a PAT secret.
 
 ### Sync Guide
 
@@ -109,9 +129,10 @@ The integration provides four commands, all prefixed with **AKS:**
 2. Select **AKS: Check Argo CD Status**.
 3. The **Argo CD** output channel shows:
    - Whether the `argocd` namespace exists.
+   - Whether the **Azure-managed `Microsoft.ArgoCD` extension** is detected (via the `app.kubernetes.io/managed-by` pod label).
    - Pod status (`kubectl get pods -n argocd -o wide`).
    - Service status (`kubectl get svc -n argocd`).
-   - Tips for port-forwarding and authentication.
+   - Tips for port-forwarding and authentication (SSO vs. initial admin password).
 
 ---
 
@@ -126,11 +147,21 @@ The skill explains the GitOps principle and offers a button to launch the scaffo
 
 ---
 
+## Production topologies
+
+The scaffolded `Application` manifests work unchanged with the upstream-parity features of the Azure-managed extension:
+
+- **High availability (HA)** — chosen at install time via the managed extension or upstream Helm chart; no change required to the generated YAML.
+- **Hub-and-spoke / multi-cluster** — the *Create Argo CD GitOps Pipeline* command prompts for a target cluster API server URL, which becomes `spec.destination.server` and can point at a remote spoke cluster from a central hub.
+- **`ApplicationSet`** — the scaffolder currently emits a single `Application`. For generator-driven, multi-cluster rollouts (cluster generator, Git generator, etc.), hand-author an `ApplicationSet` alongside the generated `application.yaml`; the *Apply Argo CD Application to Cluster* command accepts any `argoproj.io/v1alpha1` resource.
+
+---
+
 ## Security Notes
 
-- **PAT / passwords** are never written to disk or logged to output channels. Repo credential Secrets are created via `kubectl create secret --from-literal`.
-- **Admin password** is masked in all UI modals; only accessible via explicit Copy or Reveal actions.
-- **SSH keys** are read from a user-selected file and passed directly to the Secret — never cached.
+- **PATs and passwords** are never written to disk or logged to output channels. Repo credential Secrets are created via `kubectl create secret --from-literal` (in-memory only).
+- **Workload Identity Federation** is preferred over PATs for ACR and Azure DevOps sources when running the Azure-managed extension — no long-lived credentials are stored on the cluster.
+- **Entra ID SSO** replaces the OSS `argocd-initial-admin-secret` flow when the managed extension is configured with OIDC; the extension auto-detects this and skips the password prompt.
 
 ---
 
@@ -138,8 +169,19 @@ The skill explains the GitOps principle and offers a button to launch the scaffo
 
 | Problem | Solution |
 |---------|----------|
-| "Argo CD is not installed on cluster" | Install Argo CD first: [Getting Started guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) |
+| "Argo CD is not installed on cluster" | Install Argo CD first — see [Installation options](#installation-options) |
+| `az k8s-extension create` fails with `Microsoft.ArgoCD not found` | Register the `Microsoft.KubernetesConfiguration` resource provider and confirm region availability per the [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd) |
 | `kubectl` not found | Ensure `kubectl` is on your PATH and the correct context is active |
 | Port-forward fails | Check that no other process is using port 8080, or that the `argocd-server` Service exists |
+| Admin-password Secret missing | Expected when the managed extension is configured with Entra ID SSO — sign in through the browser instead of entering a password |
+| Want to avoid PATs for ACR or Azure DevOps | Configure **Workload Identity Federation** via the managed extension instead of using *Connect Private Repository* |
 | Repo not syncing after credential registration | Verify the repo URL matches `spec.source.repoURL` exactly (including `.git` suffix if used) |
 | Application CR not visible in Argo CD UI | Ensure the YAML has `namespace: argocd` in `metadata` — the Application CR must be in the Argo CD namespace |
+
+---
+
+## Further reading
+
+- [Announcing public preview of the Argo CD extension on AKS and Azure Arc-enabled Kubernetes clusters](https://techcommunity.microsoft.com/blog/azurearcblog/announcing-public-preview-of-argo-cd-extension-on-aks-and-azure-arc-enabled-kube/4504497) — Azure Arc Blog, Mar 2026.
+- [Microsoft Learn: Use GitOps with Argo CD on Azure Arc-enabled Kubernetes](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd).
+- [Argo CD upstream documentation](https://argo-cd.readthedocs.io/en/stable/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,7 +1087,7 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -1106,7 +1106,7 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1151,7 +1151,7 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -1359,7 +1359,7 @@
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1368,7 +1368,7 @@
             "version": "0.16.6",
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -1381,7 +1381,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -1394,7 +1394,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -1407,7 +1407,7 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -2832,14 +2832,14 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -3899,7 +3899,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3925,7 +3925,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "devOptional": true,
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3943,6 +3943,7 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5376,7 +5377,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -6259,7 +6260,7 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
@@ -6278,7 +6279,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6316,7 +6317,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6328,7 +6329,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -6341,7 +6342,7 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.16.0",
@@ -6359,7 +6360,7 @@
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
@@ -6419,7 +6420,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -6432,7 +6433,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6444,7 +6445,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -6453,7 +6454,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6706,13 +6707,14 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.1.2",
@@ -6820,7 +6822,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6873,7 +6875,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6898,7 +6900,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6911,7 +6913,7 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/foreground-child": {
@@ -7113,7 +7115,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -7441,7 +7443,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -7491,7 +7493,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -7603,7 +7605,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7620,7 +7622,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -7899,7 +7901,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -7910,7 +7912,8 @@
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/json-schema-typed": {
             "version": "8.0.2",
@@ -7922,7 +7925,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -8045,7 +8048,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8096,7 +8099,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8303,7 +8306,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -8934,7 +8937,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/nearley": {
             "version": "2.20.1",
@@ -9273,7 +9276,7 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9424,7 +9427,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -9439,7 +9442,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -9593,7 +9596,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9886,7 +9889,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -11911,7 +11914,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -12480,7 +12483,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12789,7 +12792,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -462,7 +462,6 @@
                 "command": "aks.draftArgoCDDeployment",
                 "title": "%AKS: Create Argo CD GitOps Pipeline%"
             },
-
             {
                 "command": "aks.argoCDCheckStatus",
                 "title": "%AKS: Check Argo CD Status%"
@@ -486,7 +485,6 @@
                     "command": "aks.draftArgoCDDeployment",
                     "when": "workspaceFolderCount >= 1 && config.aks.argoCDEnabled"
                 },
-
                 {
                     "command": "aks.argoCDCheckStatus",
                     "when": "config.aks.argoCDEnabled"
@@ -871,7 +869,6 @@
                     "group": "2_deploy@3",
                     "when": "workspaceFolderCount >= 1"
                 },
-
                 {
                     "command": "aks.argoCDCheckStatus",
                     "group": "2_deploy@5",

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -26,7 +26,7 @@ import { failed } from "../utils/errorable";
 import { getAuthenticatedKubeconfigYaml } from "../utils/clusters";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
-import { getOutputChannel } from "./argoCDInstall";
+import { getOutputChannel, detectManagedArgoCDExtension, ArgoCDInstallMethod } from "./argoCDInstall";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -376,10 +376,11 @@ export function classifyAzureRepoHost(repoUrl: string): AzureRepoHost {
     if (!url) return "other";
     // ACR — Azure Container Registry (OCI Helm/manifest sources).
     if (/(^|\/\/|@)[a-z0-9-]+\.azurecr\.io(\/|$|:)/.test(url)) return "acr";
-    // Azure DevOps Git — both modern and legacy hostnames.
-    if (/(^|\/\/|@)(dev\.azure\.com|[a-z0-9-]+\.visualstudio\.com)(\/|$|:)/.test(url)) {
-        return "azure-devops";
-    }
+    // Azure DevOps Git — covers HTTPS and SSH host variants:
+    //   HTTPS: https://dev.azure.com/<org>/...    or  https://<org>.visualstudio.com/...
+    //   SSH:   git@ssh.dev.azure.com:v3/<org>/... or  <org>@vs-ssh.visualstudio.com:v3/...
+    if (/(^|\/\/|@)(ssh\.)?dev\.azure\.com(\/|$|:)/.test(url)) return "azure-devops";
+    if (/(^|\/\/|@)(vs-ssh\.)?[a-z0-9-]+\.visualstudio\.com(\/|$|:)/.test(url)) return "azure-devops";
     return "other";
 }
 
@@ -687,9 +688,10 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
         const repoUrl = doc.spec?.source?.repoURL || "";
         const isGitHub = /github\.com/i.test(repoUrl);
 
-        const [authMode, repoVisibility] = await Promise.all([
+        const [authMode, repoVisibility, installMethod] = await Promise.all([
             detectArgoCDAuthMode(kubectl, kubeConfigFile.filePath),
             isGitHub ? probeGitHubRepoVisibility(repoUrl) : Promise.resolve("unknown" as const),
+            detectManagedArgoCDExtension(kubectl, kubeConfigFile.filePath),
         ]);
 
         // Brief success toast.
@@ -707,6 +709,7 @@ export async function argoCDApplyApp(_context: IActionContext, target: unknown):
             repoUrl,
             authMode,
             repoVisibility,
+            installMethod,
         );
     } finally {
         kubeConfigFile.dispose();
@@ -726,6 +729,7 @@ export async function argoCDPostApplyActions(
     repoUrlArg?: unknown,
     authModeArg?: unknown,
     repoVisibilityArg?: unknown,
+    installMethodArg?: unknown,
 ): Promise<void> {
     // When called from the command palette we have no pre-resolved context,
     // so resolve kubectl + cluster fresh from the active kubeconfig.
@@ -736,6 +740,7 @@ export async function argoCDPostApplyActions(
     let repoUrl = "";
     let authMode: "sso" | "admin-password";
     let repoVisibility: "public" | "private" | "unknown";
+    let installMethod: ArgoCDInstallMethod;
     let ownedTempFile: Awaited<ReturnType<typeof createTempFile>> | undefined;
 
     // If called programmatically (from argoCDApplyApp) all args are provided.
@@ -769,12 +774,14 @@ export async function argoCDPostApplyActions(
         }
 
         const isGitHub = /github\.com/i.test(repoUrl);
-        const [detectedAuth, detectedVisibility] = await Promise.all([
+        const [detectedAuth, detectedVisibility, detectedInstallMethod] = await Promise.all([
             detectArgoCDAuthMode(kubectl, kubeConfigFilePath),
             isGitHub ? probeGitHubRepoVisibility(repoUrl) : Promise.resolve("unknown" as const),
+            detectManagedArgoCDExtension(kubectl, kubeConfigFilePath),
         ]);
         authMode = detectedAuth;
         repoVisibility = detectedVisibility;
+        installMethod = detectedInstallMethod;
     } else {
         kubectl = kubectlArg as k8s.APIAvailable<k8s.KubectlV1>;
         kubeConfigFilePath = kubeConfigFileArg as string;
@@ -783,6 +790,7 @@ export async function argoCDPostApplyActions(
         repoUrl = repoUrlArg as string;
         authMode = authModeArg as "sso" | "admin-password";
         repoVisibility = repoVisibilityArg as "public" | "private" | "unknown";
+        installMethod = (installMethodArg as ArgoCDInstallMethod | undefined) ?? "unknown";
     }
 
     try {
@@ -790,6 +798,12 @@ export async function argoCDPostApplyActions(
             id: string;
         }
         const azureHost = classifyAzureRepoHost(repoUrl);
+        // Only surface the Workload Identity hint when we have positive
+        // signal that the cluster is running the Azure-managed Argo CD
+        // extension (managed-by label) or has Entra ID SSO configured.
+        // Otherwise the linked Learn flow would not apply to the user's
+        // install path.
+        const showWifHint = azureHost !== "other" && (installMethod === "managed" || authMode === "sso");
         const actionItems: ActionItem[] = [
             {
                 label: "$(browser) Open Argo CD UI",
@@ -799,7 +813,7 @@ export async function argoCDPostApplyActions(
                         : l10n.t("Open the Argo CD dashboard in your browser"),
                 id: "open_ui",
             },
-            ...(azureHost !== "other"
+            ...(showWifHint
                 ? [
                       {
                           label:

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -355,6 +355,34 @@ async function openArgoCDUI(
  *   "private" — repo exists and is private (credentials required)
  *   "unknown" — no silent session, API error, or non-GitHub URL
  */
+
+// ---------------------------------------------------------------------------
+// Helper: classify the Git/OCI repo host so the post-apply menu can hint at
+// Workload Identity Federation for Azure sources.
+//
+// The Azure-managed Argo CD extension (public preview, Mar 2026) supports
+// federated identity to ACR and Azure DevOps, which removes the need to
+// store long-lived PATs/SSH keys as Kubernetes Secrets.  When the repoURL
+// of an applied Application points at an Azure source, we surface that path
+// instead of (or alongside) the classic PAT flow.
+//
+// Reference: https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd
+// ---------------------------------------------------------------------------
+
+export type AzureRepoHost = "acr" | "azure-devops" | "other";
+
+export function classifyAzureRepoHost(repoUrl: string): AzureRepoHost {
+    const url = repoUrl.trim().toLowerCase();
+    if (!url) return "other";
+    // ACR — Azure Container Registry (OCI Helm/manifest sources).
+    if (/(^|\/\/|@)[a-z0-9-]+\.azurecr\.io(\/|$|:)/.test(url)) return "acr";
+    // Azure DevOps Git — both modern and legacy hostnames.
+    if (/(^|\/\/|@)(dev\.azure\.com|[a-z0-9-]+\.visualstudio\.com)(\/|$|:)/.test(url)) {
+        return "azure-devops";
+    }
+    return "other";
+}
+
 async function probeGitHubRepoVisibility(repoUrl: string): Promise<"public" | "private" | "unknown"> {
     const urlMatch = repoUrl.trim().match(/github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?\/?\s*$/i);
     if (!urlMatch) return "unknown";
@@ -761,6 +789,7 @@ export async function argoCDPostApplyActions(
         interface ActionItem extends vscode.QuickPickItem {
             id: string;
         }
+        const azureHost = classifyAzureRepoHost(repoUrl);
         const actionItems: ActionItem[] = [
             {
                 label: "$(browser) Open Argo CD UI",
@@ -770,6 +799,20 @@ export async function argoCDPostApplyActions(
                         : l10n.t("Open the Argo CD dashboard in your browser"),
                 id: "open_ui",
             },
+            ...(azureHost !== "other"
+                ? [
+                      {
+                          label:
+                              azureHost === "acr"
+                                  ? "$(azure) Configure Workload Identity for ACR"
+                                  : "$(azure) Configure Workload Identity for Azure DevOps",
+                          description: l10n.t(
+                              "Open Microsoft Learn — federate Argo CD to Azure without long-lived secrets",
+                          ),
+                          id: "azure_wif",
+                      } as ActionItem,
+                  ]
+                : []),
             ...(repoVisibility === "private"
                 ? [
                       {
@@ -805,6 +848,12 @@ export async function argoCDPostApplyActions(
 
             if (pick.id === "open_ui") {
                 await openArgoCDUI(kubectl, kubeConfigFilePath, clusterName);
+            } else if (pick.id === "azure_wif") {
+                await vscode.env.openExternal(
+                    vscode.Uri.parse(
+                        "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd",
+                    ),
+                );
             } else if (pick.id === "connect_repo") {
                 await connectPrivateGitHubRepo(kubectl, kubeConfigFilePath, repoUrl);
             } else if (pick.id === "open_docs") {

--- a/src/commands/aksArgoCD/argoCDApplyApp.ts
+++ b/src/commands/aksArgoCD/argoCDApplyApp.ts
@@ -27,6 +27,7 @@ import { getAuthenticatedKubeconfigYaml } from "../utils/clusters";
 import { longRunning } from "../utils/host";
 import { NonZeroExitCodeBehaviour } from "../utils/shell";
 import { getOutputChannel, detectManagedArgoCDExtension, ArgoCDInstallMethod } from "./argoCDInstall";
+import { runWifBootstrap } from "./argoCDWifBootstrap";
 
 // ---------------------------------------------------------------------------
 // Type guard — validate that a parsed YAML doc is an Argo CD Application
@@ -863,11 +864,19 @@ export async function argoCDPostApplyActions(
             if (pick.id === "open_ui") {
                 await openArgoCDUI(kubectl, kubeConfigFilePath, clusterName);
             } else if (pick.id === "azure_wif") {
-                await vscode.env.openExternal(
-                    vscode.Uri.parse(
-                        "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd",
-                    ),
-                );
+                // When the Azure-managed extension is detected, run the
+                // guided WIF bootstrap helper.  Otherwise fall back to the
+                // generic Microsoft Learn tutorial (covers manual /
+                // upstream installs configured against Entra ID by hand).
+                if (installMethod === "managed") {
+                    await runWifBootstrap(kubectl, kubeConfigFilePath, azureHost);
+                } else {
+                    await vscode.env.openExternal(
+                        vscode.Uri.parse(
+                            "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd",
+                        ),
+                    );
+                }
             } else if (pick.id === "connect_repo") {
                 await connectPrivateGitHubRepo(kubectl, kubeConfigFilePath, repoUrl);
             } else if (pick.id === "open_docs") {

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -81,6 +81,35 @@ export function getOutputChannel(): vscode.OutputChannel {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: detect whether Argo CD was installed via the Azure-managed
+// `Microsoft.ArgoCD` k8s-extension (public preview, Mar 2026).
+//
+// The managed extension stamps every workload pod with a `managed-by` label
+// referencing the extension type.  We treat the presence of that label on
+// any pod in the argocd namespace as a positive signal.  When detected, the
+// UX prefers Entra ID SSO and Workload Identity Federation flows over the
+// classic admin-password + PAT/SSH paths.
+//
+// Reference: https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd
+// ---------------------------------------------------------------------------
+
+export async function detectManagedArgoCDExtension(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFile: string,
+): Promise<boolean> {
+    const result = await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFile,
+        `get pods -n ${ARGOCD_NAMESPACE} ` +
+            `-l app.kubernetes.io/managed-by=Microsoft.ArgoCD ` +
+            `--ignore-not-found -o name`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+    if (failed(result)) return false;
+    return result.result.stdout.trim() !== "";
+}
+
+// ---------------------------------------------------------------------------
 // Command: Check Argo CD Status
 // ---------------------------------------------------------------------------
 
@@ -131,6 +160,14 @@ async function showArgoCDStatus(
         );
         return;
     }
+
+    // Detect installation method (Azure-managed extension vs upstream OSS).
+    const isManagedExtension = await detectManagedArgoCDExtension(kubectl, kubeconfigFile);
+    channel.appendLine(
+        isManagedExtension
+            ? `[Argo CD Status] Install: Azure-managed extension (Microsoft.ArgoCD) detected.`
+            : `[Argo CD Status] Install: upstream Argo CD (no Microsoft.ArgoCD managed-by label found).`,
+    );
 
     // Pods.
     const podsResult = await longRunning(l10n.t("Fetching Argo CD pod status from {0}…", clusterName), () =>

--- a/src/commands/aksArgoCD/argoCDInstall.ts
+++ b/src/commands/aksArgoCD/argoCDInstall.ts
@@ -85,18 +85,25 @@ export function getOutputChannel(): vscode.OutputChannel {
 // `Microsoft.ArgoCD` k8s-extension (public preview, Mar 2026).
 //
 // The managed extension stamps every workload pod with a `managed-by` label
-// referencing the extension type.  We treat the presence of that label on
-// any pod in the argocd namespace as a positive signal.  When detected, the
-// UX prefers Entra ID SSO and Workload Identity Federation flows over the
-// classic admin-password + PAT/SSH paths.
+// referencing the extension type.  Returns a tri-state so callers can
+// distinguish a definite "upstream" install from "could not determine" (e.g.
+// RBAC forbidden, transient connection failure) and surface an appropriate
+// message instead of silently misclassifying the install.
+//
+// This helper is currently consumed in two places:
+//   * showArgoCDStatus() — informational logging in the output channel.
+//   * argoCDApplyApp.ts post-apply menu — gates the Azure Workload Identity
+//     hint so it is only shown when the managed extension is detected.
 //
 // Reference: https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd
 // ---------------------------------------------------------------------------
 
+export type ArgoCDInstallMethod = "managed" | "upstream" | "unknown";
+
 export async function detectManagedArgoCDExtension(
     kubectl: k8s.APIAvailable<k8s.KubectlV1>,
     kubeConfigFile: string,
-): Promise<boolean> {
+): Promise<ArgoCDInstallMethod> {
     const result = await invokeKubectlCommand(
         kubectl,
         kubeConfigFile,
@@ -105,8 +112,15 @@ export async function detectManagedArgoCDExtension(
             `--ignore-not-found -o name`,
         NonZeroExitCodeBehaviour.Succeed,
     );
-    if (failed(result)) return false;
-    return result.result.stdout.trim() !== "";
+    if (failed(result)) return "unknown";
+    // With NonZeroExitCodeBehaviour.Succeed, kubectl can return a non-zero
+    // exit code (e.g. RBAC forbidden) without throwing.  Treat any non-zero
+    // exit or non-empty stderr as "could not determine" rather than silently
+    // classifying the install as upstream.
+    if (result.result.code !== 0 || result.result.stderr.trim() !== "") {
+        return "unknown";
+    }
+    return result.result.stdout.trim() !== "" ? "managed" : "upstream";
 }
 
 // ---------------------------------------------------------------------------
@@ -162,12 +176,16 @@ async function showArgoCDStatus(
     }
 
     // Detect installation method (Azure-managed extension vs upstream OSS).
-    const isManagedExtension = await detectManagedArgoCDExtension(kubectl, kubeconfigFile);
-    channel.appendLine(
-        isManagedExtension
-            ? `[Argo CD Status] Install: Azure-managed extension (Microsoft.ArgoCD) detected.`
-            : `[Argo CD Status] Install: upstream Argo CD (no Microsoft.ArgoCD managed-by label found).`,
-    );
+    const installMethod = await detectManagedArgoCDExtension(kubectl, kubeconfigFile);
+    if (installMethod === "managed") {
+        channel.appendLine(`[Argo CD Status] Install: Azure-managed extension (Microsoft.ArgoCD) detected.`);
+    } else if (installMethod === "upstream") {
+        channel.appendLine(`[Argo CD Status] Install: upstream Argo CD (no Microsoft.ArgoCD managed-by label found).`);
+    } else {
+        channel.appendLine(
+            `[Argo CD Status] Install: could not determine — 'kubectl get pods -l app.kubernetes.io/managed-by=Microsoft.ArgoCD' failed (RBAC or connection issue?).`,
+        );
+    }
 
     // Pods.
     const podsResult = await longRunning(l10n.t("Fetching Argo CD pod status from {0}…", clusterName), () =>

--- a/src/commands/aksArgoCD/argoCDWifBootstrap.ts
+++ b/src/commands/aksArgoCD/argoCDWifBootstrap.ts
@@ -1,0 +1,281 @@
+/**
+ * Workload Identity Federation (WIF) bootstrap helper for Argo CD.
+ *
+ * When the Azure-managed Argo CD extension is detected (or Entra ID SSO is
+ * configured) AND the application references an Azure-hosted source (ACR or
+ * Azure DevOps), this helper replaces the previous "open Microsoft Learn tab"
+ * shortcut with a guided 3-step flow:
+ *
+ *   1. Show the Kubernetes ServiceAccount subject claim Argo CD uses and the
+ *      cluster OIDC issuer URL — the two values required to create a
+ *      federated credential on a User-Assigned Managed Identity (UAMI) or
+ *      App Registration.
+ *   2. Open the Azure Portal directly on the relevant Federated Credentials
+ *      blade so the user can paste those values.
+ *   3. Print the role-assignment guidance (`AcrPull` for ACR,
+ *      `Reader` / `Build Reader` for Azure DevOps) and the ServiceAccount
+ *      annotation to wire the identity back into the cluster.
+ *
+ * The Microsoft Learn tutorial is still surfaced as a final fallback.
+ *
+ * The helper is purely informational — it does not mutate Azure or the
+ * cluster.  All resource creation remains in the Azure Portal so the user
+ * stays in control.
+ */
+
+import * as vscode from "vscode";
+import * as k8s from "vscode-kubernetes-tools-api";
+import * as l10n from "@vscode/l10n";
+
+import { invokeKubectlCommand } from "../utils/kubectl";
+import { NonZeroExitCodeBehaviour } from "../utils/shell";
+import { failed } from "../utils/errorable";
+import { getOutputChannel } from "./argoCDInstall";
+import type { AzureRepoHost } from "./argoCDApplyApp";
+
+const ARGOCD_NAMESPACE = "argocd";
+
+// Default Argo CD ServiceAccounts that typically need to pull from Azure.
+// repo-server pulls Git manifests; image-updater optionally pulls from ACR.
+const CANDIDATE_SERVICE_ACCOUNTS = ["argocd-repo-server", "argocd-image-updater", "argocd-application-controller"];
+
+const LEARN_TUTORIAL_URL = "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd";
+const WIF_OVERVIEW_URL =
+    "https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust";
+
+type WifContext = {
+    serviceAccount: string;
+    namespace: string;
+    subject: string; // system:serviceaccount:<ns>:<sa>
+    issuerUrl: string | undefined;
+    existingClientId: string | undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Entry point — called from argoCDApplyApp's post-apply QuickPick.
+// ---------------------------------------------------------------------------
+
+export async function runWifBootstrap(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFilePath: string,
+    azureHost: AzureRepoHost,
+): Promise<void> {
+    const channel = getOutputChannel();
+    channel.show(true);
+    channel.appendLine(`\n[WIF Bootstrap] Starting Workload Identity Federation helper for ${azureHost} source…`);
+
+    const ctx = await collectWifContext(kubectl, kubeConfigFilePath, channel);
+    if (!ctx) return;
+
+    // Multi-step menu — user can re-enter each step.
+    while (true) {
+        const pick = await vscode.window.showQuickPick(
+            [
+                {
+                    label: "$(info) Step 1 · Show subject claim and issuer",
+                    description: l10n.t("Copy the values needed to create a federated credential"),
+                    id: "show",
+                },
+                {
+                    label: "$(azure) Step 2 · Open Azure Portal — Managed Identities",
+                    description: l10n.t("Pick a UAMI and add a federated credential pointing at this SA"),
+                    id: "portal_uami",
+                },
+                {
+                    label: "$(azure) Step 2b · Open Azure Portal — App registrations",
+                    description: l10n.t("Alternative: federate to an Entra app registration"),
+                    id: "portal_app",
+                },
+                {
+                    label:
+                        azureHost === "acr"
+                            ? "$(book) Step 3 · Role assignment (AcrPull) + SA annotation"
+                            : "$(book) Step 3 · Role assignment (Reader) + SA annotation",
+                    description: l10n.t("Print the final wiring steps to the Argo CD output channel"),
+                    id: "wire",
+                },
+                {
+                    label: "$(link-external) Open Microsoft Learn tutorial (fallback)",
+                    description: l10n.t("Full end-to-end Argo CD + WIF walkthrough"),
+                    id: "learn",
+                },
+            ],
+            {
+                title: l10n.t("Configure Workload Identity for {0}", azureHost === "acr" ? "ACR" : "Azure DevOps"),
+                placeHolder: l10n.t("Select a step (Esc to close)"),
+                ignoreFocusOut: true,
+            },
+        );
+
+        if (!pick) return;
+
+        if (pick.id === "show") {
+            await showSubjectAndIssuer(ctx, channel);
+        } else if (pick.id === "portal_uami") {
+            await vscode.env.openExternal(
+                vscode.Uri.parse(
+                    "https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.ManagedIdentity%2FuserAssignedIdentities",
+                ),
+            );
+        } else if (pick.id === "portal_app") {
+            await vscode.env.openExternal(
+                vscode.Uri.parse("https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"),
+            );
+        } else if (pick.id === "wire") {
+            await printWiringGuidance(ctx, azureHost, channel);
+        } else if (pick.id === "learn") {
+            await vscode.env.openExternal(vscode.Uri.parse(LEARN_TUTORIAL_URL));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Step 0 — discovery
+// ---------------------------------------------------------------------------
+
+async function collectWifContext(
+    kubectl: k8s.APIAvailable<k8s.KubectlV1>,
+    kubeConfigFilePath: string,
+    channel: vscode.OutputChannel,
+): Promise<WifContext | undefined> {
+    // Pick a ServiceAccount: prefer one that exists in the argocd namespace.
+    let serviceAccount: string | undefined;
+    let existingClientId: string | undefined;
+    for (const candidate of CANDIDATE_SERVICE_ACCOUNTS) {
+        const saResult = await invokeKubectlCommand(
+            kubectl,
+            kubeConfigFilePath,
+            `get sa ${candidate} -n ${ARGOCD_NAMESPACE} -o jsonpath="{.metadata.name},{.metadata.annotations.azure\\.workload\\.identity/client-id}"`,
+            NonZeroExitCodeBehaviour.Succeed,
+        );
+        if (failed(saResult) || saResult.result.code !== 0) continue;
+        const [name, clientId] = saResult.result.stdout.split(",");
+        if (name && name.trim() !== "") {
+            serviceAccount = name.trim();
+            existingClientId = clientId?.trim() || undefined;
+            break;
+        }
+    }
+
+    if (!serviceAccount) {
+        // Let the user enter one manually — extension may use a custom SA.
+        const entered = await vscode.window.showInputBox({
+            title: l10n.t("Argo CD ServiceAccount"),
+            prompt: l10n.t(
+                "Could not auto-detect an Argo CD ServiceAccount in the '{0}' namespace. Enter the SA name to use.",
+                ARGOCD_NAMESPACE,
+            ),
+            value: "argocd-repo-server",
+        });
+        if (!entered) return undefined;
+        serviceAccount = entered;
+    }
+
+    // Best-effort: discover the cluster OIDC issuer URL.  AKS exposes this
+    // via the public well-known endpoint; if kubectl can't fetch it the
+    // user will get it from the cluster properties / Azure Portal.
+    let issuerUrl: string | undefined;
+    const issuerResult = await invokeKubectlCommand(
+        kubectl,
+        kubeConfigFilePath,
+        `get --raw /.well-known/openid-configuration`,
+        NonZeroExitCodeBehaviour.Succeed,
+    );
+    if (!failed(issuerResult) && issuerResult.result.code === 0) {
+        const match = issuerResult.result.stdout.match(/"issuer"\s*:\s*"([^"]+)"/);
+        if (match) issuerUrl = match[1];
+    }
+
+    const subject = `system:serviceaccount:${ARGOCD_NAMESPACE}:${serviceAccount}`;
+    channel.appendLine(`[WIF Bootstrap] ServiceAccount: ${serviceAccount} (namespace=${ARGOCD_NAMESPACE})`);
+    channel.appendLine(`[WIF Bootstrap] Federated credential subject: ${subject}`);
+    channel.appendLine(`[WIF Bootstrap] OIDC issuer: ${issuerUrl ?? "(unknown — fetch from AKS cluster properties)"}`);
+    if (existingClientId) {
+        channel.appendLine(`[WIF Bootstrap] Existing azure.workload.identity/client-id on SA: ${existingClientId}`);
+    }
+
+    return { serviceAccount, namespace: ARGOCD_NAMESPACE, subject, issuerUrl, existingClientId };
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — show values + copy to clipboard
+// ---------------------------------------------------------------------------
+
+async function showSubjectAndIssuer(ctx: WifContext, channel: vscode.OutputChannel): Promise<void> {
+    channel.appendLine(`\n[WIF Bootstrap] === Step 1: federated credential inputs ===`);
+    channel.appendLine(`  Subject (paste into "Subject identifier"):  ${ctx.subject}`);
+    channel.appendLine(`  Issuer  (paste into "Issuer URL"):          ${ctx.issuerUrl ?? "(retrieve from cluster)"}`);
+    channel.appendLine(`  Audience (default):                          api://AzureADTokenExchange`);
+
+    const action = await vscode.window.showInformationMessage(
+        l10n.t(
+            "Federated credential inputs:\n\n" +
+                "Subject: {0}\n" +
+                "Issuer: {1}\n" +
+                "Audience: api://AzureADTokenExchange",
+            ctx.subject,
+            ctx.issuerUrl ?? "(unknown — open AKS cluster → Security configuration → OIDC issuer URL)",
+        ),
+        { modal: true },
+        l10n.t("Copy subject"),
+        l10n.t("Copy issuer"),
+    );
+    if (action === l10n.t("Copy subject")) {
+        await vscode.env.clipboard.writeText(ctx.subject);
+        vscode.window.showInformationMessage(l10n.t("Subject copied to clipboard."));
+    } else if (action === l10n.t("Copy issuer") && ctx.issuerUrl) {
+        await vscode.env.clipboard.writeText(ctx.issuerUrl);
+        vscode.window.showInformationMessage(l10n.t("Issuer URL copied to clipboard."));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — role assignment + SA annotation guidance
+// ---------------------------------------------------------------------------
+
+async function printWiringGuidance(
+    ctx: WifContext,
+    azureHost: AzureRepoHost,
+    channel: vscode.OutputChannel,
+): Promise<void> {
+    channel.appendLine(`\n[WIF Bootstrap] === Step 3: wire the identity to Azure + the cluster ===`);
+
+    if (azureHost === "acr") {
+        channel.appendLine(`  Grant the identity 'AcrPull' on the target Azure Container Registry:`);
+        channel.appendLine(
+            `    Azure Portal → your ACR → Access control (IAM) → Add role assignment → 'AcrPull' → Managed identity → pick your UAMI.`,
+        );
+        channel.appendLine(`  Reference: ${WIF_OVERVIEW_URL}`);
+    } else if (azureHost === "azure-devops") {
+        channel.appendLine(`  Grant the identity access to the Azure DevOps repository:`);
+        channel.appendLine(
+            `    Azure DevOps → Project settings → Permissions → grant the workload identity (or the Entra group containing it) 'Reader' on the repo.`,
+        );
+        channel.appendLine(
+            `    For pipelines that consume the identity, use service connections of type 'Workload Identity federation'.`,
+        );
+    }
+
+    channel.appendLine(`\n  Annotate the Argo CD ServiceAccount with the UAMI client id:`);
+    channel.appendLine(`    kubectl annotate sa ${ctx.serviceAccount} -n ${ctx.namespace} \\`);
+    channel.appendLine(`        azure.workload.identity/client-id=<CLIENT_ID> --overwrite`);
+    channel.appendLine(`\n  Then restart the Argo CD workload so the token mount picks up the annotation:`);
+    channel.appendLine(`    kubectl rollout restart deploy/${ctx.serviceAccount} -n ${ctx.namespace}`);
+    channel.appendLine(`\n  Full walkthrough: ${LEARN_TUTORIAL_URL}`);
+
+    const action = await vscode.window.showInformationMessage(
+        l10n.t(
+            "Step 3 commands written to the Argo CD output channel. After granting the role and annotating the ServiceAccount, restart the Argo CD workload to apply the change.",
+        ),
+        l10n.t("Copy annotate command"),
+        l10n.t("Open Learn tutorial"),
+    );
+    if (action === l10n.t("Copy annotate command")) {
+        await vscode.env.clipboard.writeText(
+            `kubectl annotate sa ${ctx.serviceAccount} -n ${ctx.namespace} azure.workload.identity/client-id=<CLIENT_ID> --overwrite`,
+        );
+        vscode.window.showInformationMessage(l10n.t("Annotate command copied to clipboard."));
+    } else if (action === l10n.t("Open Learn tutorial")) {
+        await vscode.env.openExternal(vscode.Uri.parse(LEARN_TUTORIAL_URL));
+    }
+}

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -937,6 +937,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1669,7 +1670,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6189,8 +6191,7 @@
     "@fortawesome/react-fontawesome": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
-      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
-      "requires": {}
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w=="
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -6483,6 +6484,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "requires": {
         "csstype": "^3.2.2"
       }
@@ -6491,8 +6493,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/unist": {
       "version": "3.0.0",
@@ -6697,8 +6698,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.14.0",
@@ -6934,7 +6934,8 @@
     "csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "data-view-buffer": {
       "version": "1.0.2",
@@ -9133,8 +9134,7 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.4",
@@ -9158,8 +9158,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tslib": {
       "version": "2.8.1",
@@ -9535,8 +9534,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "zwitch": {
       "version": "2.0.4",


### PR DESCRIPTION
## Summary

Aligns the Argo CD GitOps integration with the **Azure-managed Argo CD k8s extension** (`Microsoft.ArgoCD`, public preview) on AKS and Azure Arc-enabled Kubernetes clusters. Adds runtime detection of the managed install, surfaces **Workload Identity Federation** as the preferred credential path for Azure source repos with a **guided in-VS-Code bootstrap helper**, and rewrites the docs to explain both install tracks clearly.

No new commands. No behavior change for upstream Argo CD users. No change to scaffolded `application.yaml` output. Feature flag `aks.argoCDEnabled` continues to gate everything.

Refs:
- [Announcement blog (Azure Blog)](https://techcommunity.microsoft.com/blog/azurearcblog/announcing-public-preview-of-argo-cd-extension-on-aks-and-azure-arc-enabled-kube/4504497)
- [Microsoft Learn: Use GitOps with Argo CD](https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-argocd)

---

## Why

The blog above announces public preview of an Azure-managed Argo CD extension with three pillars: **Entra ID SSO + Workload Identity Federation** (no long-lived PATs/SSH for ACR / Azure DevOps), **Azure Linux–hardened images + opt-in patch channel**, and **upstream parity** (HA, hub-and-spoke, ApplicationSet). Our extension already works against the managed install, but:

- The post-apply UX still nudged users toward PAT/SSH secrets even when the source was an Azure host where WIF is the recommended path.
- Users had no way to tell from VS Code whether their cluster was running the managed extension or upstream.
- The "Configure Workload Identity" action just opened a browser tab — users still had to chase subject claims, OIDC issuer URLs, and the right portal blade by hand.
- The docs page didn't mention the managed extension, Entra SSO, WIF, or any of the production topologies that come with it.

---

## Changes

### Code

**[argoCDInstall.ts](src/commands/aksArgoCD/argoCDInstall.ts)** — install-method detection
- New `detectManagedArgoCDExtension()` — probes the `argocd` namespace for the `app.kubernetes.io/managed-by=Microsoft.ArgoCD` pod label. Returns a tri-state (`managed` / `upstream` / `unknown`) so RBAC-forbidden / connection failures don't silently misclassify as upstream.
- `showArgoCDStatus()` now logs install method in three branches; `unknown` explicitly mentions the failing `kubectl get pods` command so RBAC issues are debuggable.

**[argoCDApplyApp.ts](src/commands/aksArgoCD/argoCDApplyApp.ts)** — post-apply menu
- New `classifyAzureRepoHost(repoUrl)` — matches `*.azurecr.io`, `(ssh.)?dev.azure.com`, and legacy `(vs-ssh.)?*.visualstudio.com`.
- Post-apply menu now fetches `installMethod` alongside `authMode` / `repoVisibility` via `Promise.all`.
- Workload Identity hint is gated on `azureHost !== "other" && (installMethod === "managed" || authMode === "sso")` — i.e. only shown when the linked flow actually applies to the user's install path.
- When the WIF hint is selected and the managed extension is detected, the action now routes through the new guided helper (below). For SSO-only upstream installs it falls back to the Microsoft Learn tutorial link.

**[argoCDWifBootstrap.ts](src/commands/aksArgoCD/argoCDWifBootstrap.ts)** — new guided WIF helper (~280 LOC, no Azure or cluster mutations)
- Auto-detects the Argo CD ServiceAccount in `argocd` namespace (tries `argocd-repo-server`, `argocd-image-updater`, `argocd-application-controller`; falls back to user input).
- Reads any existing `azure.workload.identity/client-id` annotation on the SA and fetches the cluster OIDC issuer URL via `kubectl get --raw /.well-known/openid-configuration`.
- QuickPick step menu, logging each step to the shared "Argo CD" output channel:
  - **Step 1** — show federated-credential **subject claim** (`system:serviceaccount:argocd:<sa>`), issuer URL, and audience (`api://AzureADTokenExchange`) with one-click clipboard copy.
  - **Step 2** — open Azure Portal directly on **Managed Identities** (or **App registrations**) so the user pastes those values into a new federated credential.
  - **Step 3** — print role-assignment guidance (`AcrPull` for ACR, `Reader` for Azure DevOps), the `azure.workload.identity/client-id` annotation command, and the `kubectl rollout restart` to apply it.
  - **Fallback** — the original Microsoft Learn tutorial link is still one click away.

### Docs

**[docs/book/src/features/argocd-gitops-integration.md](docs/book/src/features/argocd-gitops-integration.md)**
- New **Installation options** table — managed extension vs upstream Argo CD, with capability comparison.
- New **Two orthogonal probes** section — explains that install-method (managed-by label) and auth-mode (`oidc.config` referencing `login.microsoftonline.com`) are independent signals, so a managed install without SSO and an upstream install wired to Entra ID by hand are both valid configurations.
- **Configure Workload Identity for Azure** subsection rewritten — describes the branched behavior: guided 3-step bootstrap helper when the managed extension is detected, Learn-link fallback otherwise.
- **Connect Private Repository** scoped to GitHub (Azure sources should use WIF).
- Added **Production topologies** (HA, hub-and-spoke), expanded troubleshooting, and a **Further reading** footer.

---

## What this PR does **not** change

- No new VS Code command IDs. Same five `aks.argoCD*` commands as before.
- No change to scaffolded `application.yaml` content from `aks.draftArgoCDDeployment`.
- No new dependencies. No `az` CLI shell-outs. All Azure interactions remain via the existing session provider; cluster interactions remain via `kubectl`.
- No mutations to Azure or the cluster from the WIF helper — it's purely informational + portal deep-links.
- No change for upstream Argo CD users: install-method resolves to `upstream`, WIF hint is hidden, existing flows (admin-password fetch, Open UI, Connect Private Repository) are unchanged.

---

## Testing

- TypeScript: `npx tsc --noEmit` clean.
- Manual: smoke-tested install-method and auth-mode detection on a kind cluster by patching `argocd-cm.data["oidc.config"]` and labelling pods with `app.kubernetes.io/managed-by=Microsoft.ArgoCD` (see docs § "Two orthogonal probes" for the exact probe queries).
- WIF bootstrap helper exercised against the same fake-managed cluster — Step 1 prints subject/issuer with clipboard copy working, Step 2 opens both portal blades, Step 3 prints branched ACR vs Azure DevOps guidance.

---

## Out of scope (planned follow-ups)

- **Install Azure-managed Argo CD extension from VS Code** (would call `Microsoft.KubernetesConfiguration` ARM directly, no `az` CLI). Deferred to a separate PR — current PR focuses on **post-install + deploy** scenarios.
- ApplicationSet scaffold variant for hub-and-spoke topologies.
- Auto-detecting the UAMI client ID once federation is created and offering to apply the SA annotation programmatically.