### PR TITLE
Publish release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service",
     "description": "Display Azure Kubernetes Services within VS Code",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
## Release Note (2.1.0)

AKS Container Assist is now enabled by default in version 2.1.0.

### Highlights

- Enabled Container Assist by default (`aks.containerAssistEnabledPreview: true`).
- Updated runtime behavior to align with the new default-enabled experience.
- Refreshed documentation to reflect 2.1.0 default behavior and launch paths.
- Added a dedicated “What’s New in 2.1.0” release notes entry.

### User Impact

- Users get Container Assist out of the box without manual setup.
- Teams that want to opt out can still disable it in settings by setting:
  - `aks.containerAssistEnabledPreview: false`

### VSIX to test

- [vscode-aks-tools-2.1.0-test-latest.vsix.zip](https://github.com/user-attachments/files/28694270/vscode-aks-tools-2.1.0-test-latest.vsix.zip)

~~[vscode-aks-tools-2.1.0-test.vsix.zip](https://github.com/user-attachments/files/28608417/vscode-aks-tools-2.1.0-test.vsix.zip)~~

- ~~Will add here once #2204 is merged~~. 

### Breaking Changes

- None. This is a default behavior change only; feature can still be toggled off.