### PR TITLE
feat: enable Container Assist by default and document for 2.1.0 behavior

### DIFF
--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -33,6 +33,7 @@ Azure Kubernetes Service (AKS) Extension for Visual Studio Code helps enable AKS
 
 ## Development and Release
 
+* [What's New in 2.1.0](./release/whats-new-2.1.0.md)
 * [What's New in 1.7.0](./release/whats-new-1.7.0.md)
 * [How to release](./release/releasing.md)
 * [Development](./development/development.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -37,6 +37,7 @@
   - [Argo CD GitOps Integration](./features/argocd-gitops-integration.md)
 
 - [Release](./release.md)
+  - [What's New in 2.1.0](./release/whats-new-2.1.0.md)
   - [What's New in 1.7.0](./release/whats-new-1.7.0.md)
   - [Releasing Information](./release/releasing.md)
 - [Contributing](./contributing.md)

--- a/docs/book/src/features/container-assist-integration.md
+++ b/docs/book/src/features/container-assist-integration.md
@@ -9,7 +9,7 @@
 > **Technology Note**
 > This experience is built on [Azure/containerization-assist](https://github.com/Azure/containerization-assist), which combines AI generation with a specialized containerization toolchain and knowledge/policy guidance for Docker and Kubernetes workflows.
 
-Container Assist is a feature-flagged workflow in the AKS VS Code extension that helps generate deployment assets for AKS directly from your project.
+Container Assist is a preview workflow in the AKS VS Code extension that helps generate deployment assets for AKS directly from your project.
 
 ## Detailed documentation
 
@@ -120,7 +120,9 @@ If your project type is not in the list above, the SDK classifies it as `other` 
 
 ## Feature flag
 
-Enable this preview feature in VS Code settings:
+From `2.1.0`, this preview feature is enabled by default.
+
+You can still explicitly control it in VS Code settings:
 
 ```json
 {
@@ -128,7 +130,7 @@ Enable this preview feature in VS Code settings:
 }
 ```
 
-Default value: `false`
+Default value: `true`
 
 This can also be enabled from the VS Code Settings UI.
 
@@ -143,7 +145,7 @@ Container Assist can be launched from:
 
 The AKS cluster context menu entry is shown when:
 
-- `aks.containerAssistEnabledPreview` is `true`
+- `aks.containerAssistEnabledPreview` is `true` (default in `2.1.0`)
 - At least one workspace folder is open
 
 ## User flow and options
@@ -196,7 +198,7 @@ This supports a full path from local generation to reviewable GitHub PR with min
 ## Configuration reference
 
 `aks.containerAssistEnabledPreview`
-: Enable/disable the Container Assist preview entry points.
+: Enable/disable the Container Assist preview entry points. Default: `true`.
 
 `aks.containerAssist.k8sManifestFolder`
 : Folder name for generated Kubernetes manifests. Default: `k8s`.

--- a/docs/book/src/features/features.md
+++ b/docs/book/src/features/features.md
@@ -4,7 +4,7 @@ Once you successfully log in with your Azure Account, you can view all AKS clust
 
 ## Release spotlight
 
-This release adds two feature-flagged experiences:
+This release adds two configurable experiences:
 
 - [Container Assist Integration (Preview)](./container-assist-integration.md)
 - [Simplified AKS Menu Structure (Feature Flag)](./simplified-menu-structure.md)
@@ -17,6 +17,8 @@ These can be enabled independently:
 	"aks.simplifiedMenuStructure": true
 }
 ```
+
+From `2.1.0`, `aks.containerAssistEnabledPreview` is enabled by default.
 
 Container Assist release screenshots:
 

--- a/docs/book/src/features/simplified-menu-structure.md
+++ b/docs/book/src/features/simplified-menu-structure.md
@@ -40,7 +40,7 @@ Direct commands `Show In Azure Portal` and `Show Properties` remain available.
 When both feature flags are enabled:
 
 - `aks.simplifiedMenuStructure = true`
-- `aks.containerAssistEnabledPreview = true`
+- `aks.containerAssistEnabledPreview = true` (default in `2.1.0`)
 
 and a workspace folder is open, `AKS: Run Container Assist (Preview)` appears under `Develop & Deploy`.
 

--- a/docs/book/src/release.md
+++ b/docs/book/src/release.md
@@ -3,4 +3,5 @@
 Use this section to track reader-facing changes by version and maintain release process guidance.
 
 - [What's New in 1.7.0](./release/whats-new-1.7.0.md)
+- [What's New in 2.1.0](./release/whats-new-2.1.0.md)
 - [Releasing Information](./release/releasing.md)

--- a/docs/book/src/release/whats-new-2.1.0.md
+++ b/docs/book/src/release/whats-new-2.1.0.md
@@ -1,0 +1,32 @@
+# What's New in 2.1.0
+
+Version `2.1.0` updates Container Assist preview behavior to be enabled by default.
+
+## Highlights
+
+- `aks.containerAssistEnabledPreview` now defaults to `true`.
+- Container Assist entry points are available out of the box when a workspace folder is open.
+- Users can still disable Container Assist via settings when needed.
+
+## Feature flag behavior
+
+```json
+{
+  "aks.containerAssistEnabledPreview": true
+}
+```
+
+Default in `2.1.0`: `true`
+
+To disable:
+
+```json
+{
+  "aks.containerAssistEnabledPreview": false
+}
+```
+
+## Related docs
+
+- [Container Assist Integration (Preview)](../features/container-assist-integration.md)
+- [Simplified AKS Menu Structure](../features/simplified-menu-structure.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,7 +1087,7 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -1106,7 +1106,7 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1136,7 +1136,7 @@
             "version": "0.23.5",
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
             "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^3.0.5",
@@ -1151,7 +1151,7 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -1167,7 +1167,7 @@
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
             "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.1"
@@ -1274,7 +1274,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
             "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1284,7 +1284,7 @@
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
             "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.1",
@@ -1359,7 +1359,7 @@
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1368,7 +1368,7 @@
             "version": "0.16.6",
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -1381,7 +1381,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -1394,7 +1394,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -1407,7 +1407,7 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
             "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -2832,14 +2832,14 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -3915,7 +3915,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3941,7 +3941,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "devOptional": true,
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3959,6 +3959,7 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5382,7 +5383,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -6209,7 +6210,7 @@
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
             "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
@@ -6265,7 +6266,7 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
@@ -6284,7 +6285,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6322,7 +6323,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6334,7 +6335,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -6347,7 +6348,7 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.16.0",
@@ -6365,7 +6366,7 @@
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
@@ -6425,7 +6426,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -6438,7 +6439,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6450,7 +6451,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -6459,7 +6460,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6712,13 +6713,14 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.1.2",
@@ -6826,7 +6828,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6879,7 +6881,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6904,7 +6906,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6917,7 +6919,7 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/foreground-child": {
@@ -7119,7 +7121,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -7447,7 +7449,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -7497,7 +7499,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -7609,7 +7611,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7626,7 +7628,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -7905,12 +7907,13 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/json-schema-typed": {
             "version": "8.0.2",
@@ -7922,7 +7925,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -8045,7 +8048,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8096,7 +8099,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8303,7 +8306,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -8934,7 +8937,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/nearley": {
             "version": "2.20.1",
@@ -9273,7 +9276,7 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9424,7 +9427,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -9439,7 +9442,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -9593,7 +9596,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9886,7 +9889,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -11938,7 +11941,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -12515,7 +12518,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12824,7 +12827,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
                 },
                 "aks.containerAssistEnabledPreview": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Set to true to enable deployment related file generation capability using AI tool. (Preview feature)"
                 },
                 "aks.containerAssist.k8sManifestFolder": {

--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -43,7 +43,7 @@ export class ContainerAssistService {
     async isAvailable(): Promise<Errorable<boolean>> {
         try {
             const config = vscode.workspace.getConfiguration("aks");
-            const isEnabled = config.get<boolean>("containerAssistEnabledPreview", false);
+            const isEnabled = config.get<boolean>("containerAssistEnabledPreview", true);
 
             if (!isEnabled) {
                 const errorMsg = l10n.t(


### PR DESCRIPTION
## Summary
This PR enables Container Assist by default and updates documentation for the 2.1.0 release messaging.

## What Changed

- Switched Container Assist feature flag default from off to on.
- Aligned runtime availability fallback behavior with the new default.
- Updated feature documentation to reflect default-enabled behavior in 2.1.0.
- Added a new “What’s New in 2.1.0” release notes page.
- Added links to the 2.1.0 release notes in docs navigation.

## Why

Container Assist should be available out of the box for users in 2.1.0, while still allowing teams to disable it via settings when needed.

## Validation

- Ran compile validation successfully using `npm run test-compile`.

## User Impact

- Container Assist is now visible/enabled by default (when normal visibility conditions like workspace context are met).
- Users who do not want it can explicitly set the flag to `false`.

## Release Note

- Container Assist preview is now enabled by default in 2.1.0. PR like here