### PR TITLE
fix: correct aks-deploy.template.yaml path in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ const config = {
         new CopyPlugin({
             patterns: [
                 {
-                    from: "src/commands/aksContainerAssist/aks-deploy.template.yaml",
+                    from: "resources/yaml/aks-deploy.template.yaml",
                     to: "[name][ext]",
                 },
             ],


### PR DESCRIPTION
## 🐛 Fix: Correct webpack CopyPlugin path for aks-deploy.template.yaml

### Problem

The `npm run package` command was failing with the following error:

```
ERROR in unable to locate '/Users/.../src/commands/aksContainerAssist/aks-deploy.template.yaml' glob
```

This prevented building the VSIX package for distribution.

### Root Cause

The webpack configuration's `CopyPlugin` was referencing an incorrect source path for the `aks-deploy.template.yaml` file. The plugin was looking for the file at:

```
src/commands/aksContainerAssist/aks-deploy.template.yaml
```

However, this file has always been located in:

```
resources/yaml/aks-deploy.template.yaml
```

### Solution

Updated the `CopyPlugin` configuration in webpack.config.js to use the correct source path that matches the actual file location.

**Before:**
```javascript
from: "src/commands/aksContainerAssist/aks-deploy.template.yaml"
```

**After:**
```javascript
from: "resources/yaml/aks-deploy.template.yaml"
```

This aligns the webpack production build with the `test-compile` script, which already correctly copies from yaml.

### Testing

✅ `npm run package` now completes successfully  
✅ VSIX package builds without errors: `vscode-aks-tools-2.2.0.vsix (71 files, 8.73 MB)`  
✅ Template file correctly copied to dist: `asset aks-deploy.template.yaml 5.36 KiB [copied]`

### Impact

- **Low risk**: Only changes the source path for copying a single template file
- **No functional changes**: The template file content and destination remain the same
- **Fixes build process**: Enables successful VSIX package creation

---

**Fixes**: Build break in `npm run package`