### PR TITLE
fix(container-assist): consolidate shared-manifest deploy jobs (#2163)

### DIFF
--- a/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
@@ -6,7 +6,6 @@
         runs-on: ubuntu-latest
         needs: [build]
         env:
-            CONTAINER_NAME: { { CONTAINERNAME } }
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
             - uses: actions/checkout@v4
@@ -44,7 +43,7 @@
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}
                   images: |
-                      ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+{ { IMAGES } }
                   namespace: ${{ env.NAMESPACE }}
 
             - name: Annotate namespace

--- a/resources/yaml/workflow-multi-deploy-job.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job.template.yaml
@@ -6,7 +6,6 @@
         runs-on: ubuntu-latest
         needs: [build]
         env:
-            CONTAINER_NAME: { { CONTAINERNAME } }
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
             - uses: actions/checkout@v4
@@ -37,7 +36,7 @@
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}
                   images: |
-                      ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+{ { IMAGES } }
                   namespace: ${{ env.NAMESPACE }}
 
             - name: Annotate deployment

--- a/src/commands/aksContainerAssist/workflowTemplate.ts
+++ b/src/commands/aksContainerAssist/workflowTemplate.ts
@@ -302,25 +302,35 @@ function renderMatrixInclude(containers: ContainerJobConfig[]): string {
 }
 
 /**
- * Renders a per-container deploy job fragment by loading the appropriate
- * template file and performing placeholder substitution.
+ * Renders a deploy job fragment. When multiple containers share a manifest, a
+ * single consolidated deploy job lists every image so that k8s-deploy substitutes
+ * them all in one pass — preventing concurrent per-container jobs from racing
+ * each other and reverting prior image substitutions.
  */
