### PR TITLE
feat: add "Ask @azure" context menu action for AKS clusters (#2183)

### DIFF
--- a/package.json
+++ b/package.json
@@ -485,12 +485,21 @@
                 "command": "aks.switchToStructuredMenu",
                 "title": "%Switch to Grouped Menu%",
                 "category": "AKS"
+            },
+            {
+                "command": "aks.askAzureCopilot",
+                "title": "%Ask @azure%",
+                "category": "AKS"
             }
         ],
         "menus": {
             "commandPalette": [
                 {
                     "command": "aks.refreshSubscription",
+                    "when": "never"
+                },
+                {
+                    "command": "aks.askAzureCopilot",
                     "when": "never"
                 },
                 {
@@ -602,6 +611,11 @@
                     "command": "aks.quickActions",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && config.aks.simplifiedMenuStructure",
                     "group": "6@1"
+                },
+                {
+                    "command": "aks.askAzureCopilot",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /aks\\.cluster/i && github.copilot-chat.activated",
+                    "group": "6@2"
                 },
                 {
                     "command": "aks.switchToClassicMenu",

--- a/package.nls.json
+++ b/package.nls.json
@@ -82,5 +82,6 @@
   "AKS: Apply Argo CD Application to Cluster": "AKS: Apply Argo CD Application to Cluster",
   "AKS: Argo CD Post-Deploy Actions": "AKS: Argo CD Post-Deploy Actions",
   "Take me back to Classic Menu": "Take me back to Classic Menu",
-  "Switch to Grouped Menu": "Switch to Grouped Menu"
+  "Switch to Grouped Menu": "Switch to Grouped Menu",
+  "Ask @azure": "Ask @azure"
 }

--- a/src/commands/aksAskAzureCopilot/aksAskAzureCopilot.ts
+++ b/src/commands/aksAskAzureCopilot/aksAskAzureCopilot.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { getAksClusterTreeNode } from "../utils/clusters";
+import { failed } from "../utils/errorable";
+
+export default async function aksAskAzureCopilot(_context: IActionContext, target: unknown): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const clusterNode = getAksClusterTreeNode(target, cloudExplorer);
+    if (failed(clusterNode)) {
+        vscode.window.showErrorMessage(clusterNode.error);
+        return;
+    }
+
+    const { name, armId } = clusterNode.result;
+    const query = `@azure I'd like to talk about my ${name} Azure Kubernetes Service cluster (resource ID: ${armId}).`;
+
+    await vscode.commands.executeCommand("workbench.action.chat.open", { query });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,7 @@ import {
 } from "./commands/aksContainerAssist/aksContainerAssist";
 import { migrateAndModernizeApp } from "./commands/aksContainerAssist/appModernizationBridge";
 import { switchToClassicMenu, switchToStructuredMenu } from "./commands/menuToggle/menuToggle";
+import aksAskAzureCopilot from "./commands/aksAskAzureCopilot/aksAskAzureCopilot";
 import { draftArgoCDDeployment } from "./commands/aksArgoCD/argoCDDeployment";
 import { argoCDCheckStatus } from "./commands/aksArgoCD/argoCDInstall";
 import { argoCDApplyApp, argoCDPostApplyActions, isArgoCDApplication } from "./commands/aksArgoCD/argoCDApplyApp";
@@ -190,6 +191,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerCommandWithTelemetry("aks.argoCDPostApplyActions", argoCDPostApplyActions);
         registerCommandWithTelemetry("aks.switchToClassicMenu", switchToClassicMenu);
         registerCommandWithTelemetry("aks.switchToStructuredMenu", switchToStructuredMenu);
+        registerCommandWithTelemetry("aks.askAzureCopilot", aksAskAzureCopilot);
 
         // Notify when an Argo CD Application YAML is opened in the editor.
         context.subscriptions.push(

--- a/src/tree/aksClusterTreeItem.ts
+++ b/src/tree/aksClusterTreeItem.ts
@@ -45,7 +45,7 @@ class AksClusterTreeItem extends AzExtTreeItem implements AksClusterTreeNode {
         } else {
             this.subscriptionTreeNode = parent.subscriptionTreeNode;
         }
-        this.id = `${this.clusterResource.name} ${clusterResource.resourceGroup}`;
+        this.id = this.clusterResource.id;
         this.armId = this.clusterResource.id;
         this.resourceGroupName = clusterResource.resourceGroup;
         this.name = this.clusterResource.name;


### PR DESCRIPTION
## Add "Ask @azure" context menu action for AKS clusters

Fixes #2183

### Summary

Adds a new **"Ask @azure"** context menu item to AKS clusters in the Cloud Explorer tree view. When clicked, it opens GitHub Copilot Chat with a pre-populated query containing the cluster name and ARM resource ID, targeting the `@azure` chat participant.

### Changes

- **New command** `aks.askAzureCopilot` — resolves the selected cluster node and opens Copilot Chat via `workbench.action.chat.open`
- **Menu visibility** — item only appears when `github.copilot-chat.activated` is true
- **Tree item ID fix** — uses ARM resource ID (`clusterResource.id`) instead of `name + resourceGroup` for consistency

### Files Changed

| File | Change |
|------|--------|
| package.json | Command + menu contribution registration |
| package.nls.json | Localization string |
| extension.ts | Command registration |
| aksAskAzureCopilot.ts | Command implementation (new) |
| aksClusterTreeItem.ts | Tree item ID fix |

### Testing

1. Install the extension with GitHub Copilot Chat active
2. Right-click an AKS cluster in Cloud Explorer
3. Verify "Ask @azure" appears in the context menu
4. Click it — Copilot Chat opens with: `@azure I'd like to talk about my <cluster-name> Azure Kubernetes Service cluster (resource ID: <arm-id>).`