### PR TITLE
Show signed-in user's GitHub repos in Kickstart launch panel

### DIFF
--- a/src/panels/KickstartGuidedSetupPanel.ts
+++ b/src/panels/KickstartGuidedSetupPanel.ts
@@ -1,6 +1,7 @@
 import { Uri, window } from "vscode";
 import * as vscode from "vscode";
 import * as l10n from "@vscode/l10n";
+import { Octokit } from "@octokit/rest";
 import { KICKSTART_SAMPLES, handoffToChat } from "../commands/aksKickstart/kickstartChat";
 import { MessageHandler } from "../webview-contract/messaging";
 import {
@@ -8,13 +9,15 @@ import {
     InitialState,
     ToVsCodeMsgDef,
 } from "../webview-contract/webviewDefinitions/kickstartGuidedSetup";
-import { TelemetryDefinition } from "../webview-contract/webviewTypes";
+import { TelemetryDefinition, ToWebviewMessageSink } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 
 export class KickstartGuidedSetupPanel extends BasePanel<"kickstartGuidedSetup"> {
     constructor(extensionUri: Uri) {
         super(extensionUri, "kickstartGuidedSetup", {
             errorNotification: null,
+            gitHubReposLoaded: null,
+            gitHubReposError: null,
         });
     }
 }
@@ -35,17 +38,70 @@ export class KickstartGuidedSetupDataProvider implements PanelDataProvider<"kick
     getTelemetryDefinition(): TelemetryDefinition<"kickstartGuidedSetup"> {
         return {
             finishRequest: true,
+            listGitHubReposRequest: true,
         };
     }
 
-    getMessageHandler(): MessageHandler<ToVsCodeMsgDef> {
+    getMessageHandler(webview: ToWebviewMessageSink<"kickstartGuidedSetup">): MessageHandler<ToVsCodeMsgDef> {
+        // Refresh the repo list automatically whenever the user signs in,
+        // signs out, or switches GitHub accounts in VS Code.
+        vscode.authentication.onDidChangeSessions((e) => {
+            if (e.provider.id === "github") {
+                void this.fetchRepos(webview);
+            }
+        });
+
         return {
             finishRequest: (args) => this.handleFinish(args),
+            listGitHubReposRequest: () => this.fetchRepos(webview),
         };
     }
 
     private async handleFinish(selections: GuidedSetupSelections) {
         await handoffToChat(selections);
         window.showInformationMessage(l10n.t("Continuing AKS Kickstart in the chat view."));
+    }
+
+    private async fetchRepos(webview: ToWebviewMessageSink<"kickstartGuidedSetup">) {
+        // Use whichever GitHub account is signed into VS Code. `createIfNone: false`
+        // means we never prompt — sign-in happens via the Accounts menu.
+        let session: vscode.AuthenticationSession | undefined;
+        try {
+            session = await vscode.authentication.getSession("github", ["repo"], { createIfNone: false });
+        } catch {
+            session = undefined;
+        }
+
+        if (!session) {
+            webview.postGitHubReposError({
+                message: l10n.t(
+                    "No GitHub account is signed in to VS Code. Sign in via the Accounts menu to see your repositories.",
+                ),
+            });
+            return;
+        }
+
+        try {
+            // type: "owner" restricts the list to repos owned by the signed-in user.
+            const octokit = new Octokit({ auth: session.accessToken });
+            const { data: apiRepos } = await octokit.rest.repos.listForAuthenticatedUser({
+                per_page: 100,
+                sort: "updated",
+                type: "owner",
+            });
+            webview.postGitHubReposLoaded({
+                repos: apiRepos.map((r) => ({
+                    fullName: r.full_name,
+                    description: r.description,
+                    cloneUrl: r.clone_url,
+                    private: r.private,
+                })),
+                signedInUser: session.account?.label ?? null,
+            });
+        } catch (e) {
+            webview.postGitHubReposError({
+                message: l10n.t("Failed to fetch GitHub repositories: {0}", String(e)),
+            });
+        }
     }
 }

--- a/src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts
+++ b/src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts
@@ -24,6 +24,13 @@ export interface GuidedSetupSelections {
     appSource: AppSource;
 }
 
+export interface GitHubRepo {
+    fullName: string;
+    description: string | null;
+    cloneUrl: string;
+    private: boolean;
+}
+
 export interface InitialState {
     samples: KickstartSample[];
     workspaceIsEmpty: boolean;
@@ -31,10 +38,13 @@ export interface InitialState {
 
 export type ToVsCodeMsgDef = {
     finishRequest: GuidedSetupSelections;
+    listGitHubReposRequest: void;
 };
 
 export type ToWebViewMsgDef = {
     errorNotification: { message: string };
+    gitHubReposLoaded: { repos: GitHubRepo[]; signedInUser: string | null };
+    gitHubReposError: { message: string };
 };
 
 export type KickstartGuidedSetupDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/webview-ui/src/KickstartGuidedSetup/GuidedSetupInput.tsx
+++ b/webview-ui/src/KickstartGuidedSetup/GuidedSetupInput.tsx
@@ -7,17 +7,20 @@ import {
     faLayerGroup,
     faRobot,
     faServer,
+    faSpinner,
     faTimesCircle,
+    faUser,
     faWandMagicSparkles,
     faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import * as l10n from "@vscode/l10n";
 import { MessageSink } from "../../../src/webview-contract/messaging";
 import {
     AppSource,
     AppSourceKind,
+    GitHubRepo,
     GuidedSetupSelections,
     KickstartSample,
     ProjectType,
@@ -35,6 +38,10 @@ interface GuidedSetupInputProps {
     samples: KickstartSample[];
     workspaceIsEmpty: boolean;
     errorMessage: string | null;
+    githubRepos: GitHubRepo[] | null;
+    githubReposLoading: boolean;
+    githubReposError: string | null;
+    githubSignedInUser: string | null;
     eventHandlers: EventHandlers<EventDef>;
     vscode: MessageSink<ToVsCodeMsgDef>;
 }
@@ -82,6 +89,22 @@ export function GuidedSetupInput(props: GuidedSetupInputProps) {
     const [projectIdea, setProjectIdea] = useState<string>("");
     const [sampleLabel, setSampleLabel] = useState<string>(props.samples[0]?.label ?? "");
     const [submitAttempted, setSubmitAttempted] = useState(false);
+
+    // Auto-load the user's GitHub repositories the first time they open the
+    // "Start from a GitHub repo" section. Uses whichever GitHub account is
+    // currently signed in to VS Code (no prompt, no account picker).
+    useEffect(() => {
+        if (
+            appSourceKind === "repo" &&
+            props.githubRepos === null &&
+            !props.githubReposLoading &&
+            props.githubReposError === null
+        ) {
+            props.eventHandlers.onSetGitHubReposLoading();
+            props.vscode.postListGitHubReposRequest();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [appSourceKind]);
 
     function buildAppSource(): AppSource | null {
         switch (appSourceKind) {
@@ -143,23 +166,90 @@ export function GuidedSetupInput(props: GuidedSetupInputProps) {
             </div>
 
             {appSourceKind === "repo" && (
-                <>
-                    <label htmlFor="repo-url-input" className={styles.label}>
-                        {l10n.t("Repository URL*")}
-                    </label>
-                    <input
-                        type="text"
-                        id="repo-url-input"
-                        className={styles.longControl}
-                        value={isValueSet(repoUrl) ? repoUrl.value : ""}
-                        placeholder="https://github.com/owner/repo"
-                        onInput={(e) => {
-                            const v = e.currentTarget.value;
-                            setRepoUrl(v ? valid(v) : missing<string>(l10n.t("A repository URL is required.")));
-                        }}
-                    />
-                    {renderValidationMessage(repoUrl)}
-                </>
+                <div className={styles.ghSection}>
+                    <div className={styles.ghHeader}>
+                        <span className={styles.ghHeaderTitle}>
+                            <FontAwesomeIcon icon={faCodeBranch} />
+                            {l10n.t("Your GitHub repositories")}
+                        </span>
+                        <div className={styles.ghHeaderActions}>
+                            {props.githubReposLoading && (
+                                <span className={styles.ghLoading}>
+                                    <FontAwesomeIcon icon={faSpinner} spin />
+                                    {l10n.t("Loading…")}
+                                </span>
+                            )}
+                            {props.githubSignedInUser && (
+                                <>
+                                    <span className={styles.ghEmptyHint}>{l10n.t("Signed in as")}</span>
+                                    <span className={styles.ghAccountPill}>
+                                        <FontAwesomeIcon icon={faUser} />
+                                        {props.githubSignedInUser}
+                                    </span>
+                                </>
+                            )}
+                        </div>
+                    </div>
+
+                    {props.githubReposError && (
+                        <span className={styles.ghErrorRow}>
+                            <FontAwesomeIcon icon={faTimesCircle} />
+                            {props.githubReposError}
+                        </span>
+                    )}
+
+                    {props.githubRepos && props.githubRepos.length === 0 && (
+                        <span className={styles.ghEmptyHint}>
+                            {l10n.t("No repositories were found for this GitHub account.")}
+                        </span>
+                    )}
+
+                    {props.githubRepos && props.githubRepos.length > 0 && (
+                        <CustomDropdown
+                            id="github-repo-dropdown"
+                            className={styles.ghDropdown}
+                            value={
+                                isValueSet(repoUrl) && props.githubRepos.some((r) => r.cloneUrl === repoUrl.value)
+                                    ? repoUrl.value
+                                    : ""
+                            }
+                            onChange={(value) => {
+                                if (value) setRepoUrl(valid(value));
+                            }}
+                        >
+                            {props.githubRepos.map((repo) => {
+                                const name = repo.fullName.split("/").slice(1).join("/") || repo.fullName;
+                                return (
+                                    <CustomDropdownOption
+                                        key={repo.cloneUrl}
+                                        value={repo.cloneUrl}
+                                        label={`${name}${repo.private ? "  •  private" : ""}${
+                                            repo.description ? `  —  ${repo.description}` : ""
+                                        }`}
+                                    />
+                                );
+                            })}
+                        </CustomDropdown>
+                    )}
+
+                    <div className={styles.ghDivider}>{l10n.t("or")}</div>
+
+                    <div className={styles.ghManualField}>
+                        <label htmlFor="repo-url-input">{l10n.t("Paste a repository URL*")}</label>
+                        <input
+                            type="text"
+                            id="repo-url-input"
+                            className={styles.ghManualInput}
+                            value={isValueSet(repoUrl) ? repoUrl.value : ""}
+                            placeholder="https://github.com/owner/repo"
+                            onInput={(e) => {
+                                const v = e.currentTarget.value;
+                                setRepoUrl(v ? valid(v) : missing<string>(l10n.t("A repository URL is required.")));
+                            }}
+                        />
+                        {renderValidationMessage(repoUrl)}
+                    </div>
+                </div>
             )}
 
             {appSourceKind === "new" && (

--- a/webview-ui/src/KickstartGuidedSetup/KickstartGuidedSetup.module.css
+++ b/webview-ui/src/KickstartGuidedSetup/KickstartGuidedSetup.module.css
@@ -246,3 +246,105 @@
     color: var(--vscode-descriptionForeground);
     font-size: 0.9em;
 }
+
+/* ---------- GitHub repo browser ---------- */
+
+.ghSection {
+    grid-column: 1 / 4;
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--vscode-panel-border, var(--vscode-editorWidget-border));
+    border-radius: 6px;
+    background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+}
+
+.ghHeader {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+}
+
+.ghHeaderTitle {
+    display: flex;
+    align-items: center;
+    column-gap: 0.5rem;
+    font-weight: 600;
+}
+
+.ghHeaderActions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    column-gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.ghAccountPill {
+    display: inline-flex;
+    align-items: center;
+    column-gap: 0.35rem;
+    padding: 0.1rem 0.55rem;
+    border-radius: 1rem;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    font-size: 0.85em;
+}
+
+.ghLoading {
+    display: inline-flex;
+    align-items: center;
+    column-gap: 0.4rem;
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+}
+
+.ghEmptyHint {
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.9em;
+}
+
+.ghDropdown {
+    width: 100%;
+}
+
+.ghDivider {
+    display: flex;
+    align-items: center;
+    column-gap: 0.6rem;
+    color: var(--vscode-descriptionForeground);
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 0.25rem 0;
+}
+
+.ghDivider::before,
+.ghDivider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--vscode-panel-border, var(--vscode-editorWidget-border));
+}
+
+.ghManualField {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.35rem;
+}
+
+.ghManualInput {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.ghErrorRow {
+    display: flex;
+    align-items: flex-start;
+    column-gap: 0.4rem;
+    color: var(--vscode-testing-iconFailed);
+    font-size: 0.9em;
+}

--- a/webview-ui/src/KickstartGuidedSetup/KickstartGuidedSetup.tsx
+++ b/webview-ui/src/KickstartGuidedSetup/KickstartGuidedSetup.tsx
@@ -16,6 +16,10 @@ export function KickstartGuidedSetup(initialState: InitialState) {
                         samples={state.samples}
                         workspaceIsEmpty={state.workspaceIsEmpty}
                         errorMessage={state.errorMessage}
+                        githubRepos={state.githubRepos}
+                        githubReposLoading={state.githubReposLoading}
+                        githubReposError={state.githubReposError}
+                        githubSignedInUser={state.githubSignedInUser}
                         eventHandlers={eventHandlers}
                         vscode={vscode}
                     />

--- a/webview-ui/src/KickstartGuidedSetup/helpers/state.ts
+++ b/webview-ui/src/KickstartGuidedSetup/helpers/state.ts
@@ -1,4 +1,4 @@
-import { InitialState } from "../../../../src/webview-contract/webviewDefinitions/kickstartGuidedSetup";
+import { GitHubRepo, InitialState } from "../../../../src/webview-contract/webviewDefinitions/kickstartGuidedSetup";
 import { WebviewStateUpdater } from "../../utilities/state";
 import { getWebviewMessageContext } from "../../utilities/vscode";
 
@@ -10,10 +10,15 @@ export enum Stage {
 export type KickstartGuidedSetupState = InitialState & {
     stage: Stage;
     errorMessage: string | null;
+    githubRepos: GitHubRepo[] | null;
+    githubReposLoading: boolean;
+    githubReposError: string | null;
+    githubSignedInUser: string | null;
 };
 
 export type EventDef = {
     setFinishing: void;
+    setGitHubReposLoading: void;
 };
 
 export const stateUpdater: WebviewStateUpdater<"kickstartGuidedSetup", EventDef, KickstartGuidedSetupState> = {
@@ -21,15 +26,37 @@ export const stateUpdater: WebviewStateUpdater<"kickstartGuidedSetup", EventDef,
         ...initialState,
         stage: Stage.CollectingInput,
         errorMessage: null,
+        githubRepos: null,
+        githubReposLoading: false,
+        githubReposError: null,
+        githubSignedInUser: null,
     }),
     vscodeMessageHandler: {
         errorNotification: (state, args) => ({ ...state, errorMessage: args.message }),
+        gitHubReposLoaded: (state, args) => ({
+            ...state,
+            githubRepos: args.repos,
+            githubReposLoading: false,
+            githubReposError: null,
+            githubSignedInUser: args.signedInUser,
+        }),
+        gitHubReposError: (state, args) => ({
+            ...state,
+            githubReposLoading: false,
+            githubReposError: args.message,
+        }),
     },
     eventHandler: {
         setFinishing: (state) => ({ ...state, stage: Stage.Finishing }),
+        setGitHubReposLoading: (state) => ({
+            ...state,
+            githubReposLoading: true,
+            githubReposError: null,
+        }),
     },
 };
 
 export const vscode = getWebviewMessageContext<"kickstartGuidedSetup">({
     finishRequest: null,
+    listGitHubReposRequest: null,
 });


### PR DESCRIPTION
## Summary

Adds a list of the user's GitHub repositories to the **Start from a GitHub repo** option in the Kickstart guided setup panel, so users can pick from their own repos instead of having to paste a URL.

## Behavior

- Uses VS Code's built-in `github` authentication provider with `createIfNone: false` — completely silent, never prompts. Sign-in is driven entirely by VS Code's Accounts menu.
- Calls `octokit.rest.repos.listForAuthenticatedUser({ type: 'owner', sort: 'updated', per_page: 100 })` so the list is scoped to repos the user owns (no org/collaborator noise).
- Subscribes to `vscode.authentication.onDidChangeSessions` and re-fetches automatically when the user signs in, signs out, or switches GitHub accounts — no in-panel refresh or switch-account button needed.
- Manual URL input is preserved as a fallback below the dropdown.
- Shows the signed-in account as a pill in the section header.

## Changes

- `src/panels/KickstartGuidedSetupPanel.ts` — `fetchRepos` helper, session-change listener, Octokit call.
- `src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts` — `GitHubRepo` type, `listGitHubReposRequest` (in), `gitHubReposLoaded` / `gitHubReposError` (out).
- `webview-ui/src/KickstartGuidedSetup/helpers/state.ts` — repo list state + reducers.
- `webview-ui/src/KickstartGuidedSetup/GuidedSetupInput.tsx` — auto-fetch `useEffect`, new `ghSection` card with header, dropdown, divider, and manual URL field.
- `webview-ui/src/KickstartGuidedSetup/KickstartGuidedSetup.module.css` — `gh*` styles using VS Code theme tokens.

## Verification

- `npm run test-compile` clean (extension host + webview build).
- `npm run lint` clean in both root and `webview-ui`.
- Manually verified: panel opens → repos appear → switching GitHub accounts via VS Code Accounts menu auto-refreshes the list → selecting a repo populates the URL field → existing submit flow unchanged.