### PR TITLE
Add argoCDCheckStatus to classic menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -790,6 +790,11 @@
                     "command": "aks.draftWorkflow",
                     "group": "navigation",
                     "when": "workspaceFolderCount >= 1"
+                },
+                {
+                    "command": "aks.argoCDCheckStatus",
+                    "group": "navigation",
+                    "when": "config.aks.argoCDEnabled"
                 }
             ],
             "aks.networkTroubleshootingSubMenu": [


### PR DESCRIPTION
This PR adds `argoCDCheckStatus`. It's currently only accessible from a clusters context via the grouped menu variant, and is missing from the classic menu. 