### PR TITLE
Kickstart enhancements

### DIFF
--- a/src/chatParticipants/kickstart/orchestrator.ts
+++ b/src/chatParticipants/kickstart/orchestrator.ts
@@ -182,19 +182,8 @@ export async function handleStart(
 
     stream.markdown("\n✅ **Files generated** — review in the panel, then click **Save to project**:\n\n");
 
-    // Build file tree for native chat rendering
-    const fileTree: vscode.ChatResponseFileTree[] = [];
-    const k8sChildren: vscode.ChatResponseFileTree[] = [];
-    for (const sf of stagedSoFar) {
-        if (sf.filename.startsWith("k8s/")) {
-            k8sChildren.push({ name: sf.filename.replace("k8s/", "") });
-        } else {
-            fileTree.push({ name: sf.filename });
-        }
-    }
-    if (k8sChildren.length > 0) {
-        fileTree.push({ name: "k8s", children: k8sChildren });
-    }
+    // Build file tree for native chat rendering (supports nested per-module paths).
+    const fileTree = buildNestedFileTree(stagedSoFar.map((sf) => sf.filename));
     // Use the staging root as the filetree base so clicking a file opens the staged copy
     stream.filetree(fileTree, stagedManager.stagingRoot);
     for (const sf of stagedSoFar) {
@@ -271,4 +260,30 @@ function isCancelled(token: vscode.CancellationToken, stream: vscode.ChatRespons
 
     stream.markdown("Cancelled.");
     return true;
+}
+
+/**
+ * Builds a nested ChatResponseFileTree from "/"-separated filenames.
+ * Staged filenames may be flat (e.g. "Dockerfile") or per-module
+ * (e.g. "src/api/Dockerfile", "src/api/k8s/deployment.yaml").
+ */
+function buildNestedFileTree(filenames: string[]): vscode.ChatResponseFileTree[] {
+    type Node = { name: string; children?: Node[] };
+    const root: Node = { name: "", children: [] };
+    for (const fn of filenames) {
+        const parts = fn.split("/").filter((p) => p.length > 0);
+        let curr: Node = root;
+        for (let i = 0; i < parts.length; i++) {
+            const name = parts[i];
+            const isLast = i === parts.length - 1;
+            curr.children = curr.children ?? [];
+            let next = curr.children.find((c) => c.name === name);
+            if (!next) {
+                next = isLast ? { name } : { name, children: [] };
+                curr.children.push(next);
+            }
+            curr = next;
+        }
+    }
+    return (root.children ?? []) as vscode.ChatResponseFileTree[];
 }

--- a/src/chatParticipants/kickstart/phases/analyze.ts
+++ b/src/chatParticipants/kickstart/phases/analyze.ts
@@ -152,8 +152,15 @@ export async function analyzePhase(
         if (existingFiles.hasDockerfile || existingFiles.hasK8sManifests) {
             stream.markdown("\n### Existing Artifacts Detected\n\n");
 
-            if (existingFiles.hasDockerfile) {
-                stream.markdown(`- **Dockerfile**: \`${existingFiles.dockerfilePath}\`\n`);
+            if (existingFiles.hasDockerfile && existingFiles.dockerfilePaths) {
+                if (existingFiles.dockerfilePaths.length === 1) {
+                    stream.markdown(`- **Dockerfile**: \`${existingFiles.dockerfilePaths[0]}\`\n`);
+                } else {
+                    stream.markdown(`- **Dockerfiles** (${existingFiles.dockerfilePaths.length}):\n`);
+                    for (const dfPath of existingFiles.dockerfilePaths) {
+                        stream.markdown(`  - \`${dfPath}\`\n`);
+                    }
+                }
             }
 
             if (existingFiles.hasK8sManifests && existingFiles.k8sManifestPaths) {
@@ -188,6 +195,8 @@ export async function analyzePhase(
             hasDockerfile: existingFiles.hasDockerfile,
             hasK8sManifests: existingFiles.hasK8sManifests,
             hasGitHubWorkflow: false,
+            existingDockerfilePaths: existingFiles.dockerfilePaths,
+            existingK8sManifestPaths: existingFiles.k8sManifestPaths,
         };
 
         return {

--- a/src/chatParticipants/kickstart/phases/build.ts
+++ b/src/chatParticipants/kickstart/phases/build.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import { scanForDockerfiles } from "../../../commands/aksContainerAssist/fileOperations";
 import { PhaseResult } from "../phaseRunner";
 import { ArtifactsData, ConfigData, ImageData } from "../state";
-import { StagedFileManager } from "../stagedFileManager";
 import { runInTerminal } from "../terminalTool";
 
 /**
@@ -39,14 +38,51 @@ export async function buildPhase(
 
         stream.markdown("🐳 **Building and pushing container image**\n\n");
 
-        // Resolve the build context directory.
-        // If the user has already saved artifacts to disk, build from the workspace.
-        // Otherwise build from the extension's staging directory, which was already
-        // written during the Prepare phase (no re-write needed).
-        let buildContextPath: string;
+        // The build context is always the workspace directory so that the Dockerfile
+        // can reference source files (e.g. .mvn/, pom.xml, src/) that live there.
+        // When artifacts have not yet been saved to disk, the generated Dockerfile
+        // lives in the staging directory, so we pass its path via --file.
+        const buildContextPath = workspacePath;
+
+        // Collect Dockerfile build targets. Monorepos have one Dockerfile per module
+        // (staged as "<modulePath>/Dockerfile"); single-module projects have one
+        // at the root (staged as "Dockerfile").
+        interface BuildTarget {
+            dockerfilePath: string;
+            dockerfileFlag: string;
+            imageName: string;
+        }
+
+        const workspaceFolderName = path.basename(workspacePath);
+        const sanitize = (s: string): string =>
+            s
+                .toLowerCase()
+                .replace(/[^a-z0-9-]+/g, "-")
+                .replace(/^-+|-+$/g, "");
+        const baseImageName = sanitize(workspaceFolderName) || "app";
+
+        const targets: BuildTarget[] = [];
 
         if (artifacts.savedToDisk) {
-            buildContextPath = workspacePath;
+            // Dockerfiles are already in the workspace – let az acr build find them.
+            const dockerfiles = await scanForDockerfiles(workspacePath);
+            if (dockerfiles.length === 0) {
+                return {
+                    ok: false,
+                    error: "Dockerfile not found. Please run the Prepare phase to generate one.",
+                    retryable: false,
+                };
+            }
+            for (const df of dockerfiles) {
+                const relDir = path.relative(workspacePath, path.dirname(df));
+                const isRoot = !relDir || relDir === ".";
+                const suffix = isRoot ? "" : `-${sanitize(relDir.split(path.sep).join("-"))}`;
+                targets.push({
+                    dockerfilePath: df,
+                    dockerfileFlag: isRoot ? "" : `--file "${df}"`,
+                    imageName: `${baseImageName}${suffix}`,
+                });
+            }
         } else {
             if (!storageUri) {
                 return {
@@ -55,19 +91,30 @@ export async function buildPhase(
                     retryable: false,
                 };
             }
-            const stagingRoot = new StagedFileManager(storageUri).stagingRoot;
-            buildContextPath = stagingRoot.fsPath;
-            stream.markdown("ℹ️ Building from staged files (artifacts not yet saved to workspace).\n\n");
-        }
-
-        // Check that Dockerfile exists in the build context
-        const dockerfiles = await scanForDockerfiles(buildContextPath);
-        if (dockerfiles.length === 0) {
-            return {
-                ok: false,
-                error: "Dockerfile not found. Please run the Prepare phase to generate one.",
-                retryable: false,
-            };
+            const stagedDockerfiles = artifacts.stagedFiles.filter(
+                (f) => f.filename === "Dockerfile" || f.filename.endsWith("/Dockerfile"),
+            );
+            if (stagedDockerfiles.length === 0) {
+                return {
+                    ok: false,
+                    error: "Dockerfile not found. Please run the Prepare phase to generate one.",
+                    retryable: false,
+                };
+            }
+            for (const sf of stagedDockerfiles) {
+                const fsPath = vscode.Uri.parse(sf.stagedPath).fsPath;
+                const isRoot = sf.filename === "Dockerfile";
+                const relDir = isRoot ? "" : sf.filename.substring(0, sf.filename.length - "/Dockerfile".length);
+                const suffix = relDir ? `-${sanitize(relDir.replace(/\//g, "-"))}` : "";
+                targets.push({
+                    dockerfilePath: fsPath,
+                    dockerfileFlag: `--file "${fsPath}"`,
+                    imageName: `${baseImageName}${suffix}`,
+                });
+            }
+            stream.markdown(
+                `ℹ️ Building from staged Dockerfile${targets.length > 1 ? "s" : ""} with workspace source code.\n\n`,
+            );
         }
 
         // Validate ACR configuration
@@ -79,19 +126,25 @@ export async function buildPhase(
             };
         }
 
-        // Determine image name from workspace folder
-        const workspaceFolderName = path.basename(workspacePath);
-        const imageName = workspaceFolderName.toLowerCase().replace(/[^a-z0-9-]/g, "-");
         const imageTag = "latest";
-        const fullImageUri = `${config.acrLoginServer}/${imageName}:${imageTag}`;
 
-        // Show build preview
-        stream.markdown("### Build Configuration\n\n");
-        stream.markdown(`- **ACR:** ${config.acrName} (${config.acrLoginServer})\n`);
-        stream.markdown(`- **Image Name:** ${imageName}\n`);
-        stream.markdown(`- **Image Tag:** ${imageTag}\n`);
-        stream.markdown(`- **Full URI:** ${fullImageUri}\n`);
-        stream.markdown(`- **Dockerfile:** ${dockerfiles[0]}\n\n`);
+        if (targets.length > 1) {
+            stream.markdown(`### Build Plan (${targets.length} images)\n\n`);
+            for (const t of targets) {
+                stream.markdown(
+                    `- **${config.acrLoginServer}/${t.imageName}:${imageTag}** — \`${t.dockerfilePath}\`\n`,
+                );
+            }
+            stream.markdown("\n");
+        } else {
+            const t = targets[0];
+            stream.markdown("### Build Configuration\n\n");
+            stream.markdown(`- **ACR:** ${config.acrName} (${config.acrLoginServer})\n`);
+            stream.markdown(`- **Image Name:** ${t.imageName}\n`);
+            stream.markdown(`- **Image Tag:** ${imageTag}\n`);
+            stream.markdown(`- **Full URI:** ${config.acrLoginServer}/${t.imageName}:${imageTag}\n`);
+            stream.markdown(`- **Dockerfile:** ${t.dockerfilePath}\n\n`);
+        }
 
         // Check if token is cancelled before starting build
         if (token.isCancellationRequested) {
@@ -102,58 +155,86 @@ export async function buildPhase(
             };
         }
 
-        stream.markdown("### Building image...\n\n");
-        stream.progress("Building container image...");
+        let lastImageName = "";
+        for (const target of targets) {
+            if (token.isCancellationRequested) {
+                return { ok: false, error: "Build cancelled by user.", retryable: true };
+            }
 
-        const buildCommand = `az acr build --registry ${config.acrName} --image ${imageName}:${imageTag} .`;
+            stream.markdown(`### Building image \`${target.imageName}:${imageTag}\`...\n\n`);
+            stream.progress(`Building ${target.imageName}...`);
 
-        const buildResult = await runInTerminal(buildCommand, buildContextPath, token, request.toolInvocationToken);
+            const buildCommand =
+                `az acr build --registry ${config.acrName} --image ${target.imageName}:${imageTag} --subscription ${config.subscriptionId} ${target.dockerfileFlag} .`.trimEnd();
 
-        if (!buildResult.succeeded) {
-            return {
-                ok: false,
-                error: `Container build failed: ${buildResult.error}`,
-                retryable: true,
-            };
-        }
+            const buildResult = await runInTerminal(buildCommand, buildContextPath, token, request.toolInvocationToken);
 
-        stream.markdown("### Verifying image in registry...\n\n");
+            if (!buildResult.succeeded) {
+                return {
+                    ok: false,
+                    error: `Container build failed for ${target.imageName}: ${buildResult.error}`,
+                    retryable: true,
+                };
+            }
 
-        const verifyCommand = `az acr repository show-tags --name ${config.acrName} --repository ${imageName} --orderby time_desc --output json`;
-        const verifyResult = await runInTerminal(verifyCommand, buildContextPath, token, request.toolInvocationToken);
+            stream.markdown(`### Verifying image \`${target.imageName}\` in registry...\n\n`);
 
-        if (!verifyResult.succeeded) {
-            stream.markdown(
-                "⚠️ Could not verify image tag, but build command succeeded. The image should be available in the registry.\n\n",
+            const verifyCommand = `az acr repository show-tags --name ${config.acrName} --repository ${target.imageName} --subscription ${config.subscriptionId} --orderby time_desc --output json`;
+            const verifyResult = await runInTerminal(
+                verifyCommand,
+                buildContextPath,
+                token,
+                request.toolInvocationToken,
             );
-        } else {
-            try {
-                const tags = JSON.parse(verifyResult.result);
-                if (Array.isArray(tags) && tags.includes(imageTag)) {
-                    stream.markdown(`✅ Image verified in registry: **${imageName}:${imageTag}**\n\n`);
-                } else {
+
+            if (!verifyResult.succeeded) {
+                stream.markdown(
+                    `⚠️ Could not verify image \`${target.imageName}\`, but build command succeeded. The image should be available in the registry.\n\n`,
+                );
+            } else {
+                try {
+                    const tags = JSON.parse(verifyResult.result);
+                    if (Array.isArray(tags) && tags.includes(imageTag)) {
+                        stream.markdown(`✅ Image verified in registry: **${target.imageName}:${imageTag}**\n\n`);
+                    } else {
+                        stream.markdown(
+                            `⚠️ Tag '${imageTag}' not found in recent tags for **${target.imageName}**. The image may take a moment to appear.\n\n`,
+                        );
+                    }
+                } catch {
                     stream.markdown(
-                        `⚠️ Tag '${imageTag}' not found in recent tags. The image may take a moment to appear in the registry.\n\n`,
+                        `ℹ️ Image **${target.imageName}** build completed. Tag verification parsing skipped.\n\n`,
                     );
                 }
-            } catch {
-                stream.markdown("ℹ️ Image build completed. Tag verification parsing skipped.\n\n");
             }
+
+            lastImageName = target.imageName;
         }
 
         // Build successful
         stream.markdown("### Summary\n\n");
-        stream.markdown(`✅ **Build and push complete!**\n`);
-        stream.markdown(`- **Repository:** ${config.acrLoginServer}/${imageName}\n`);
-        stream.markdown(`- **Tag:** ${imageTag}\n`);
-        stream.markdown(`- **Full Reference:** ${fullImageUri}\n\n`);
+        if (targets.length > 1) {
+            stream.markdown(`✅ **Built and pushed ${targets.length} images:**\n`);
+            for (const t of targets) {
+                stream.markdown(`- ${config.acrLoginServer}/${t.imageName}:${imageTag}\n`);
+            }
+            stream.markdown("\n");
+        } else {
+            const t = targets[0];
+            stream.markdown(`✅ **Build and push complete!**\n`);
+            stream.markdown(`- **Repository:** ${config.acrLoginServer}/${t.imageName}\n`);
+            stream.markdown(`- **Tag:** ${imageTag}\n`);
+            stream.markdown(`- **Full Reference:** ${config.acrLoginServer}/${t.imageName}:${imageTag}\n\n`);
+        }
 
         stream.markdown("### Next Steps\n\n");
-        stream.markdown("1. Your container image is now available in Azure Container Registry\n");
+        stream.markdown("1. Your container image(s) are now available in Azure Container Registry\n");
         stream.markdown("2. Proceed to the **Deploy** phase to apply Kubernetes manifests to your cluster\n");
 
+        // Return ImageData for the last-built image (singular for backward compat).
+        // Monorepo deploy/verify currently treats this as the primary image.
         const image: ImageData = {
-            repository: `${config.acrLoginServer}/${imageName}`,
+            repository: `${config.acrLoginServer}/${lastImageName}`,
             tag: imageTag,
         };
 

--- a/src/chatParticipants/kickstart/phases/deploy.ts
+++ b/src/chatParticipants/kickstart/phases/deploy.ts
@@ -119,8 +119,21 @@ export async function deployPhase(
         const kubeConfigFile = await createTempFile(kubeconfigYaml, "yaml");
 
         try {
-            // Determine manifests directory
-            const manifestsDir = path.join(workspacePath, "k8s");
+            // Determine manifest directories. Monorepo modules have manifests under
+            // "<module>/k8s/"; single-module projects have them at the workspace root "k8s/".
+            const isManifestFilename = (filename: string): boolean => /(^|\/)k8s\//.test(filename);
+            const manifestDirsRel = new Set<string>();
+            for (const sf of artifacts.stagedFiles) {
+                if (!isManifestFilename(sf.filename)) continue;
+                const idx = sf.filename.lastIndexOf("k8s/");
+                const dirRel = idx > 0 ? `${sf.filename.substring(0, idx)}k8s` : "k8s";
+                manifestDirsRel.add(dirRel);
+            }
+            if (manifestDirsRel.size === 0) {
+                // Fall back to default location (backward compat with non-staged flows)
+                manifestDirsRel.add("k8s");
+            }
+            const manifestDirs = [...manifestDirsRel].map((d) => path.join(workspacePath, d));
 
             // Skip namespace creation for AKS Automatic (it manages namespaces automatically)
             if (config.clusterSku === "Automatic") {
@@ -133,9 +146,17 @@ export async function deployPhase(
             }
 
             stream.markdown(`### Applying manifests to **${config.clusterName}**\n\n`);
+            if (manifestDirs.length > 1) {
+                stream.markdown(`Applying manifests from ${manifestDirs.length} module directories:\n`);
+                for (const d of manifestDirs) {
+                    stream.markdown(`- \`${d}\`\n`);
+                }
+                stream.markdown("\n");
+            }
             stream.progress("Applying manifests to cluster...");
 
-            const applyCommand = `kubectl apply -f "${manifestsDir}" --kubeconfig="${kubeConfigFile.filePath}"`;
+            const fFlags = manifestDirs.map((d) => `-f "${d}"`).join(" ");
+            const applyCommand = `kubectl apply ${fFlags} --kubeconfig="${kubeConfigFile.filePath}"`;
             const applyResult = await runInTerminal(applyCommand, workspacePath, token, request.toolInvocationToken);
 
             if (!applyResult.succeeded) {
@@ -177,7 +198,7 @@ export async function deployPhase(
 
             // Build list of applied manifests for tracking
             const appliedManifests = artifacts.stagedFiles
-                .filter((f) => f.filename.startsWith("k8s/"))
+                .filter((f) => isManifestFilename(f.filename))
                 .map((f) => f.filename);
 
             // Create deployment data

--- a/src/chatParticipants/kickstart/phases/prepare.ts
+++ b/src/chatParticipants/kickstart/phases/prepare.ts
@@ -140,12 +140,12 @@ export async function preparePhase(
 
         for (const sf of stagedSoFar) {
             // Only process k8s manifests (not the Dockerfile)
-            if (!sf.filename.startsWith("k8s/")) {
+            if (!isManifestFilename(sf.filename)) {
                 adaptedStaged.push(sf);
                 continue;
             }
             // Extract just the base filename for the AKS Automatic checks
-            const baseFilename = sf.filename.replace(/^k8s\//, "");
+            const baseFilename = manifestBaseFilename(sf.filename);
             const rawContent = manifestFiles[baseFilename] ?? sf.content;
             const processedContent =
                 config.clusterSku === "Automatic" ? adaptManifestForAutomatic(rawContent, baseFilename) : rawContent;
@@ -165,8 +165,8 @@ export async function preparePhase(
         }
 
         // Step 4: Validate that we have required artifacts
-        const hasDockerfile = adaptedStaged.some((s) => s.filename === "Dockerfile");
-        const manifestStaged = adaptedStaged.filter((s) => s.filename.startsWith("k8s/"));
+        const hasDockerfile = adaptedStaged.some((s) => isDockerfileFilename(s.filename));
+        const manifestStaged = adaptedStaged.filter((s) => isManifestFilename(s.filename));
 
         if (!hasDockerfile || manifestStaged.length === 0) {
             return {
@@ -188,19 +188,7 @@ export async function preparePhase(
         }
 
         // Step 5: Show generated files as a native file tree in chat
-        const fileTree: vscode.ChatResponseFileTree[] = [];
-        const k8sChildren: vscode.ChatResponseFileTree[] = [];
-
-        for (const sf of adaptedStaged) {
-            if (sf.filename.startsWith("k8s/")) {
-                k8sChildren.push({ name: sf.filename.replace("k8s/", "") });
-            } else {
-                fileTree.push({ name: sf.filename });
-            }
-        }
-        if (k8sChildren.length > 0) {
-            fileTree.push({ name: "k8s", children: k8sChildren });
-        }
+        const fileTree = buildNestedFileTree(adaptedStaged.map((s) => s.filename));
 
         stream.markdown("\n✅ **Files generated** — review in the panel, then click **Save to project**:\n\n");
         // Use the staging root as the filetree base so clicking a file opens the staged copy
@@ -276,4 +264,46 @@ function adaptManifestForAutomatic(content: string, filename: string): string {
     adapted = adapted.replace(/^\s*resources:\s*\n(?=\s*(?:name:|image:|ports:|env:|$))/gm, "");
 
     return adapted;
+}
+
+/**
+ * Filename match helpers — staged filenames may be flat (single module / root)
+ * or module-prefixed (monorepo): e.g. "Dockerfile", "src/api/Dockerfile",
+ * "k8s/deployment.yaml", or "src/api/k8s/deployment.yaml".
+ */
+function isDockerfileFilename(filename: string): boolean {
+    return filename === "Dockerfile" || filename.endsWith("/Dockerfile");
+}
+
+function isManifestFilename(filename: string): boolean {
+    return /(^|\/)k8s\//.test(filename);
+}
+
+function manifestBaseFilename(filename: string): string {
+    const idx = filename.lastIndexOf("k8s/");
+    return idx >= 0 ? filename.substring(idx + "k8s/".length) : filename;
+}
+
+/**
+ * Builds a nested ChatResponseFileTree from "/"-separated filenames.
+ */
+function buildNestedFileTree(filenames: string[]): vscode.ChatResponseFileTree[] {
+    type Node = { name: string; children?: Node[] };
+    const root: Node = { name: "", children: [] };
+    for (const fn of filenames) {
+        const parts = fn.split("/").filter((p) => p.length > 0);
+        let curr: Node = root;
+        for (let i = 0; i < parts.length; i++) {
+            const name = parts[i];
+            const isLast = i === parts.length - 1;
+            curr.children = curr.children ?? [];
+            let next = curr.children.find((c) => c.name === name);
+            if (!next) {
+                next = isLast ? { name } : { name, children: [] };
+                curr.children.push(next);
+            }
+            curr = next;
+        }
+    }
+    return (root.children ?? []) as vscode.ChatResponseFileTree[];
 }

--- a/src/chatParticipants/kickstart/phases/prepare.ts
+++ b/src/chatParticipants/kickstart/phases/prepare.ts
@@ -1,7 +1,8 @@
+import * as path from "path";
 import * as vscode from "vscode";
-import { generateDockerfileStep } from "../steps/dockerfile";
-import { generateManifestsStep } from "../steps/manifests";
-import { AnalysisResult } from "../steps/analyze";
+import { generateDockerfileStep, DockerfileEnhancementInput } from "../steps/dockerfile";
+import { generateManifestsStep, ExistingManifestInput } from "../steps/manifests";
+import { AnalysisResult, ModuleAnalysis } from "../steps/analyze";
 import { LMClient } from "../../../commands/aksContainerAssist/lmClient";
 import { failed } from "../../../commands/utils/errorable";
 import { PhaseResult } from "../phaseRunner";
@@ -73,6 +74,33 @@ export async function preparePhase(
             isMonorepo: analysis.isMonorepo,
         };
 
+        // Read existing artifacts (if any), grouped per module, so each module gets enhanced
+        // from its own existing files rather than mixed across modules.
+        const existingDockerfileByModule = await readExistingDockerfilesByModule(analysis, workspacePath);
+        const existingManifestsByModule = await readExistingManifestsByModule(analysis, workspacePath);
+
+        const enhancedDockerfileSources: string[] = [];
+        for (const input of existingDockerfileByModule.values()) {
+            enhancedDockerfileSources.push(input.sourcePath ?? "Dockerfile");
+        }
+        const enhancedManifestSources: string[] = [];
+        for (const list of existingManifestsByModule.values()) {
+            for (const m of list) enhancedManifestSources.push(m.filename);
+        }
+
+        if (enhancedDockerfileSources.length > 0) {
+            const list = enhancedDockerfileSources.map((s) => `\`${s}\``).join(", ");
+            stream.markdown(
+                `\n\uD83D\uDD04 **Enhancing ${enhancedDockerfileSources.length} existing Dockerfile(s)**: ${list} will be preserved and improved rather than replaced.\n\n`,
+            );
+        }
+        if (enhancedManifestSources.length > 0) {
+            const list = enhancedManifestSources.map((m) => `\`${m}\``).join(", ");
+            stream.markdown(
+                `\uD83D\uDD04 **Enhancing ${enhancedManifestSources.length} existing Kubernetes manifest(s)**: ${list} will be preserved and improved.\n\n`,
+            );
+        }
+
         // Step 1: Generate Dockerfile
         stream.markdown("**Generating Dockerfile...**\n\n");
         stream.progress("Generating Dockerfile...");
@@ -91,6 +119,7 @@ export async function preparePhase(
                 stagedSoFar.push(...allStaged);
                 onFileStaged(file, allStaged);
             },
+            existingDockerfileByModule.size > 0 ? existingDockerfileByModule : undefined,
         );
 
         if (!dockerfileResult.succeeded) {
@@ -122,6 +151,7 @@ export async function preparePhase(
             {
                 acrLoginServer: config.acrLoginServer,
                 clusterName: config.clusterName,
+                existingManifestsByModule: existingManifestsByModule.size > 0 ? existingManifestsByModule : undefined,
             },
         );
 
@@ -306,4 +336,107 @@ function buildNestedFileTree(filenames: string[]): vscode.ChatResponseFileTree[]
         }
     }
     return (root.children ?? []) as vscode.ChatResponseFileTree[];
+}
+
+/**
+ * Returns the workspace-relative posix path of a module's source directory,
+ * or "" for a root module. Mirrors `moduleStagePrefix` without the trailing slash.
+ */
+function moduleRelPosix(module: ModuleAnalysis, workspacePath: string): string {
+    if (!module.modulePath) return "";
+    const rel = path.isAbsolute(module.modulePath)
+        ? path.relative(workspacePath, module.modulePath)
+        : module.modulePath;
+    if (!rel || rel === "." || rel.startsWith("..")) return "";
+    return rel.split(path.sep).join("/");
+}
+
+/**
+ * Picks the module whose source directory is the longest prefix of `relDir`.
+ * Falls back to the first module if no prefix matches (defensive — keeps the
+ * enhancement from being silently dropped when paths look unfamiliar).
+ */
+function pickModuleForRelDir(
+    relDir: string,
+    modules: ModuleAnalysis[],
+    workspacePath: string,
+): ModuleAnalysis | undefined {
+    if (modules.length === 0) return undefined;
+    const normRelDir = relDir.split(path.sep).join("/");
+    let best: { module: ModuleAnalysis; len: number } | undefined;
+    for (const mod of modules) {
+        const modRel = moduleRelPosix(mod, workspacePath);
+        if (modRel === "") {
+            // Root module always matches; prefer more specific matches if any.
+            if (!best) best = { module: mod, len: 0 };
+            continue;
+        }
+        if (normRelDir === modRel || normRelDir.startsWith(`${modRel}/`)) {
+            if (!best || modRel.length > best.len) {
+                best = { module: mod, len: modRel.length };
+            }
+        }
+    }
+    return best?.module;
+}
+
+/**
+ * Reads existing Dockerfiles and groups them per module so each module's
+ * generation can be enhanced from its own existing file.
+ */
+async function readExistingDockerfilesByModule(
+    analysis: AnalysisData,
+    workspacePath: string,
+): Promise<Map<string, DockerfileEnhancementInput>> {
+    const result = new Map<string, DockerfileEnhancementInput>();
+    const paths = analysis.existingDockerfilePaths ?? [];
+    if (paths.length === 0) return result;
+    for (const absPath of paths) {
+        try {
+            const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(absPath));
+            const content = Buffer.from(bytes).toString("utf-8");
+            if (!content.trim()) continue;
+            const relPath = path.relative(workspacePath, absPath);
+            const relDir = path.dirname(relPath);
+            const module = pickModuleForRelDir(relDir, analysis.modules, workspacePath);
+            if (!module) continue;
+            const key = module.modulePath ?? "";
+            if (result.has(key)) continue; // first match wins
+            result.set(key, { content, sourcePath: relPath || "Dockerfile" });
+        } catch {
+            // Skip unreadable files silently
+        }
+    }
+    return result;
+}
+
+/**
+ * Reads existing K8s manifests and groups them per module so each module's
+ * manifest generation only sees its own existing files.
+ */
+async function readExistingManifestsByModule(
+    analysis: AnalysisData,
+    workspacePath: string,
+): Promise<Map<string, ExistingManifestInput[]>> {
+    const result = new Map<string, ExistingManifestInput[]>();
+    const paths = analysis.existingK8sManifestPaths ?? [];
+    if (paths.length === 0) return result;
+    for (const absPath of paths) {
+        try {
+            const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(absPath));
+            const content = Buffer.from(bytes).toString("utf-8");
+            if (!content.trim()) continue;
+            const relPath = path.relative(workspacePath, absPath) || path.basename(absPath);
+            const relDir = path.dirname(relPath);
+            const module = pickModuleForRelDir(relDir, analysis.modules, workspacePath);
+            if (!module) continue;
+            const key = module.modulePath ?? "";
+            const list = result.get(key) ?? [];
+            list.push({ filename: relPath, content });
+            result.set(key, list);
+        } catch {
+            // Skip unreadable files silently
+        }
+    }
+    return result;
 }

--- a/src/chatParticipants/kickstart/state.ts
+++ b/src/chatParticipants/kickstart/state.ts
@@ -36,6 +36,10 @@ export interface AnalysisData {
     hasDockerfile: boolean;
     hasK8sManifests: boolean;
     hasGitHubWorkflow: boolean;
+    /** Absolute paths of existing Dockerfiles detected in the workspace. */
+    existingDockerfilePaths?: string[];
+    /** Absolute paths of existing K8s manifests detected in the workspace. */
+    existingK8sManifestPaths?: string[];
 }
 
 /**

--- a/src/chatParticipants/kickstart/steps/dockerfile.ts
+++ b/src/chatParticipants/kickstart/steps/dockerfile.ts
@@ -12,6 +12,11 @@ import { StagedFile } from "../state";
 
 export type OnFileStaged = (file: StagedFile, allStaged: StagedFile[]) => void;
 
+export interface DockerfileEnhancementInput {
+    content: string;
+    sourcePath?: string;
+}
+
 /**
  * Returns the staging path prefix for files belonging to `module`.
  * Returns "" for a root-level module (single module or module at project root),
@@ -34,6 +39,7 @@ export async function generateDockerfileStep(
     stagedFileManager: StagedFileManager,
     currentStaged: StagedFile[],
     onFileStaged: OnFileStaged,
+    existingDockerfileByModule?: Map<string, DockerfileEnhancementInput>,
 ): Promise<Errorable<{ dockerfile: string }>> {
     const modules = modulesOrProject(analysis, projectPath);
     let dockerfile = "";
@@ -63,9 +69,10 @@ export async function generateDockerfileStep(
                 continue;
             }
 
+            const existingDockerfile = existingDockerfileByModule?.get(module.modulePath ?? "");
             const response = await lmClient.sendRequestWithTools(
                 DOCKERFILE_SYSTEM_PROMPT,
-                buildDockerfileUserPrompt(planResult.value),
+                buildDockerfileUserPrompt(planResult.value, existingDockerfile),
                 {
                     tools: PROJECT_TOOLS,
                     toolHandler: (call) => handleToolCall(call, projectPath),

--- a/src/chatParticipants/kickstart/steps/dockerfile.ts
+++ b/src/chatParticipants/kickstart/steps/dockerfile.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { generateDockerfile as sdkGenerateDockerfile, formatErrorForLLM } from "containerization-assist-mcp/sdk";
 import { DOCKERFILE_SYSTEM_PROMPT, buildDockerfileUserPrompt } from "../../../commands/aksContainerAssist/prompts";
@@ -10,6 +11,19 @@ import { StagedFileManager } from "../stagedFileManager";
 import { StagedFile } from "../state";
 
 export type OnFileStaged = (file: StagedFile, allStaged: StagedFile[]) => void;
+
+/**
+ * Returns the staging path prefix for files belonging to `module`.
+ * Returns "" for a root-level module (single module or module at project root),
+ * or "<rel>/" (forward-slash separated, workspace-relative) otherwise.
+ * Used so monorepo modules don't clobber each other's Dockerfile / k8s manifests.
+ */
+export function moduleStagePrefix(module: ModuleAnalysis, projectPath: string): string {
+    if (!module.modulePath) return "";
+    const rel = path.isAbsolute(module.modulePath) ? path.relative(projectPath, module.modulePath) : module.modulePath;
+    if (!rel || rel === "." || rel.startsWith("..")) return "";
+    return `${rel.split(path.sep).join("/")}/`;
+}
 
 export async function generateDockerfileStep(
     analysis: AnalysisResult,
@@ -35,7 +49,7 @@ export async function generateDockerfileStep(
             const planResult = await sdkGenerateDockerfile(
                 {
                     repositoryPath: projectPath,
-                    modulePath: module.modulePath ?? projectPath,
+                    modulePath: path.resolve(projectPath, module.modulePath ?? projectPath),
                     language: module.language,
                     framework: module.framework,
                     detectedDependencies: module.dependencies,
@@ -67,8 +81,9 @@ export async function generateDockerfileStep(
 
             dockerfile = extractContent(response.result, "dockerfile");
 
-            // Stage the file in the temp dir and notify
-            const stagedFile = await stagedFileManager.stage("Dockerfile", dockerfile);
+            // Stage per-module so monorepo modules don't clobber each other.
+            const stagedFilename = `${moduleStagePrefix(module, projectPath)}Dockerfile`;
+            const stagedFile = await stagedFileManager.stage(stagedFilename, dockerfile);
             staged.push(stagedFile);
             onFileStaged(stagedFile, staged);
         } catch (error) {

--- a/src/chatParticipants/kickstart/steps/manifests.ts
+++ b/src/chatParticipants/kickstart/steps/manifests.ts
@@ -14,6 +14,11 @@ import { StagedFileManager } from "../stagedFileManager";
 import { StagedFile } from "../state";
 import { OnFileStaged, moduleStagePrefix } from "./dockerfile";
 
+export interface ExistingManifestInput {
+    filename: string;
+    content: string;
+}
+
 export async function generateManifestsStep(
     analysis: AnalysisResult,
     _dockerfileResult: Errorable<{ dockerfile: string }>,
@@ -24,7 +29,11 @@ export async function generateManifestsStep(
     stagedFileManager: StagedFileManager,
     currentStaged: StagedFile[],
     onFileStaged: OnFileStaged,
-    options?: { acrLoginServer?: string; clusterName?: string },
+    options?: {
+        acrLoginServer?: string;
+        clusterName?: string;
+        existingManifestsByModule?: Map<string, ExistingManifestInput[]>;
+    },
 ): Promise<Errorable<{ files: Record<string, string> }>> {
     const modules = modulesOrProject(analysis, projectPath);
     const files: Record<string, string> = {};
@@ -55,6 +64,7 @@ export async function generateManifestsStep(
             }
 
             const appName = module.name ?? "app";
+            const existingManifestsForModule = options?.existingManifestsByModule?.get(module.modulePath ?? "");
             const response = await lmClient.sendRequestWithTools(
                 K8S_MANIFEST_SYSTEM_PROMPT,
                 buildK8sManifestUserPrompt(
@@ -62,6 +72,7 @@ export async function generateManifestsStep(
                     appName,
                     "default",
                     options?.acrLoginServer ?? "<your-registry>",
+                    existingManifestsForModule,
                 ),
                 {
                     tools: PROJECT_TOOLS,

--- a/src/chatParticipants/kickstart/steps/manifests.ts
+++ b/src/chatParticipants/kickstart/steps/manifests.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { generateK8sManifests as sdkGenerateK8sManifests, formatErrorForLLM } from "containerization-assist-mcp/sdk";
 import { K8S_MANIFEST_SYSTEM_PROMPT, buildK8sManifestUserPrompt } from "../../../commands/aksContainerAssist/prompts";
@@ -11,7 +12,7 @@ import { Errorable, failed } from "../../../commands/utils/errorable";
 import { AnalysisResult, ModuleAnalysis, tokenToAbortSignal } from "./analyze";
 import { StagedFileManager } from "../stagedFileManager";
 import { StagedFile } from "../state";
-import { OnFileStaged } from "./dockerfile";
+import { OnFileStaged, moduleStagePrefix } from "./dockerfile";
 
 export async function generateManifestsStep(
     analysis: AnalysisResult,
@@ -40,7 +41,7 @@ export async function generateManifestsStep(
                 {
                     manifestType: "kubernetes",
                     repositoryPath: projectPath,
-                    modulePath: module.modulePath ?? projectPath,
+                    modulePath: path.resolve(projectPath, module.modulePath ?? projectPath),
                     language: module.language,
                     framework: module.framework,
                 },
@@ -81,7 +82,9 @@ export async function generateManifestsStep(
                 : parsed;
 
             for (const manifest of manifests) {
-                const stageFilename = `k8s/${manifest.filename}`;
+                // Stage per-module so monorepo modules don't clobber each other.
+                const prefix = moduleStagePrefix(module, projectPath);
+                const stageFilename = `${prefix}k8s/${manifest.filename}`;
                 files[manifest.filename] = manifest.content;
 
                 // Stage the file and notify

--- a/src/chatParticipants/kickstart/terminalTool.ts
+++ b/src/chatParticipants/kickstart/terminalTool.ts
@@ -1,17 +1,36 @@
 import * as vscode from "vscode";
 import { Errorable } from "../../commands/utils/errorable";
 
+// The real tool name as registered by the Copilot extension.
+const RUN_IN_TERMINAL_TOOL = "run_in_terminal";
+
 export async function runInTerminal(
     command: string,
     cwd: string,
     token: vscode.CancellationToken,
     toolInvocationToken?: vscode.ChatParticipantToolToken,
 ): Promise<Errorable<string>> {
+    const toolAvailable = vscode.lm.tools.some((t) => t.name === RUN_IN_TERMINAL_TOOL);
+    if (!toolAvailable) {
+        return {
+            succeeded: false,
+            error: "The built-in `run_in_terminal` tool is not available. Please use Kickstart in agent mode with GitHub Copilot Chat.",
+        };
+    }
+
+    // The tool does not accept a cwd parameter — prepend a cd to the command instead.
+    const fullCommand = `cd ${JSON.stringify(cwd)} && ${command}`;
+
     try {
         const result = await vscode.lm.invokeTool(
-            "runInTerminal",
+            RUN_IN_TERMINAL_TOOL,
             {
-                input: { command, cwd },
+                input: {
+                    command: fullCommand,
+                    explanation: `Running: ${command}`,
+                    goal: command,
+                    mode: "sync",
+                },
                 toolInvocationToken,
             },
             token,

--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -38,7 +38,7 @@ export async function checkExistingFiles(folderPath: string): Promise<ExistingFi
         const dockerfilePaths = await scanForDockerfiles(folderPath);
         if (dockerfilePaths.length > 0) {
             result.hasDockerfile = true;
-            result.dockerfilePath = dockerfilePaths[0];
+            result.dockerfilePaths = dockerfilePaths;
         }
 
         // Check for K8s manifests

--- a/src/commands/aksContainerAssist/prompts.ts
+++ b/src/commands/aksContainerAssist/prompts.ts
@@ -22,6 +22,13 @@ WORKFLOW:
 3. If the analysis says "unknown" for entry point or other critical fields, use listDirectory and readProjectFile to find the correct values.
 4. Generate the Dockerfile based on ACTUAL project files, not assumptions.
 
+ENHANCEMENT MODE:
+If the user message contains an "Existing Dockerfile to enhance" section, you MUST treat this as an enhancement task:
+- Preserve the user's intent: base image family, build stages, custom RUN steps, COPY paths, ARG/ENV vars, labels, and entrypoint.
+- Improve only what the guidance explicitly calls out: missing multi-stage build, non-root user, missing HEALTHCHECK, pinned versions, smaller base image of the SAME family, .dockerignore-friendly COPY order.
+- Do NOT silently change the base image family (e.g. alpine→debian) or rename the entrypoint binary unless the existing one is clearly broken.
+- Return the COMPLETE enhanced Dockerfile (not a diff).
+
 IMPORTANT: Your final response must contain ONLY the Dockerfile content wrapped in <content></content> markers.
 Do not include any explanations, markdown code fences, or text outside the content markers.
 
@@ -57,6 +64,13 @@ Follow security best practices:
 - Include resource limits, security context, and appropriate labels.
 - When an Image Repository is provided, you MUST use that EXACT value as the container image in deployment.yaml. Do NOT use placeholders like <your-acr-name>, <image>, or any other synthetic value. Do NOT use a bare image name such as "app-name:1.0.0" — always include the full registry URL (e.g. myacr.azurecr.io/app-name).
 
+ENHANCEMENT MODE:
+If the user message contains an "Existing Kubernetes manifests to enhance" section, you MUST treat this as an enhancement task:
+- Preserve user-authored fields: metadata.labels, metadata.annotations, env vars, envFrom, volumes, volumeMounts, ConfigMap/Secret references, custom probes, serviceAccountName, nodeSelector, tolerations, affinity, replicas.
+- Improve only: missing securityContext, missing resources, missing health probes when a port exists, outdated apiVersion, placeholder image references (replace with the provided Image Repository), missing labels required by AKS best practices.
+- Return a <content> block for EACH existing manifest you modify, using the SAME filename as the existing file. Add new manifests (e.g. service.yaml) only if clearly missing for the application type.
+- Do NOT delete existing manifests.
+
 IMPORTANT: Generate EACH manifest file separately with its own <content filename="FILENAME"></content> markers.
 Do not include any explanations, markdown code fences, or text outside the content markers.
 
@@ -72,7 +86,15 @@ kind: Service
 # ... rest of service
 </content>`;
 
-export function buildDockerfileUserPrompt(plan: DockerfilePlan): string {
+export interface DockerfileEnhancementOverride {
+    content: string;
+    sourcePath?: string;
+}
+
+export function buildDockerfileUserPrompt(
+    plan: DockerfilePlan,
+    enhancementOverride?: DockerfileEnhancementOverride,
+): string {
     const repoInfo = plan.repositoryInfo;
     const formattedPlan = formatGenerateDockerfileResult(plan);
 
@@ -134,10 +156,18 @@ Repository Info:
     if (plan.existingDockerfile) {
         const guidance = plan.existingDockerfile.guidance;
         prompt += `\n\nExisting Dockerfile to enhance:\n${plan.existingDockerfile.content}\n\nEnhancement guidance:\n- Preserve: ${guidance.preserve.join(", ")}\n- Improve: ${guidance.improve.join(", ")}\n- Add missing: ${guidance.addMissing.join(", ")}`;
+    } else if (enhancementOverride) {
+        const sourceHint = enhancementOverride.sourcePath ? ` (from ${enhancementOverride.sourcePath})` : "";
+        prompt += `\n\nExisting Dockerfile to enhance${sourceHint}:\n${enhancementOverride.content}\n\nEnhancement guidance:\n- Preserve: base image family, build stages, custom RUN/COPY/ENV/ARG/LABEL directives, entrypoint, exposed ports.\n- Improve: pin image tags if floating, add non-root USER if missing, add HEALTHCHECK if missing, ensure multi-stage build for compiled languages, reorder COPY for better layer caching.\n- Add missing: .dockerignore-friendly COPY order, security best practices, build-time arg defaults.`;
     }
 
     prompt += "\n\nGenerate the complete Dockerfile now. Remember to wrap the output in <content></content> markers:";
     return prompt;
+}
+
+export interface ExistingManifest {
+    filename: string;
+    content: string;
 }
 
 export function buildK8sManifestUserPrompt(
@@ -145,6 +175,7 @@ export function buildK8sManifestUserPrompt(
     appName: string,
     namespace: string,
     imageRepository?: string,
+    existingManifests?: ExistingManifest[],
 ): string {
     const repoInfo = plan.repositoryInfo;
     const formattedPlan = formatGenerateK8sManifestsResult(plan);
@@ -162,6 +193,8 @@ export function buildK8sManifestUserPrompt(
         ? `- Image Repository: ${imageRepository} (use this EXACT full URL as the container image — including the registry hostname — no bare names, no placeholders)`
         : undefined;
 
+    const existingBlock = buildExistingManifestsBlock(existingManifests);
+
     return `Generate Kubernetes manifests based on the following analysis and recommendations:
 
 ${formattedPlan}
@@ -176,9 +209,26 @@ Application Details:
 - Dependencies: ${dependencyNames.join(", ") || "none"}
 ${imageLine ? `${imageLine}` : ""}
 ${manifestGuidance}
-${buildK8sVerificationHints(ports, repoInfo?.entryPoint)}
+${buildK8sVerificationHints(ports, repoInfo?.entryPoint)}${existingBlock}
 Generate ONLY the manifests that are appropriate for this application.
 Each manifest should be in a separate <content filename="..."></content> block:`;
+}
+
+function buildExistingManifestsBlock(existing?: ExistingManifest[]): string {
+    if (!existing || existing.length === 0) {
+        return "";
+    }
+
+    const formatted = existing.map((m) => `\n=== ${m.filename} ===\n${m.content}`).join("\n");
+
+    return (
+        `\n\nExisting Kubernetes manifests to enhance (return each one in a <content filename="..."> block using the SAME filename):` +
+        `${formatted}` +
+        `\n\nEnhancement guidance:\n` +
+        `- Preserve: metadata.labels, metadata.annotations, env, envFrom, volumes, volumeMounts, ConfigMap/Secret references, custom probes, serviceAccountName, nodeSelector, tolerations, affinity, replicas.\n` +
+        `- Improve: missing securityContext, missing resources block, missing health probes (when a port is exposed), outdated apiVersion, placeholder image references (replace with the Image Repository above).\n` +
+        `- Do NOT delete existing manifests. Only ADD a new manifest (e.g. service.yaml) if it is clearly required for the application type and is missing from the list above.`
+    );
 }
 
 function buildManifestGuidance(isWebApp: boolean, hasExternalDependencies: boolean, ports: number[]): string {

--- a/src/commands/aksContainerAssist/types.ts
+++ b/src/commands/aksContainerAssist/types.ts
@@ -41,7 +41,8 @@ export interface AnalyzeRepositoryResult {
 export interface ExistingFilesCheckResult {
     hasDockerfile: boolean;
     hasK8sManifests: boolean;
-    dockerfilePath?: string;
+    /** Absolute paths to all detected Dockerfiles, sorted shallowest-first. */
+    dockerfilePaths?: string[];
     k8sManifestPaths?: string[];
 }
 

--- a/src/commands/aksKickstart/registerKickstartCommands.ts
+++ b/src/commands/aksKickstart/registerKickstartCommands.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { CommandCallback } from "@microsoft/vscode-azext-utils";
 import { aksKickstart } from "./kickstart";
 import { buildAndPush } from "./buildAndPush";
-import { useWorkspace, useSample } from "./repoSource";
+import { useWorkspace, useSample, KICKSTART_TEMP_ROOT } from "./repoSource";
 import { KickstartPanel } from "../../panels/KickstartPanel";
 
 type RegisterCommand = (command: string, callback: CommandCallback) => void;
@@ -48,9 +48,22 @@ export function registerKickstartCommands(
     });
 
     registerCommandWithTelemetry("aks.kickstart.useSample", async () => {
-        const result = await useSample(new vscode.CancellationTokenSource().token);
+        // In vscode.dev/azure the workspace already has a folder (azure-XXX on Cloud Shell).
+        // Clone the sample into that folder so it lands on the Cloud Shell filesystem.
+        // On desktop with no open workspace, fall back to the temp root and then add
+        // the cloned folder as a workspace folder so the handler can proceed.
+        const existingFolders = vscode.workspace.workspaceFolders;
+        const parentPath =
+            existingFolders && existingFolders.length > 0 ? existingFolders[0].uri.fsPath : KICKSTART_TEMP_ROOT;
+
+        const result = await useSample(new vscode.CancellationTokenSource().token, parentPath);
         if (result.succeeded) {
             context.globalState.update("kickstart.pendingSamplePath", result.result);
+            // If there was no open workspace, add the cloned folder so the extension
+            // has a workspace root and the handler can pick up pendingSamplePath.
+            if (!existingFolders || existingFolders.length === 0) {
+                vscode.workspace.updateWorkspaceFolders(0, 0, { uri: vscode.Uri.file(result.result) });
+            }
             await openChat("@kickstart /start");
         } else if (result.error !== "Cancelled.") {
             vscode.window.showErrorMessage(result.error);

--- a/src/commands/aksKickstart/repoSource.ts
+++ b/src/commands/aksKickstart/repoSource.ts
@@ -25,7 +25,10 @@ export async function useWorkspace(): Promise<Errorable<string>> {
 
 export const KICKSTART_TEMP_ROOT = path.join(os.tmpdir(), "kickstart-samples");
 
-export async function useSample(token: vscode.CancellationToken): Promise<Errorable<string>> {
+export async function useSample(
+    token: vscode.CancellationToken,
+    parentPath: string = KICKSTART_TEMP_ROOT,
+): Promise<Errorable<string>> {
     const picked = await vscode.window.showQuickPick(
         KICKSTART_SAMPLE_REPOS.map((r) => ({
             label: r.label,
@@ -49,12 +52,12 @@ export async function useSample(token: vscode.CancellationToken): Promise<Errora
             ?.replace(/\.git$/, "") ?? "sample";
 
     try {
-        await vscode.workspace.fs.createDirectory(vscode.Uri.file(KICKSTART_TEMP_ROOT));
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(parentPath));
     } catch {
         // directory already exists — safe to ignore
     }
 
-    const cloneResult = await cloneSample(picked.url, KICKSTART_TEMP_ROOT, repoName, token);
+    const cloneResult = await cloneSample(picked.url, parentPath, repoName, token);
     if (!cloneResult.succeeded) {
         return cloneResult;
     }

--- a/src/tests/suite/containerAssist/containerAssistService.test.ts
+++ b/src/tests/suite/containerAssist/containerAssistService.test.ts
@@ -143,7 +143,7 @@ describe("ContainerAssistService", () => {
             sandbox.stub(service, "checkExistingFiles").resolves({
                 hasDockerfile: true,
                 hasK8sManifests: true,
-                dockerfilePath: "/test/path/Dockerfile",
+                dockerfilePaths: ["/test/path/Dockerfile"],
                 k8sManifestPaths: ["/test/path/k8s/deployment.yaml"],
             });
             const infoStub = sandbox.stub(vscode.window, "showInformationMessage");
@@ -161,7 +161,7 @@ describe("ContainerAssistService", () => {
             sandbox.stub(service, "checkExistingFiles").resolves({
                 hasDockerfile: true,
                 hasK8sManifests: false,
-                dockerfilePath: "/test/path/Dockerfile",
+                dockerfilePaths: ["/test/path/Dockerfile"],
             });
             const infoStub = sandbox.stub(vscode.window, "showInformationMessage");
             const mockModel = {


### PR DESCRIPTION
fix(kickstart): correct run_in_terminal tool invocation — was calling "runInTerminal" with {command, cwd}; the real tool is "run_in_terminal" with {command, explanation, goal, mode} (no cwd). Probe vscode.lm.tools first and prepend cd <cwd> && to the command.

feat(kickstart): clone sample repos into existing workspace folder — in vscode.dev / Cloud Shell, samples must land on the Cloud-Shell-backed folder, not os.tmpdir(). useSample() now takes an optional parentPath and the command passes the open workspace folder when one exists.

feat(kickstart): support monorepos with per-module Dockerfile and k8s manifests

Stage per-module at <moduleRel>/Dockerfile and <moduleRel>/k8s/<file> via a new moduleStagePrefix() helper; single-module projects keep the flat layout.
ExistingFilesCheckResult.dockerfilePaths: string[] (was a single path); AnalysisData carries existing Dockerfile / manifest paths.
Build phase: one target per Dockerfile with sanitized image names, workspace as build context, --file for staged Dockerfiles, --subscription on az acr calls.
Deploy phase: collects every <module>/k8s/ dir and applies them all with multiple -f flags in one kubectl apply.
Generic buildNestedFileTree() for chat file-tree rendering of nested paths.
Resolve modulePath to absolute before SDK calls. Tests updated.
feat(kickstart): enhance existing Dockerfiles and k8s manifests instead of overwriting

prepare.ts reads existing files into Map<modulePath, …> via longest-prefix match (pickModuleForRelDir) so each module only sees its own.
Streams a "🔄 Enhancing N existing …" message when applicable.
System prompts gain an ENHANCEMENT MODE section: preserve base image family, custom RUN/COPY/ENV, metadata, env vars, volumes, probes; improve only missing best practices (multi-stage, non-root, HEALTHCHECK, securityContext, resources, image refs); return the COMPLETE artifact, not a diff.
buildDockerfileUserPrompt / buildK8sManifestUserPrompt accept the existing artifacts and append them as guidance.