### PR TITLE
Enforce ESLint in CI pipeline

### DIFF
--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -79,6 +79,9 @@ extends:
               - script: npm run install:all
                 displayName: Install npm for project
 
+              - script: npm run lint:all
+                displayName: Run ESLint
+
               - script: npm run webpack
                 displayName: Run webpack
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
     - name: Build Extension
       run: |
         npm run install:all
+    - name: Lint
+      run: npm run lint:all
     - name: Smoke test (Linux)
       run: xvfb-run -a npm run test
       if: runner.os == 'Linux'

--- a/package.json
+++ b/package.json
@@ -1027,8 +1027,8 @@
     },
     "scripts": {
         "install:all": "npm install --legacy-peer-deps && cd webview-ui && npm install --legacy-peer-deps",
-        "lint:all": "eslint -c .eslintrc.js --ext .ts ./src && cd webview-ui && npm run lint",
-        "lint-fix:all": "eslint -c .eslintrc.js --ext .ts ./src --fix && cd webview-ui && npm run lint-fix",
+        "lint:all": "npx eslint . && cd webview-ui && npm run lint",
+        "lint-fix:all": "npx eslint . --fix && cd webview-ui && npm run lint-fix",
         "prettier-format": "prettier --config .prettierrc . --write",
         "dev:webview": "cd webview-ui && npm run dev",
         "build:webview": "cd webview-ui && npm run build",


### PR DESCRIPTION
This PR adds `npm run lint:all` to both CI workflows so lint errors are caught on PRs.

Changes:
- Add lint step to `.github/workflows/build.yml`
- Add lint step to `.github/workflows/1es-pipeline.yml`
- Fix `lint:all` and `lint-fix:all` scripts in `package.json` to use flat config: (`npx eslint .`) instead of deleted `.eslintrc.js` (Deleted in #2209 )

The current ESLint errors that exist are resolved in PR #2209 
- https://github.com/Azure/vscode-aks-tools/pull/2209

(Build for this PR will fail due to lint until changes from #2209 are merged)