-function renderDeployJob(jobId: string, container: ContainerJobConfig, isManagedNamespace: boolean): string {
+function renderDeployJob(
+    jobId: string,
+    containers: ContainerJobConfig[],
+    manifestPath: string,
+    isManagedNamespace: boolean,
+): string {
     const templateName = isManagedNamespace ? "workflow-multi-deploy-job-managed-ns" : "workflow-multi-deploy-job";
     let template = loadMultiTemplate(templateName);
 
-    // The block scalar produced by formatManifestPathForYamlBlock is indented for
-    // the top-level (4-space) env block used by the single-container template;
-    // here the key sits at 12 spaces, so re-indent the content lines to 16
-    // spaces to keep the YAML valid for multi-manifest configs.
-    const rawManifestPath = container.deploymentManifestPath ?? "";
-    const manifestPath = reindentBlockScalar(rawManifestPath, 16);
-    const imageName = sanitizeImageName(container.containerName);
+    // Image refs align under `images: |` at 22 spaces.
+    const indent = " ".repeat(22);
+    const images = containers
+        .map(
+            (c) =>
+                `${indent}\${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${sanitizeImageName(c.containerName)}:\${{ github.sha }}`,
+        )
+        .join("\n");
 
     const replacements: Record<string, string> = {
         "{ { DEPLOY_JOB_ID } }": `deploy-${jobId}`,
-        "{ { CONTAINERNAME } }": imageName,
-        "{ { DEPLOYMENTMANIFESTPATH } }": manifestPath,
+        // Manifest block scalars come pre-indented for the single-container template;
+        // re-indent to 16 spaces for the multi-container deploy env block.
+        "{ { DEPLOYMENTMANIFESTPATH } }": reindentBlockScalar(manifestPath, 16),
+        "{ { IMAGES } }": images,
     };
 
     for (const [placeholder, value] of Object.entries(replacements)) {
@@ -361,14 +371,23 @@ export function renderMultiContainerWorkflowTemplate(config: MultiContainerWorkf
     const matrixInclude = renderMatrixInclude(config.containers);
     buildJob = buildJob.replace(/\{\s*\{\s*MATRIX_INCLUDE\s*\}\s*\}/g, matrixInclude);
 
-    // --- Deploy jobs (one per container with a manifest) ---
-    const deployJobs = config.containers
-        .filter((container) => container.deploymentManifestPath)
-        .map((container) => {
-            const jobId = sanitizeJobId(container.containerName);
-            return renderDeployJob(jobId, container, config.isManagedNamespace);
-        })
-        .join("\n");
+    // --- Deploy jobs (one per unique manifest path) ---
+    // Group containers by manifest so a shared manifest yields one consolidated
+    // deploy job; concurrent per-container deploys would race and revert each
+    // other's image substitutions.
+    const groups = new Map<string, ContainerJobConfig[]>();
+    for (const c of config.containers) {
+        if (!c.deploymentManifestPath) continue;
+        const list = groups.get(c.deploymentManifestPath) ?? [];
+        list.push(c);
+        groups.set(c.deploymentManifestPath, list);
+    }
+
+    let sharedCount = 0;
+    const deployJobs = Array.from(groups, ([manifestPath, containers]) => {
+        const jobId = containers.length === 1 ? sanitizeJobId(containers[0].containerName) : `shared-${++sharedCount}`;
+        return renderDeployJob(jobId, containers, manifestPath, config.isManagedNamespace);
+    }).join("\n");
 
     return `${header}${buildJob}\n${deployJobs}`;
 }

--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -383,8 +383,8 @@ describe("Multi-Container Workflow Template Tests", () => {
             assert.ok(yaml.includes("image: api"), "matrix should include api image");
             assert.ok(yaml.includes("build_context: frontend"), "matrix should include frontend build context");
             assert.ok(yaml.includes("build_context: api"), "matrix should include api build context");
-            assert.ok(yaml.includes("CONTAINER_NAME: frontend"), "deploy-frontend job should set CONTAINER_NAME");
-            assert.ok(yaml.includes("CONTAINER_NAME: api"), "deploy-api job should set CONTAINER_NAME");
+            assert.ok(yaml.includes(".azurecr.io/frontend:"), "deploy-frontend job should reference frontend image");
+            assert.ok(yaml.includes(".azurecr.io/api:"), "deploy-api job should reference api image");
         });
 
         it("does not contain unreplaced template placeholders", () => {
@@ -474,14 +474,16 @@ describe("Multi-Container Workflow Template Tests", () => {
                     `image must be OCI-safe (lowercase [a-z0-9._-]); got "${value}"`,
                 );
             }
-            // Check CONTAINER_NAME in deploy job
-            const containerNameLines = rendered.split("\n").filter((line) => line.includes("CONTAINER_NAME:"));
-            assert.ok(containerNameLines.length >= 1, "Should emit at least one CONTAINER_NAME line");
-            for (const line of containerNameLines) {
-                const value = line.split("CONTAINER_NAME:")[1].trim();
+            // Check image references in the deploy job's images block are OCI-safe.
+            // The build job uses a `${{ matrix.image }}` placeholder; only inspect the
+            // bare-name refs emitted into deploy jobs.
+            const deployImageRefRe = /\.azurecr\.io\/([a-zA-Z0-9._-]+):\$\{\{ github\.sha \}\}/g;
+            const deployImageRefs = Array.from(rendered.matchAll(deployImageRefRe), (m) => m[1]);
+            assert.ok(deployImageRefs.length >= 1, "Should emit at least one bare-name image ref in the deploy job");
+            for (const value of deployImageRefs) {
                 assert.ok(
                     /^[a-z0-9._-]+$/.test(value),
-                    `CONTAINER_NAME must be OCI-safe (lowercase [a-z0-9._-]); got "${value}"`,
+                    `deploy image ref must be OCI-safe (lowercase [a-z0-9._-]); got "${value}"`,
                 );
             }
         });
@@ -705,7 +707,7 @@ describe("Multi-Container Workflow Template Tests", () => {
             assert.ok(apiManifest!.includes("api/k8s/service.yaml"));
         });
 
-        it("shared manifest across all services produces correct per-job env (#2163)", () => {
+        it("shared manifest across all services consolidates into a single deploy job (#2163)", () => {
             const sharedManifest = "k8s/shared-deployment.yaml";
             const sharedConfig: MultiContainerWorkflowConfig = {
                 ...threeServiceConfig,
@@ -719,10 +721,226 @@ describe("Multi-Container Workflow Template Tests", () => {
                 jobs?: Record<string, { env?: Record<string, string> }>;
             };
 
-            // All deploy jobs should have the same manifest path
-            assert.strictEqual(parsed.jobs?.["deploy-web"]?.env?.DEPLOYMENT_MANIFEST_PATH, sharedManifest);
-            assert.strictEqual(parsed.jobs?.["deploy-api"]?.env?.DEPLOYMENT_MANIFEST_PATH, sharedManifest);
-            assert.strictEqual(parsed.jobs?.["deploy-worker"]?.env?.DEPLOYMENT_MANIFEST_PATH, sharedManifest);
+            // Per-container deploy jobs must NOT exist when a manifest is shared.
+            assert.ok(!parsed.jobs?.["deploy-web"], "deploy-web should not exist when manifest is shared");
+            assert.ok(!parsed.jobs?.["deploy-api"], "deploy-api should not exist when manifest is shared");
+            assert.ok(!parsed.jobs?.["deploy-worker"], "deploy-worker should not exist when manifest is shared");
+            // Exactly one consolidated deploy job that carries the shared manifest path.
+            assert.strictEqual(parsed.jobs?.["deploy-shared-1"]?.env?.DEPLOYMENT_MANIFEST_PATH, sharedManifest);
         });
+    });
+});
+
+describe("Multi-Container Shared-Manifest Deploy Consolidation", () => {
+    const base: Omit<MultiContainerWorkflowConfig, "containers"> = {
+        workflowName: "deploy-monorepo",
+        branchName: "main",
+        acrResourceGroup: "shared-rg",
+        azureContainerRegistry: "monoacr",
+        clusterName: "mono-cluster",
+        clusterResourceGroup: "mono-cluster-rg",
+        namespace: "apps",
+        isManagedNamespace: false,
+    };
+
+    it("emits a single deploy job when two containers share the same manifest", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+
+        // Matrix build job covers both containers; consolidated single deploy job.
+        assert.ok(rendered.includes("service: frontend"), "matrix build should include frontend");
+        assert.ok(rendered.includes("service: api"), "matrix build should include api");
+
+        // Exactly one deploy job; per-container deploy jobs must NOT exist for shared manifests.
+        assert.ok(!rendered.includes("deploy-frontend:"), "deploy-frontend should not exist (consolidated)");
+        assert.ok(!rendered.includes("deploy-api:"), "deploy-api should not exist (consolidated)");
+        const deployJobMatches = rendered.match(/^ {4}deploy-[A-Za-z0-9_-]+:$/gm) ?? [];
+        assert.strictEqual(deployJobMatches.length, 1, `Expected exactly one deploy job, got ${deployJobMatches}`);
+        assert.ok(rendered.includes("deploy-shared-1:"), "consolidated deploy job should be named deploy-shared-1");
+    });
+
+    it("the consolidated deploy job depends on the matrix build job", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+        assert.ok(
+            rendered.includes("needs: [build]"),
+            `Consolidated deploy job must depend on the matrix build job; got:\n${rendered}`,
+        );
+    });
+
+    it("the consolidated deploy job lists every container image in the k8s-deploy images block", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+        const parsed = yaml.load(rendered) as {
+            jobs: Record<string, { env?: Record<string, string>; steps: Array<{ with?: { images?: string } }> }>;
+        };
+        const deploy = parsed.jobs["deploy-shared-1"];
+        assert.ok(deploy, "deploy-shared-1 should be present in parsed YAML");
+        const deployStep = deploy.steps.find((s) => s.with?.images !== undefined);
+        assert.ok(deployStep && deployStep.with?.images, "Deploy step should set k8s-deploy images");
+        const images = deployStep.with!.images!;
+        assert.ok(
+            images.includes(".azurecr.io/frontend:${{ github.sha }}"),
+            `images should include frontend ref; got: ${images}`,
+        );
+        assert.ok(
+            images.includes(".azurecr.io/api:${{ github.sha }}"),
+            `images should include api ref; got: ${images}`,
+        );
+        // CONTAINER_NAME env must NOT be present on consolidated deploy jobs.
+        assert.ok(
+            !deploy.env || deploy.env.CONTAINER_NAME === undefined,
+            "Consolidated deploy job should not set CONTAINER_NAME env",
+        );
+    });
+
+    it("keeps distinct deploy jobs for containers with different manifests", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath: "frontend/k8s/dep.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath: "api/k8s/dep.yaml",
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+        assert.ok(rendered.includes("deploy-frontend:"));
+        assert.ok(rendered.includes("deploy-api:"));
+        assert.ok(!rendered.includes("deploy-shared-"), "Distinct manifests must not be consolidated");
+    });
+
+    it("supports mixed: a shared group + a distinct deploy + a build-only container", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath: "k8s/app.yaml",
+                },
+                {
+                    containerName: "billing",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "billing",
+                    deploymentManifestPath: "billing/k8s/dep.yaml",
+                },
+                {
+                    containerName: "worker",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "worker",
+                    // No manifest — build-only.
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+        const deployJobMatches = rendered.match(/^ {4}deploy-[A-Za-z0-9_-]+:$/gm) ?? [];
+        assert.strictEqual(
+            deployJobMatches.length,
+            2,
+            `Expected 2 deploy jobs (shared + billing), got ${deployJobMatches}`,
+        );
+        assert.ok(rendered.includes("deploy-shared-1:"), "shared deploy job present");
+        assert.ok(rendered.includes("deploy-billing:"), "distinct billing deploy job present");
+        assert.ok(rendered.includes("service: worker"), "worker is in matrix build");
+        assert.ok(!rendered.includes("deploy-worker:"), "worker has no deploy job (skipped)");
+    });
+
+    it("produces valid YAML when consolidating with a multi-manifest block scalar", () => {
+        const cfg: MultiContainerWorkflowConfig = {
+            ...base,
+            containers: [
+                {
+                    containerName: "frontend",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "frontend",
+                    deploymentManifestPath:
+                        "|\n        k8s/deployment.yaml\n        k8s/service.yaml\n        k8s/ingress.yaml",
+                },
+                {
+                    containerName: "api",
+                    dockerFile: "Dockerfile",
+                    buildContextPath: "api",
+                    deploymentManifestPath:
+                        "|\n        k8s/deployment.yaml\n        k8s/service.yaml\n        k8s/ingress.yaml",
+                },
+            ],
+        };
+        const rendered = renderMultiContainerWorkflowTemplate(cfg);
+        let parsed: unknown;
+        assert.doesNotThrow(() => {
+            parsed = yaml.load(rendered);
+        }, `Consolidated workflow must be valid YAML:\n${rendered}`);
+        const root = parsed as { jobs: Record<string, { env?: Record<string, string> }> };
+        const manifestEnv = root.jobs["deploy-shared-1"]?.env?.DEPLOYMENT_MANIFEST_PATH;
+        assert.ok(
+            typeof manifestEnv === "string" && manifestEnv.includes("k8s/deployment.yaml"),
+            "Consolidated deploy job should carry the shared multi-manifest list",
+        );
+        assert.ok(manifestEnv!.includes("k8s/service.yaml"));
+        assert.ok(manifestEnv!.includes("k8s/ingress.yaml"));
     });
 });


