### PR TITLE
fix: rename 'Take me back to Classic Menu' command to 'Switch to Classic Menu'

### DIFF
--- a/docs/book/src/features/simplified-menu-structure.md
+++ b/docs/book/src/features/simplified-menu-structure.md
@@ -12,7 +12,7 @@ The AKS extension uses a role-based cluster context menu organization as the def
 
 Default value: `true`
 
-After changing this setting, reload the VS Code window. You can also switch modes via the commands **AKS: Take me back to Classic Menu** and **AKS: Switch to Grouped Menu** without editing settings directly.
+After changing this setting, reload the VS Code window. You can also switch modes via the commands **AKS: Switch to Classic Menu** and **AKS: Switch to Grouped Menu** without editing settings directly.
 
 ## What changes when enabled
 
@@ -50,14 +50,14 @@ Two commands let you switch menu modes without opening Settings:
 
 | Command | Effect |
 |---------|--------|
-| **AKS: Take me back to Classic Menu** | Sets `aks.simplifiedMenuStructure` to `false` and prompts to reload. |
+| **AKS: Switch to Classic Menu** | Sets `aks.simplifiedMenuStructure` to `false` and prompts to reload. |
 | **AKS: Switch to Grouped Menu** | Sets `aks.simplifiedMenuStructure` to `true` and prompts to reload. |
 
 Both commands are available in:
 
 - The **Command Palette** (`Cmd+Shift+P` / `Ctrl+Shift+P`).
 - The **AKS cluster context menu** (right-click on a cluster in the Azure/Kubernetes Cloud Explorer).  
-  Only the applicable command is shown — if the grouped menu is active you see "Take me back to Classic Menu", and vice versa.
+  Only the applicable command is shown — if the grouped menu is active you see "Switch to Classic Menu", and vice versa.
 
 After running either command, VS Code prompts you to reload the window. The new menu layout takes effect after the reload.
 

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
                 "aks.simplifiedMenuStructure": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Use the grouped AKS menu (Develop & Deploy, Troubleshoot & Diagnose, Manage Cluster). When disabled, the classic menu layout is shown. Requires reload after changing. You can also toggle this via the commands 'AKS: Take me back to Classic Menu' and 'AKS: Switch to Grouped Menu'."
+                    "description": "Use the grouped AKS menu (Develop & Deploy, Troubleshoot & Diagnose, Manage Cluster). When disabled, the classic menu layout is shown. Requires reload after changing. You can also toggle this via the commands 'AKS: Switch to Classic Menu' and 'AKS: Switch to Grouped Menu'."
                 },
                 "aks.argoCDEnabled": {
                     "type": "boolean",
@@ -478,7 +478,7 @@
             },
             {
                 "command": "aks.switchToClassicMenu",
-                "title": "%Take me back to Classic Menu%",
+                "title": "%Switch to Classic Menu%",
                 "category": "AKS"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -81,6 +81,6 @@
   "AKS: Check Argo CD Status": "AKS: Check Argo CD Status",
   "AKS: Apply Argo CD Application to Cluster": "AKS: Apply Argo CD Application to Cluster",
   "AKS: Argo CD Post-Deploy Actions": "AKS: Argo CD Post-Deploy Actions",
-  "Take me back to Classic Menu": "Take me back to Classic Menu",
+  "Switch to Classic Menu": "Switch to Classic Menu",
   "Switch to Grouped Menu": "Switch to Grouped Menu"
 }

--- a/src/commands/menuToggle/menuToggle.ts
+++ b/src/commands/menuToggle/menuToggle.ts
@@ -39,7 +39,7 @@ export async function switchToStructuredMenu(_context: IActionContext, _target?:
     await setSimplifiedMenuStructure(true);
     await promptReload(
         l10n.t(
-            "Grouped AKS menu enabled. Reload the window for the change to take effect. You can switch back at any time with 'Take me back to Classic Menu'.",
+            "Grouped AKS menu enabled. Reload the window for the change to take effect. You can switch back at any time with 'Switch to Classic Menu'.",
         ),
     );
 }


### PR DESCRIPTION
## Summary

Renames the user-facing command title from **"Take me back to Classic Menu"** to **"Switch to Classic Menu"** for consistency with its sibling **"Switch to Grouped Menu"**.

The internal command id (`aks.switchToClassicMenu`) and exported function name (`switchToClassicMenu`) were already correct, so no API/contract changes are introduced.

## Changes

- [package.json](https://github.com/Azure/vscode-aks-tools/blob/main/package.json) — updated command `title` and the `aks.simplifiedMenuStructure` setting description
- [package.nls.json](https://github.com/Azure/vscode-aks-tools/blob/main/package.nls.json) — renamed localization key
- [src/commands/menuToggle/menuToggle.ts](https://github.com/Azure/vscode-aks-tools/blob/main/src/commands/menuToggle/menuToggle.ts) — updated the reload prompt text shown after enabling the grouped menu
- [docs/book/src/features/simplified-menu-structure.md](https://github.com/Azure/vscode-aks-tools/blob/main/docs/book/src/features/simplified-menu-structure.md) — updated 3 doc references

## Testing

- Verified no remaining occurrences of "Take me back" in the repo
- TypeScript compile clean (no errors in changed files)