### PR TITLE
test(containerAssist): make LM-unavailable tests deterministic

### DIFF
--- a/src/tests/suite/containerAssist/containerAssistService.test.ts
+++ b/src/tests/suite/containerAssist/containerAssistService.test.ts
@@ -56,6 +56,7 @@ describe("ContainerAssistService", () => {
     describe("generateDockerfile", () => {
         it("returns error when LM not available", async function () {
             this.timeout(10_000);
+            sandbox.stub(vscode.lm, "selectChatModels").resolves([]);
             const moduleInfo: ModuleAnalysisResult = {
                 name: "test-module",
                 modulePath: "/test/path",
@@ -77,6 +78,7 @@ describe("ContainerAssistService", () => {
     describe("generateManifests", () => {
         it("returns error when LM not available", async function () {
             this.timeout(10_000);
+            sandbox.stub(vscode.lm, "selectChatModels").resolves([]);
             const moduleInfo: ModuleAnalysisResult = {
                 name: "test-module",
                 modulePath: "/test/path",


### PR DESCRIPTION
## Summary

Stub `vscode.lm.selectChatModels` to return `[]` in the two "returns error when LM not available" tests for `generateDockerfile` and `generateManifests`.

## Why

These tests previously relied on the test host having no chat model registered. When Copilot is installed in the test environment, real models are returned and the assertions fail because the code path under test isn't exercised. Explicitly stubbing the API makes the tests deterministic regardless of environment.

## Changes

- src/tests/suite/containerAssist/containerAssistService.test.ts: add `sandbox.stub(vscode.lm, "selectChatModels").resolves([])` to both LM-unavailable tests.