### PR DESCRIPTION
## What

When multiple containers in a multi-container workflow share a single Kubernetes manifest, the generator previously emitted one `deploy-<container>` job per container. The concurrent jobs each ran `Azure/k8s-deploy@v5` against the same manifest with only their own image substitution, so later jobs reverted earlier jobs' image swaps.

This change groups containers by their `deploymentManifestPath` and emits **one consolidated deploy job per unique manifest**, listing every contributing image in the `k8s-deploy` `images:` block so all substitutions happen in a single pass.

## Changes

- **`workflowTemplate.ts`** — `renderDeployJob` now accepts `(jobId, containers[], manifestPath, isManagedNamespace)`; `renderMultiContainerWorkflowTemplate` groups by manifest into a `Map` and names shared groups `deploy-shared-N`.
- **`workflow-multi-deploy-job.template.yaml` / `…-managed-ns.template.yaml`** — drop `CONTAINER_NAME` env, replace the single image line with a `{ { IMAGES } }` placeholder the renderer expands.
- **Tests** — cover shared, distinct, and mixed manifest scenarios; update upstream assertions that depended on the per-container `CONTAINER_NAME` env.

## Behavior preserved

- Single-container workflows: unchanged.
- Multi-container workflows where each container has a distinct manifest: still one `deploy-<container>` job per container.
- Containers without a manifest: still build-only (no deploy job).
- Matrix build job (introduced in #2169): unchanged.

## Related

Fixes the race condition surfaced by #2163 and the "Apply to all remaining services" UX added in #2169 (the UX path produces identical manifest strings, which now collapse into one deploy job).

## Testing

`npm run test` — 204 passing locally. The one pre-existing `Webview Styles` 2 s timeout flake is unaffected by this branch.