### PR TITLE
Fix Kickstart GitHub repo listing to detect signed-in account

### DIFF
--- a/src/commands/aksKickstart/kickstartLaunch.ts
+++ b/src/commands/aksKickstart/kickstartLaunch.ts
@@ -21,6 +21,6 @@ export async function kickstartLaunch(): Promise<void> {
 
     const panel = new KickstartGuidedSetupPanel(extension.result.extensionUri);
     const dataProvider = new KickstartGuidedSetupDataProvider();
-    panel.show(dataProvider);
+    panel.show(dataProvider, dataProvider.getProviderDisposable());
     await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
 }

--- a/src/panels/KickstartGuidedSetupPanel.ts
+++ b/src/panels/KickstartGuidedSetupPanel.ts
@@ -1,4 +1,3 @@
-import { Uri, window } from "vscode";
 import * as vscode from "vscode";
 import * as l10n from "@vscode/l10n";
 import { Octokit } from "@octokit/rest";
@@ -13,7 +12,7 @@ import { TelemetryDefinition, ToWebviewMessageSink } from "../webview-contract/w
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 
 export class KickstartGuidedSetupPanel extends BasePanel<"kickstartGuidedSetup"> {
-    constructor(extensionUri: Uri) {
+    constructor(extensionUri: vscode.Uri) {
         super(extensionUri, "kickstartGuidedSetup", {
             errorNotification: null,
             gitHubReposLoaded: null,
@@ -23,84 +22,95 @@ export class KickstartGuidedSetupPanel extends BasePanel<"kickstartGuidedSetup">
 }
 
 export class KickstartGuidedSetupDataProvider implements PanelDataProvider<"kickstartGuidedSetup"> {
+    private authListener: vscode.Disposable | undefined;
+
     getTitle(): string {
         return l10n.t("AKS Kickstart");
     }
 
     getInitialState(): InitialState {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
         return {
             samples: KICKSTART_SAMPLES,
-            workspaceIsEmpty: !workspaceFolders || workspaceFolders.length === 0,
+            workspaceIsEmpty: !vscode.workspace.workspaceFolders?.length,
         };
     }
 
     getTelemetryDefinition(): TelemetryDefinition<"kickstartGuidedSetup"> {
-        return {
-            finishRequest: true,
-            listGitHubReposRequest: true,
-        };
+        return { finishRequest: true, listGitHubReposRequest: true };
+    }
+
+    /** Disposable to pass to `panel.show(...)` so the auth listener is cleaned up. */
+    getProviderDisposable(): vscode.Disposable {
+        return new vscode.Disposable(() => this.authListener?.dispose());
     }
 
     getMessageHandler(webview: ToWebviewMessageSink<"kickstartGuidedSetup">): MessageHandler<ToVsCodeMsgDef> {
-        // Refresh the repo list automatically whenever the user signs in,
-        // signs out, or switches GitHub accounts in VS Code.
-        vscode.authentication.onDidChangeSessions((e) => {
-            if (e.provider.id === "github") {
-                void this.fetchRepos(webview);
-            }
+        // Silently refresh whenever the user signs in/out or switches GitHub accounts.
+        this.authListener = vscode.authentication.onDidChangeSessions((e) => {
+            if (e.provider.id === "github") void this.fetchRepos(webview, { prompt: false });
         });
 
         return {
             finishRequest: (args) => this.handleFinish(args),
-            listGitHubReposRequest: () => this.fetchRepos(webview),
+            // User-initiated, so we may prompt for the `repo` scope.
+            listGitHubReposRequest: () => this.fetchRepos(webview, { prompt: true }),
         };
     }
 
     private async handleFinish(selections: GuidedSetupSelections) {
         await handoffToChat(selections);
-        window.showInformationMessage(l10n.t("Continuing AKS Kickstart in the chat view."));
+        vscode.window.showInformationMessage(l10n.t("Continuing AKS Kickstart in the chat view."));
     }
 
-    private async fetchRepos(webview: ToWebviewMessageSink<"kickstartGuidedSetup">) {
-        // Use whichever GitHub account is signed into VS Code. `createIfNone: false`
-        // means we never prompt — sign-in happens via the Accounts menu.
+    /**
+     * Obtain a GitHub session with the `repo` scope and list the user's repos.
+     * On user-initiated calls we prompt for the scope if it hasn't been granted;
+     * background refreshes (auth-change events) stay silent.
+     */
+    private async fetchRepos(webview: ToWebviewMessageSink<"kickstartGuidedSetup">, opts: { prompt: boolean }) {
         let session: vscode.AuthenticationSession | undefined;
         try {
-            session = await vscode.authentication.getSession("github", ["repo"], { createIfNone: false });
+            session = await vscode.authentication.getSession(
+                "github",
+                ["repo"],
+                opts.prompt ? { createIfNone: true } : { silent: true },
+            );
         } catch {
-            session = undefined;
+            // Treat as "no session" below.
         }
 
         if (!session) {
             webview.postGitHubReposError({
                 message: l10n.t(
-                    "No GitHub account is signed in to VS Code. Sign in via the Accounts menu to see your repositories.",
+                    "No GitHub account with `repo` access is signed in. Sign in via the Accounts menu to see your repositories.",
                 ),
+                signedInUser: null,
             });
             return;
         }
 
+        const signedInUser = session.account?.label ?? null;
+
         try {
-            // type: "owner" restricts the list to repos owned by the signed-in user.
             const octokit = new Octokit({ auth: session.accessToken });
-            const { data: apiRepos } = await octokit.rest.repos.listForAuthenticatedUser({
+            const { data } = await octokit.rest.repos.listForAuthenticatedUser({
                 per_page: 100,
                 sort: "updated",
                 type: "owner",
             });
             webview.postGitHubReposLoaded({
-                repos: apiRepos.map((r) => ({
+                repos: data.map((r) => ({
                     fullName: r.full_name,
                     description: r.description,
                     cloneUrl: r.clone_url,
                     private: r.private,
                 })),
-                signedInUser: session.account?.label ?? null,
+                signedInUser,
             });
         } catch (e) {
             webview.postGitHubReposError({
                 message: l10n.t("Failed to fetch GitHub repositories: {0}", String(e)),
+                signedInUser,
             });
         }
     }

--- a/src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts
+++ b/src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts
@@ -44,7 +44,7 @@ export type ToVsCodeMsgDef = {
 export type ToWebViewMsgDef = {
     errorNotification: { message: string };
     gitHubReposLoaded: { repos: GitHubRepo[]; signedInUser: string | null };
-    gitHubReposError: { message: string };
+    gitHubReposError: { message: string; signedInUser: string | null };
 };
 
 export type KickstartGuidedSetupDefinition = WebviewDefinition<InitialState, ToVsCodeMsgDef, ToWebViewMsgDef>;

--- a/webview-ui/src/KickstartGuidedSetup/helpers/state.ts
+++ b/webview-ui/src/KickstartGuidedSetup/helpers/state.ts
@@ -44,6 +44,7 @@ export const stateUpdater: WebviewStateUpdater<"kickstartGuidedSetup", EventDef,
             ...state,
             githubReposLoading: false,
             githubReposError: args.message,
+            githubSignedInUser: args.signedInUser ?? state.githubSignedInUser,
         }),
     },
     eventHandler: {


### PR DESCRIPTION
Follow-up to #2244.

## Problem
The Kickstart guided-setup panel reported "No GitHub account is signed in to VS Code" even when the user clearly was signed in.

Root cause (in `KickstartGuidedSetupPanel.ts`):
```ts
vscode.authentication.getSession("github", ["repo"], { createIfNone: false })
```
VS Code's GitHub auth provider keys sessions by their granted scope set. A silent lookup for `["repo"]` only matches sessions whose scopes exactly equal `["repo"]`, so users signed in via Copilot, Settings Sync, or the Accounts menu (different scope sets) were treated as not signed in. There was also no way for a first-time user to grant the scope from the panel.

## Fix
- Switch to `createIfNone: true` on user-initiated requests so VS Code prompts for the `repo` scope on first use (cold-start sign-in works too).
- Keep `silent: true` for the background `onDidChangeSessions` refresh path so unrelated session changes never pop a dialog.
- Capture the auth-listener disposable and tear it down via a new `getProviderDisposable()` wired through `panel.show(...)` — fixes a listener leak across panel reopens.
- Add `signedInUser` to the `gitHubReposError` payload so the webview keeps the "Signed in as" pill on transient errors.

## Files
- `src/panels/KickstartGuidedSetupPanel.ts` — auth lookup + disposable plumbing
- `src/commands/aksKickstart/kickstartLaunch.ts` — pass provider disposable to `panel.show`
- `src/webview-contract/webviewDefinitions/kickstartGuidedSetup.ts` — extend `gitHubReposError`
- `webview-ui/src/KickstartGuidedSetup/helpers/state.ts` — preserve signed-in user on error

## Testing
- `npx tsc --noEmit` passes for both extension and `webview-ui`.
- `npx eslint` clean on the changed files.
- Manual: with a GitHub account signed in for Copilot only, the panel now correctly prompts once for `repo` and lists repositories; with no account, the OAuth flow runs end-to-end.