### PR TITLE
feat(argo): enable Argo CD feature flag by default and update related docs

### DIFF
--- a/docs/book/src/features/argocd-gitops-integration.md
+++ b/docs/book/src/features/argocd-gitops-integration.md
@@ -9,15 +9,17 @@ The Argo CD integration brings a complete GitOps workflow to AKS clusters direct
 
 ## Feature Flag
 
-All Argo CD commands are gated behind a feature flag and **disabled by default**. To enable:
+All Argo CD commands are gated behind a feature flag and **enabled by default**.
+
+If you want to hide Argo CD commands, set:
 
 ```json
 {
-  "aks.argoCDEnabled": true
+   "aks.argoCDEnabled": false
 }
 ```
 
-Default value: `false`
+Default value: `true`
 
 After changing this setting, reload the VS Code window (`Developer: Reload Window`).
 

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
                 },
                 "aks.argoCDEnabled": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Enable Argo CD GitOps integration commands (Create Argo CD GitOps Pipeline, Apply Argo CD Application, Check Argo CD Status, Post-Deploy Actions). Requires reload after changing."
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // Notify when an Argo CD Application YAML is opened in the editor.
         context.subscriptions.push(
             vscode.workspace.onDidOpenTextDocument(async (document) => {
-                const argoCDEnabled = vscode.workspace.getConfiguration("aks").get<boolean>("argoCDEnabled", false);
+                const argoCDEnabled = vscode.workspace.getConfiguration("aks").get<boolean>("argoCDEnabled", true);
                 if (!argoCDEnabled) return;
                 if (document.languageId !== "yaml" && document.languageId !== "yml") return;
                 // Cheap substring pre-check to avoid parsing large YAML files unnecessarily.


### PR DESCRIPTION
## Summary

This PR enables the existing Argo CD feature flag by default so users can discover and use Argo CD GitOps commands out of the box, while still allowing opt-out via settings.

## Changes

1. Changed the default value of the Argo CD feature flag from false to true.
2. Updated activation-time config fallback to align with the new default.
3. Updated documentation to reflect the new behavior and how to disable the feature if needed.

## Why
Argo CD functionality was already feature-gated, but defaulting to disabled made it easy to miss. Enabling it by default improves discoverability and reduces setup friction, while preserving control for users who want to hide it.

## User Impact

- New default: Argo CD commands are visible/enabled by default.
- Users can disable them with:
  - aks.argoCDEnabled = false
- Reload is still required after changing the setting.

## Validation

1. Fresh install / default settings: Argo CD commands appear.
2. Set aks.argoCDEnabled to false and reload: Argo CD commands are hidden.
3. Re-enable and reload: commands return as expected.

## Risk

Low risk. Behavior is controlled by an existing feature flag and remains fully reversible through settings.