### PR TITLE
feat(kickstart): align existing-cluster acr access with new-cluster flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,13 @@ This extension contributes two declarative Copilot chat agents defined in `agent
 
 Guides users through deploying an application to AKS Automatic in seven sequential phases:
 
-1. **Discover** — Understand the app (language, deps, ports, env vars)
+1. **Discover** — Understand the app (language, deps, ports, env vars) and map each service's structure (build context, entry point, existing Dockerfile path)
 2. **Configure Infrastructure** — Create new or select existing Azure resources (RG, AKS, ACR). Cluster creates with `--no-wait` to run in background.
 3. **Design** — Propose target architecture, get approval
-4. **Generate** — Create Dockerfile, K8s manifests, Bicep, GitHub Actions workflow
-5. **Review** — Validate artifacts against safeguards and security checks
+4. **Generate** — Create Dockerfile (reuse existing when present, validate every COPY/ADD path, build & inspect the image), K8s manifests, Bicep, GitHub Actions workflow
+5. **Review** — Validate artifacts against safeguards and security checks, confirm the Dockerfile source→destination map, verify the image builds
 6. **Pre-Deploy Check** — Verify cluster is ready, ACR attached
-7. **Deploy** — Build, push, apply with `az` CLI and `kubectl`
+7. **Deploy** — Build (per-service build context + Dockerfile path, never `.`), push, apply with `az` CLI and `kubectl`, then health-check the running app
 
 Each phase invokes a dedicated phase skill (`/kickstart-discover`, `/kickstart-design`, etc.) plus domain-specific skills as needed. See `kickstart-guide.md` for the full skill invocation map.
 

--- a/agents/kickstart.agent.md
+++ b/agents/kickstart.agent.md
@@ -66,7 +66,7 @@ Handle each starting point (ask via `vscode_askQuestions` only when it wasn't al
     }]
   }
   ```
-  Clone with `run_in_terminal`, then load `/kickstart-samples` for the pre-filled profile and confirm it with the user. **Skip Phase 1 entirely** — go straight to **Phase 2 (Configure Infrastructure)**. Do NOT ask the user for app name, port, language, or any discovery questions.
+  Clone with `run_in_terminal`, then load `/kickstart-samples` for the pre-filled profile and confirm it with the user. **Skip Phase 1's questions** — go straight to **Phase 2 (Configure Infrastructure)**. Do NOT ask the user for app name, port, language, or any discovery questions — but still run the quick structure scan from `/kickstart-samples` to confirm each service's build context, Dockerfile path, and entry point before generating anything.
 - **Use my current workspace**: Proceed to **Phase 1 (Discover)**.
 
 ## Phases
@@ -74,9 +74,9 @@ Handle each starting point (ask via `vscode_askQuestions` only when it wasn't al
 Seven phases in order. Announce each transition in bold ("**✓ [Phase] complete → [Next phase].**") and open each phase with a one-line statement of what it will accomplish. To condense or skip phases — only when the user has supplied all inputs up-front — first follow `/kickstart-phase-acceleration`.
 
 ### 1 — Discover
-**Skip this phase if the user chose "Start from an example"** — the pre-filled profile from `/kickstart-samples` already provides all needed info.
+**Skip this phase's questions if the user chose "Start from an example"** — the pre-filled profile from `/kickstart-samples` provides the app details, but still confirm each service's build context, Dockerfile path, and entry point via a quick structure scan.
 
-Follow `/kickstart-discover`. Use `search` and `codebase` to auto-detect language, framework, ports, deps, Dockerfile, CI/CD before asking. Collect remaining details via `vscode_askQuestions`. Exit when you have enough to propose architecture.
+Follow `/kickstart-discover`. Use `search` and `codebase` to auto-detect language, framework, ports, deps, Dockerfile, CI/CD before asking, and to map each deployable service's build context, entry-point file, and existing Dockerfile path (never assume a flat repo). Collect remaining details via `vscode_askQuestions`. Exit when you have enough to propose architecture.
 
 ### 2 — Configure Infrastructure
 Follow `/kickstart-configure-infra`. Do NOT pick subscriptions or run `az aks create` yourself — launch the dedicated cluster-setup view with `vscode_runCommand` (command id `aks.kickstartCluster`), passing the app context as a single JSON argument so it can pre-fill sensible resource names: `{"appName":"<slug>","appSummary":"<one-line app description>","suggestedLocation":"<region, if known>"}`. Only set `suggestedLocation` when the user has a region preference, and prefer a low-capacity-risk region (e.g. `eastus2`, `westus3`, `swedencentral`) over high-demand ones (`eastus`, `westeurope`, `southeastasia`) that frequently hit AKS Automatic capacity limits; otherwise omit it and let the view's quota scan choose. That view collects the subscription, resource group, cluster, and ACR, then creates them (an AKS Automatic cluster + ACR, with the registry already attached to the cluster) and reports the provisioned resource names back to this chat. After launching it, tell the user to complete the cluster setup in that view and that you'll pick back up automatically — then **end your turn**. When the view hands back (a new message carrying the provisioned subscription, resource group, cluster, ACR, and login server), confirm those names in your opening prose and continue to Phase 3.
@@ -85,15 +85,15 @@ Follow `/kickstart-configure-infra`. Do NOT pick subscriptions or run `az aks cr
 Follow `/kickstart-design`. Present architecture summary (container strategy, AKS Automatic, Gateway API, Workload Identity, ACR, monitoring). Get user approval via `vscode_askQuestions`. Run `/kickstart-cluster-status` before transitioning.
 
 ### 4 — Generate
-Follow `/kickstart-generate`. Produce Dockerfile, K8s manifests (`k8s/`), Bicep (`infra/`), GitHub Actions workflow. Use actual resource names from Phase 2. Pin image tags — never `:latest`. Run `/kickstart-cluster-status` before transitioning.
+Follow `/kickstart-generate`. Produce Dockerfile (reuse an existing one when present), K8s manifests (`k8s/`), Bicep (`infra/`), GitHub Actions workflow — driven by the structure map, with every `COPY`/`ADD` path validated against the build context. Use actual resource names from Phase 2. Pin image tags — never `:latest`. Build and inspect each image (confirm the entry point landed) before exiting. Run `/kickstart-cluster-status` before transitioning.
 
 ### 5 — Review
-Follow `/kickstart-review`. Run `/kickstart-safeguard-checklist` validation. Present pass/fail/warn checklist. Fix failures before proceeding. Run `/kickstart-cluster-status` before transitioning.
+Follow `/kickstart-review`. Show the Dockerfile source→destination map for confirmation and verify the image builds with the entry point present, then run `/kickstart-safeguard-checklist` validation. Present pass/fail/warn checklist. Fix failures before proceeding. Run `/kickstart-cluster-status` before transitioning.
 
 ### 6 — Pre-Deploy Check
 Follow `/kickstart-handoff` — it carries the full strict-order playbook: cluster readiness (6a), metadata detection (6b), ACR attachment verification (6c — idempotent; the registry is usually already attached during cluster setup), kubelogin (6d), and the consolidated permission probes (6e–6g) via the bundled `aks.checkDeploymentPermissions` command. Escalate through `/kickstart-pim-activation` whenever a role assignment returns 403. Confirm readiness with the user via `vscode_askQuestions` before deploying.
 
 ### 7 — Deploy
-Follow `/kickstart-deploy` — build & push to ACR, get credentials, apply manifests, and verify, executed step by step via `run_in_terminal` with confirmation between each and error classification on failure.
+Follow `/kickstart-deploy` — build & push to ACR (using each service's build context and Dockerfile path from the structure map, never `.`), get credentials, apply manifests, then verify and health-check the running app (hit its endpoint, compare expected vs actual — not just pod readiness), executed step by step via `run_in_terminal` with confirmation between each and error classification on failure.
 
 Once the app is running, offer to commit the generated artifacts (Dockerfile, `k8s/`, `infra/`, workflow). If the user wants to commit or open a PR, follow `/kickstart-github-pr-conventions` for branch naming, Conventional Commits, and PR structure.

--- a/kickstart-guide.md
+++ b/kickstart-guide.md
@@ -71,13 +71,13 @@ The main agent follows seven phases in strict order. Each phase has a dedicated 
 
 | Phase | Skill | What it does | Exit criteria |
 |---|---|---|---|
-| 1. Discover | `/kickstart-discover` | Collect app name, language, framework, deps, port, env vars, Dockerfile/CI status | Enough info to propose architecture |
+| 1. Discover | `/kickstart-discover` | Collect app name, language, framework, deps, port, env vars, Dockerfile/CI status; map each service's build context, entry point, and existing Dockerfile path | Enough info to propose architecture + structure mapped |
 | 2. Configure | `/kickstart-configure-infra` | Create new or select existing Azure resources (RG, AKS cluster, ACR). Cluster creates with `--no-wait` | Resources selected/creating |
 | 3. Design | `/kickstart-design` | Propose AKS Automatic architecture, get user approval | User approves |
-| 4. Generate | `/kickstart-generate` | Create Dockerfile, K8s manifests, Bicep, GHA workflow | All files written to workspace |
-| 5. Review | `/kickstart-review` | Validate artifacts against safeguards + security | All checks pass |
+| 4. Generate | `/kickstart-generate` | Create Dockerfile (reuse existing, validate COPY/ADD paths, build & inspect image), K8s manifests, Bicep, GHA workflow | All files written + image builds |
+| 5. Review | `/kickstart-review` | Confirm Dockerfile source→destination map, verify image builds, validate artifacts against safeguards + security | All checks pass |
 | 6. Pre-Deploy | `/kickstart-handoff` | Verify cluster ready, ACR attached, final summary | Cluster provisioned, user confirms |
-| 7. Deploy | `/kickstart-deploy` | Build, push, apply with `az` and `kubectl` | App running on AKS |
+| 7. Deploy | `/kickstart-deploy` | Build (per-service context + Dockerfile path), push, apply with `az` and `kubectl`, health-check endpoint | App running + endpoint verified |
 
 ### Phase transitions
 - The agent announces each transition: *"Discovery complete — moving to the Design phase."*

--- a/skills/kickstart-deploy/SKILL.md
+++ b/skills/kickstart-deploy/SKILL.md
@@ -10,8 +10,8 @@ Deploy using Azure CLI and `kubectl`. Execute each step via `run_in_terminal`, c
 
 ## Steps
 
-1. **Build and push**: `az acr build --registry <acr> --image <image>:<tag> .`
-   Tag with a version (e.g. v1.0.0), never `:latest`. Use the project path as build context.
+1. **Build and push**: `az acr build --registry <acr> --image <image>:<tag> -f <dockerfilePath> <buildContext>`
+   Use the build context and Dockerfile path from the structure map — never assume repo root (`.`). For monorepos, build each service from its own context. Tag with a version (e.g. v1.0.0), never `:latest`.
 
 2. **Get credentials**: `az aks get-credentials --resource-group <rg> --name <cluster> --overwrite-existing`
    kubelogin handles AAD auth automatically (verified in Pre-Deploy Check). Never use `--admin`.
@@ -20,6 +20,11 @@ Deploy using Azure CLI and `kubectl`. Execute each step via `run_in_terminal`, c
 
 4. **Verify**: `kubectl get pods -n <namespace>` and `kubectl get services -n <namespace>`
    If pods not Ready, run `kubectl describe pod <name>` and `kubectl logs <name>` to diagnose.
+
+5. **Health-check the running app**: don't declare success on pod readiness alone — actually hit the app and compare against the expected response:
+   - Via the gateway/service URL from `kubectl get httproute` / `kubectl get services`: `curl -sS -o /dev/null -w "%{http_code}" http://<url>/` (expect 2xx/3xx).
+   - Or in-cluster: `kubectl exec <pod> -n <namespace> -- curl -sS localhost:<port>/<health-path>`.
+   If the response isn't what the app should return (wrong status, error body, or logs show a missing entry point), classify as a `cluster` failure and diagnose before reporting success.
 
 ## Error Handling
 
@@ -33,7 +38,7 @@ Provide specific `az` or `kubectl` fix commands. Offer retry via `vscode_askQues
 
 ## Post-Deployment
 
-- Verify app accessible via `kubectl get services` (external IP or gateway URL).
+- Confirm the app actually responds at its external IP / gateway URL (the health-check above) — not just that the service has an address.
 - Check Azure Monitor dashboards (managed Prometheus + Grafana auto-enabled).
 - Set up alerts: CPU >80%, memory >85%, pod restarts >5.
 

--- a/skills/kickstart-discover/SKILL.md
+++ b/skills/kickstart-discover/SKILL.md
@@ -12,14 +12,28 @@ Collect enough information to propose a deployment architecture.
 
 Use `search` and `codebase` to scan the workspace before asking anything. Look for `package.json`, `requirements.txt`, `go.mod`, `*.csproj`, `Dockerfile`, `.github/workflows/`, `azure-pipelines.yml`.
 
+## Map the structure (before anything else)
+
+Never assume a flat repo. Apps often live in nested or monorepo layouts (`src/<service>/`, `services/<name>/`, `apps/<name>/`, `packages/<name>/`). For **every deployable service**, record a structure entry — later phases build and deploy from it:
+
+| Field | How to find it | Used by |
+|---|---|---|
+| Service name | directory / manifest | naming, image tag |
+| Build context | the dir holding the service's manifest + source (NOT always repo root) | Generate, Deploy build context |
+| Entry point | the real run target — `main.py`, `app.js`, `cmd/<svc>/main.go`, `*.csproj` — confirm the file exists | Dockerfile `CMD`/`ENTRYPOINT` |
+| Existing Dockerfile | search the build context; record its path or "none — generate" | Generate (reuse vs. create) |
+| Port | code (`app.listen(3000)`, `EXPOSE`, framework default) | Service, probes |
+
+Use `codebase`/`search` to confirm each path actually exists — do not infer it from the language alone. Surface this map to the user and let them correct it before proceeding.
+
 ## What to collect
 
 - App name
 - Language / framework (detect from manifest files, confirm via `vscode_askQuestions`)
+- Per-service structure map (build context, entry point, existing Dockerfile path) — see above
 - Dependencies (databases, caches, queues — offer common options as multi-select)
 - Port (detect from code like `app.listen(3000)`, confirm)
 - Environment variables (detect from `.env.example` or code)
-- Existing Dockerfile (search workspace)
 - Existing CI/CD (search workspace)
 
 ## Rules
@@ -29,4 +43,4 @@ Use `search` and `codebase` to scan the workspace before asking anything. Look f
 - When the answer is open-ended (app name), use `allowFreeformInput: true`.
 
 ## Exit Criteria
-You know the app name, language, framework, port, key deps, env vars, and Dockerfile/CI status. Announce: "Discovery complete — moving to Configure Infrastructure."
+You know the app name, language, framework, port, key deps, env vars, CI status, and a confirmed per-service structure map (build context + entry point + existing Dockerfile path) for every deployable service. Announce: "Discovery complete — moving to Configure Infrastructure."

--- a/skills/kickstart-generate/SKILL.md
+++ b/skills/kickstart-generate/SKILL.md
@@ -8,6 +8,14 @@ disable-model-invocation: true
 
 Create all deployment artifacts and write them to the workspace. Follow `/kickstart-file-generation` for the batch-write order: compute ALL contents first, write all files, then report.
 
+## Build from the structure map, not assumptions
+
+Use the per-service structure map from Discovery (build context, entry point, existing Dockerfile path). Never assume the app sits at the repo root.
+
+- **Reuse existing Dockerfiles.** If a service already ships a working `Dockerfile`, use it as-is (or amend in place) — do not generate a parallel one. Only author a Dockerfile for services that lack one.
+- **Cross-check every `COPY`/`ADD`.** Each source must resolve to a real file/dir inside that service's build context, and the destination must match where the entry point runs (e.g. `WORKDIR /app` + `COPY . /app` only if the entry point is at the context root). Use `search`/`codebase` to confirm sources exist before writing the Dockerfile; flag and fix any mismatch.
+- **Set the run target from the real entry point** (`CMD`/`ENTRYPOINT`), not a guessed filename.
+
 ## Domain playbooks
 
 Load these for detailed patterns as you author each artifact:
@@ -17,7 +25,7 @@ Load these for detailed patterns as you author each artifact:
 
 ## Artifacts
 
-**Dockerfile**: Multi-stage build, pinned base image (never `:latest`), non-root user, `.dockerignore`.
+**Dockerfile**: Multi-stage build, pinned base image (never `:latest`), non-root user, `.dockerignore`. `COPY`/`ADD` paths validated against the build context; `CMD` runs the real entry point.
 
 **K8s Manifests** (`k8s/`): `namespace.yaml`, `deployment.yaml` (resource limits, probes, `runAsNonRoot`, Workload Identity labels, env from ConfigMap/Secret), `service.yaml` (ClusterIP), `httproute.yaml` (Gateway API, not Ingress). See `/kickstart-workload-identity`.
 
@@ -28,8 +36,19 @@ Load these for detailed patterns as you author each artifact:
 ## Rules
 - Use actual resource names from the Configure phase.
 - Never use `:latest` tags.
+- Honor each service's build context and entry point from the structure map; reuse existing Dockerfiles instead of duplicating them.
 - All K8s manifests must comply with AKS deployment safeguards (restricted pod security, no privileged, no hostPath).
 - After writing all files, confirm with user via `vscode_askQuestions`.
 
+## Validate the build (before exit)
+
+Do not hand off unbuilt artifacts. For each Dockerfile, build and inspect before announcing completion:
+
+1. **Build** from the service's build context:
+   - Local Docker/Podman daemon available: `docker build -t kickstart-validate-<svc>:check -f <dockerfilePath> <buildContext>`.
+   - Otherwise build in ACR (also catches missing `COPY` sources): `az acr build --registry <acr> --image kickstart-validate/<svc>:check -f <dockerfilePath> <buildContext>`.
+2. **Inspect contents** (when built locally): `docker run --rm kickstart-validate-<svc>:check ls -la <workdir>` — confirm the entry point and expected files landed where the app runs from. A build that succeeds but places files in the wrong dir is exactly the failure this step catches.
+3. If the build fails or the entry point is missing, fix the Dockerfile/paths and rebuild — do not proceed to Review with a broken image.
+
 ## Exit Criteria
-All artifacts written. Announce: "Artifacts generated — moving to Review."
+All artifacts written, every Dockerfile builds, and the entry point is confirmed present in the image. Announce: "Artifacts generated and build-validated — moving to Review."

--- a/skills/kickstart-review/SKILL.md
+++ b/skills/kickstart-review/SKILL.md
@@ -10,7 +10,7 @@ Validate every artifact against security, correctness, and AKS Automatic complia
 
 ## Checklist
 
-**Dockerfile**: Multi-stage build, pinned base image, non-root user, `.dockerignore` present.
+**Dockerfile**: Multi-stage build, pinned base image, non-root user, `.dockerignore` present. Build context + every `COPY`/`ADD` source→destination resolves to real files; `CMD`/`ENTRYPOINT` runs the actual entry point; the image builds and the entry point is present in the built image.
 
 **K8s Manifests**: `runAsNonRoot: true`, no privileged containers, resource requests+limits, liveness/readiness probes, Gateway API HTTPRoute (not Ingress), Workload Identity labels+SA, namespace specified.
 
@@ -20,15 +20,22 @@ Validate every artifact against security, correctness, and AKS Automatic complia
 
 ## Process
 
-1. Run `/kickstart-safeguard-checklist` for the full safeguard rule set.
-2. Run validation via `run_in_terminal`:
+1. **Confirm the image is real, not assumed.** Present a source→destination table for each Dockerfile so the user can verify what lands where:
+
+   | Build context | COPY/ADD source | → destination | Entry point | Port |
+   |---|---|---|---|---|
+   | `src/order-service` | `package.json`, `src/` | `/app` | `/app/server.js` | 3000 |
+
+   Then confirm (or run) the build validation from `/kickstart-generate` — the image must build and `ls <workdir>` must show the entry point. A missing or mismatched path is a FAIL.
+2. Run `/kickstart-safeguard-checklist` for the full safeguard rule set.
+3. Run validation via `run_in_terminal`:
    ```bash
    kubectl apply --dry-run=client -f k8s/
    az bicep build --file infra/main.bicep
    ```
-3. Present results as PASS ✓ / FAIL ✗ / WARN ⚠ per item.
-4. If FAILs: use `vscode_askQuestions` — fix automatically (recommended), show details, or skip.
-5. If WARNs only: confirm proceeding via `vscode_askQuestions`.
+4. Present results as PASS ✓ / FAIL ✗ / WARN ⚠ per item.
+5. If FAILs: use `vscode_askQuestions` — fix automatically (recommended), show details, or skip.
+6. If WARNs only: confirm proceeding via `vscode_askQuestions`.
 
 ## Exit Criteria
 All checks pass. Announce: "Review complete — moving to Pre-Deploy Check."

--- a/skills/kickstart-samples/SKILL.md
+++ b/skills/kickstart-samples/SKILL.md
@@ -29,10 +29,10 @@ After the user picks, clone with `run_in_terminal`:
 | Azure Voting App | `git clone https://github.com/Azure-Samples/azure-voting-app-redis.git` |
 | Contoso Real Estate | `git clone https://github.com/Azure-Samples/contoso-real-estate.git` |
 
-Then present the pre-filled profile below and confirm it with the user via `vscode_askQuestions` ("Looks good, continue to Configure" recommended). **Skip Discovery entirely** — go straight to Phase 2.
+After cloning, **do a quick structure scan to confirm the profile** — the paths below are the expected layout, but samples change. Use `search`/`codebase` to verify each service's build context, `Dockerfile` path, and entry-point file actually exist before relying on them. Then present the (corrected) profile and confirm it via `vscode_askQuestions` ("Looks good, continue to Configure" recommended). **Skip the Discovery questions** — but never skip this structure check — then go straight to Phase 2.
 
-**AKS Store Demo**: Monorepo, 4 services — `store-front` (Node.js:8080), `order-service` (Node.js:3000), `product-service` (Go:3002), `makeline-service` (Rust:3001). Deps: MongoDB, RabbitMQ. Has Dockerfiles, K8s manifests, GitHub Actions.
+**AKS Store Demo** (monorepo, services under `src/`): `store-front` (Node.js, :8080, context `src/store-front`), `order-service` (Node.js, :3000, context `src/order-service`), `product-service` (Go, :3002, context `src/product-service`), `makeline-service` (Rust, :3001, context `src/makeline-service`). Each service dir is its own build context and ships a `Dockerfile`. Deps: MongoDB, RabbitMQ. Has K8s manifests, GitHub Actions.
 
-**Azure Voting App**: Single app — `azure-vote` (Python/Flask:80). Deps: Redis. Has Dockerfile and K8s manifests. No GitHub Actions.
+**Azure Voting App** (`Azure-Samples/azure-voting-app-redis`): `azure-vote` (Python/Flask, :80). Build context `azure-vote/`, Dockerfile `azure-vote/Dockerfile`, entry point `azure-vote/azure-vote/main.py` — note the nested dir, a classic flat-structure trap. Deps: Redis. Has K8s manifests. No GitHub Actions.
 
-**Contoso Real Estate**: Monorepo — `portal` (Next.js:3000), `api` (Fastify:3001). Deps: PostgreSQL. Partial Dockerfiles, no K8s manifests, has GitHub Actions.
+**Contoso Real Estate** (monorepo, packages under `packages/`): `portal` (Next.js, :3000, context `packages/portal`), `api` (Fastify, :3001, context `packages/api`). Deps: PostgreSQL. Partial Dockerfiles (generate the missing ones), no K8s manifests, has GitHub Actions.

--- a/src/commands/aksCheckPermissions/checkDeploymentPermissions.ts
+++ b/src/commands/aksCheckPermissions/checkDeploymentPermissions.ts
@@ -23,6 +23,12 @@ const QUICKPICK_TITLE = "Check AKS deployment permissions";
 // Required actions for each gate in Phase 6 of the Kickstart agent.
 export const AKS_CLUSTER_USER_ACTION = "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action";
 export const AKS_DATAPLANE_WRITE_ACTION = "Microsoft.ContainerService/managedClusters/apps/deployments/write";
+// NOTE: despite the `*_DATAACTION` naming, Azure's built-in AcrPull/AcrPush roles grant these
+// registry permissions as control-plane *actions* (their `dataActions` arrays are empty), and Azure
+// can reclassify actions<->dataActions over time. Probes therefore match them via
+// `grantsActionEitherBucket` rather than assuming a fixed bucket. Checking only `dataActions` was a
+// false-negative: a valid AcrPull assignment was present but never matched, leaving a permanent
+// "still propagating" warning that never cleared.
 export const ACR_PULL_DATAACTION = "Microsoft.ContainerRegistry/registries/pull/read";
 export const ACR_PUSH_DATAACTION = "Microsoft.ContainerRegistry/registries/push/write";
 export const ACR_TASKS_ACTION = "Microsoft.ContainerRegistry/registries/tasks/write";
@@ -33,6 +39,11 @@ const ROLE_RBAC_WRITER = "Azure Kubernetes Service RBAC Writer";
 const ROLE_ACR_PULL = "AcrPull";
 const ROLE_ACR_PUSH = "AcrPush";
 const ROLE_ACR_TASKS = "Container Registry Tasks Contributor";
+
+// Fixed role-definition GUID for the built-in AcrPull role. Azure built-in role IDs are immutable,
+// so this lets us recognize an AcrPull assignment by ID even before its data actions have
+// propagated through Azure AD (when the role-definition lookup can't yet confirm the grant).
+const ACR_PULL_ROLE_DEFINITION_ID = "7f951dda-4ed3-4680-a7ca-43fe172d538d";
 
 type DeploymentScope = {
     subscriptionId: string;
@@ -64,6 +75,8 @@ export type Probe = {
     recommendedRoles?: string[];
     /** A ready-to-run `az role assignment create` command for the first recommended role. */
     remediation?: string;
+    /** Object ID of the principal this probe evaluated (e.g. the kubelet identity), for display. */
+    principalId?: string;
 };
 
 export type CheckDeploymentPermissionsArgs = {
@@ -197,7 +210,7 @@ function evaluateAcrPushProbe(perms: Errorable<Permission[]>, scope: DeploymentS
         label: `Push container images to ACR '${scope.acrName}'`,
         perms,
         action: ACR_PUSH_DATAACTION,
-        kind: "dataAction",
+        kind: "action",
         scopeId: scope.acrScopeId!,
         recommendedRoles: [ROLE_ACR_PUSH],
     });
@@ -233,6 +246,8 @@ async function evaluateAcrPullProbe(
         return probe;
     }
 
+    probe.principalId = kubeletObjectId.result;
+
     const assignments = await getPrincipalRoleAssignmentsForAcr(
         authClient,
         kubeletObjectId.result,
@@ -244,8 +259,10 @@ async function evaluateAcrPullProbe(
         return probe;
     }
 
+    let hasAcrPullAssignment = false;
     for (const ra of assignments.result) {
-        const grants = await roleAssignmentGrantsDataAction(authClient, ra, ACR_PULL_DATAACTION);
+        if (isAcrPullRoleAssignment(ra)) hasAcrPullAssignment = true;
+        const grants = await roleAssignmentGrantsAcrPull(authClient, ra, ACR_PULL_DATAACTION);
         if (grants) {
             probe.status = "pass";
             probe.reason = `Kubelet identity has an assignment that grants \`${ACR_PULL_DATAACTION}\`.`;
@@ -253,8 +270,18 @@ async function evaluateAcrPullProbe(
         }
     }
 
+    // An AcrPull assignment exists for the kubelet identity, but its role definition couldn't be
+    // read to confirm the grant (a transient lookup failure, or a brand-new assignment that hasn't
+    // replicated through Azure AD yet). Surface it as a soft "still confirming" signal ("unknown")
+    // instead of a hard fail, and omit the re-assign remediation since the role is already assigned.
+    if (hasAcrPullAssignment) {
+        probe.status = "unknown";
+        probe.reason = `The kubelet identity has an AcrPull assignment, but the grant couldn't be confirmed yet — a brand-new assignment can take a few minutes to replicate through Azure AD.`;
+        return probe;
+    }
+
     probe.status = "fail";
-    probe.reason = `The cluster's kubelet identity has no role assignment on this ACR that grants \`${ACR_PULL_DATAACTION}\`.`;
+    probe.reason = `No AcrPull role assignment that grants \`${ACR_PULL_DATAACTION}\` is visible on this ACR for the kubelet identity yet. If it was just assigned, it can take a few minutes to appear.`;
     probe.remediation = azRoleAssignmentCommand({
         assigneeObjectId: kubeletObjectId.result,
         principalType: "ServicePrincipal",
@@ -286,7 +313,7 @@ function probeFromActionCheck(input: {
         return probe;
     }
 
-    const verdict = findGrantingAction(input.perms.result, input.action, input.kind);
+    const verdict = grantsActionEitherBucket(input.perms.result, input.action);
     if (verdict.granted) {
         probe.status = "pass";
         probe.reason = `Granted via \`${verdict.via!}\`.`;
@@ -304,18 +331,40 @@ function probeFromActionCheck(input: {
     return probe;
 }
 
-async function roleAssignmentGrantsDataAction(
+/**
+ * True iff `perms` grant `action` in EITHER the `actions` or `dataActions` bucket. Azure classifies
+ * some Container Registry permissions (AcrPull's `registries/pull/read`, AcrPush's
+ * `registries/push/write`) as control-plane actions despite their data-plane nature, and can
+ * reclassify actions<->dataActions over time, so we accept a match in either bucket rather than
+ * hard-coding which one applies.
+ */
+function grantsActionEitherBucket(perms: Permission[], action: string): { granted: boolean; via?: string } {
+    const asAction = findGrantingAction(perms, action, "action");
+    return asAction.granted ? asAction : findGrantingAction(perms, action, "dataAction");
+}
+
+async function roleAssignmentGrantsAcrPull(
     authClient: AuthorizationManagementClient,
     assignment: RoleAssignment,
-    dataAction: string,
+    pullAction: string,
 ): Promise<boolean> {
     if (!assignment.roleDefinitionId) return false;
     try {
         const def = await authClient.roleDefinitions.getById(assignment.roleDefinitionId);
-        return findGrantingAction(def.permissions ?? [], dataAction, "dataAction").granted;
+        return grantsActionEitherBucket(def.permissions ?? [], pullAction).granted;
     } catch {
         return false;
     }
+}
+
+/**
+ * True when the role assignment references the built-in AcrPull role (matched by its fixed
+ * role-definition GUID). Unlike {@link roleAssignmentGrantsAcrPull} this is a pure string check
+ * with no network call, so it still recognizes the assignment when the role-definition lookup hasn't
+ * propagated yet — letting the probe distinguish "assigned, still propagating" from "absent".
+ */
+function isAcrPullRoleAssignment(assignment: RoleAssignment): boolean {
+    return assignment.roleDefinitionId?.toLowerCase().endsWith(`/${ACR_PULL_ROLE_DEFINITION_ID}`) ?? false;
 }
 
 async function listForResource(

--- a/src/commands/aksKickstart/kickstartChat.ts
+++ b/src/commands/aksKickstart/kickstartChat.ts
@@ -116,11 +116,31 @@ export interface ProvisionedClusterInfo {
     clusterPortalUrl: string | null;
     acrName: string;
     acrLoginServer: string | null;
+    /**
+     * Absolute path to a kubelogin binary the launch wizard already downloaded during cluster setup,
+     * or null if it couldn't be fetched. Handed to the agent so it reuses this copy instead of running
+     * `which kubelogin` / `az aks install-cli` (AKS Automatic disables local accounts, so kubelogin is
+     * always required for cluster auth).
+     */
+    kubeloginPath: string | null;
 }
 
-export async function handoffClusterToChat(info: ProvisionedClusterInfo): Promise<void> {
+export interface ClusterHandoffOptions {
+    /**
+     * When true, the cluster is still being created in the background (the handoff happened early,
+     * right after the kubelet identity was granted AcrPull). The chat prose tells the agent to keep
+     * working through the phases that don't need a ready cluster while the create + RBAC propagation
+     * finish.
+     */
+    stillProvisioning?: boolean;
+}
+
+export async function handoffClusterToChat(
+    info: ProvisionedClusterInfo,
+    options: ClusterHandoffOptions = {},
+): Promise<void> {
     await openMaximizedChat(false);
-    await vscode.commands.executeCommand("workbench.action.chat.open", buildClusterChatOpenOptions(info));
+    await vscode.commands.executeCommand("workbench.action.chat.open", buildClusterChatOpenOptions(info, options));
 }
 
 function buildClusterContextSummary(info: ProvisionedClusterInfo): string {
@@ -138,16 +158,43 @@ function buildClusterContextSummary(info: ProvisionedClusterInfo): string {
     return lines.join("\n");
 }
 
-function buildClusterChatOpenOptions(info: ProvisionedClusterInfo): Record<string, unknown> {
-    const summary = buildClusterContextSummary(info);
+function buildKubeloginInstruction(kubeloginPath: string): string {
+    return (
+        `kubelogin is already installed at \`${kubeloginPath}\` — the launch wizard downloaded it during cluster setup. ` +
+        "Use this binary for AKS Automatic cluster authentication and add its parent directory to your PATH so " +
+        "`kubectl`'s exec credential plugin can find it. Skip the `which kubelogin` check and do not run " +
+        "`az aks install-cli` or otherwise download kubelogin again."
+    );
+}
 
-    const query = [
-        `@${KICKSTART_AGENT_NAME} The cluster and registry are ready. Here's the infrastructure that was provisioned:`,
-        "",
-        summary,
-        "",
-        "The AKS Automatic cluster and ACR exist and the registry is already attached to the cluster. Continue from Phase 3 (Design) using these exact resource names.",
-    ].join("\n");
+function buildClusterChatOpenOptions(
+    info: ProvisionedClusterInfo,
+    options: ClusterHandoffOptions = {},
+): Record<string, unknown> {
+    const summary = buildClusterContextSummary(info);
+    const stillProvisioning = options.stillProvisioning ?? false;
+
+    const baseQuery = stillProvisioning
+        ? [
+              `@${KICKSTART_AGENT_NAME} The cluster and registry are being set up. Here's the infrastructure:`,
+              "",
+              summary,
+              "",
+              "The AKS Automatic cluster is still being created in the background (this can take several minutes), and its kubelet identity has already been granted AcrPull on the registry so the role assignment is propagating while we work. Don't wait for it — continue from Phase 3 (Design) using these exact resource names. Phases 3 and 4 (Design and Generate) don't need the cluster to be ready. Before pushing images and deploying in Phase 7, run the `/kickstart-cluster-status` check to confirm the cluster has finished provisioning.",
+          ].join("\n")
+        : [
+              `@${KICKSTART_AGENT_NAME} The cluster and registry are ready. Here's the infrastructure that was provisioned:`,
+              "",
+              summary,
+              "",
+              "The AKS Automatic cluster and ACR exist and the registry is already attached to the cluster. Continue from Phase 3 (Design) using these exact resource names.",
+          ].join("\n");
+
+    const query = info.kubeloginPath ? `${baseQuery}\n\n${buildKubeloginInstruction(info.kubeloginPath)}` : baseQuery;
+
+    const response = stillProvisioning
+        ? `The cluster is being created in the background:\n\n${summary}\n\nLet's keep going while it finishes.`
+        : `Provisioning is complete:\n\n${summary}\n\nLet's keep going.`;
 
     return {
         mode: KICKSTART_AGENT_NAME,
@@ -155,7 +202,7 @@ function buildClusterChatOpenOptions(info: ProvisionedClusterInfo): Record<strin
         previousRequests: [
             {
                 request: "Set up my AKS Automatic cluster and container registry.",
-                response: `Provisioning is complete:\n\n${summary}\n\nLet's keep going.`,
+                response,
             },
         ],
         query,

--- a/src/commands/aksKickstart/kickstartCluster.ts
+++ b/src/commands/aksKickstart/kickstartCluster.ts
@@ -41,6 +41,9 @@ export async function kickstartCluster(context: vscode.ExtensionContext, launchC
     const panel = new KickstartClusterPanel(extension.result.extensionUri);
     const dataProvider = new KickstartClusterDataProvider(sessionProvider.result, context, launchContext);
     panel.show(dataProvider);
+    // Give the view the full editor surface: close the bottom panel (terminal/output) and hide the
+    // side bar. `maximizeEditorHideSidebar` alone leaves the terminal visible, so close it explicitly.
+    await vscode.commands.executeCommand("workbench.action.closePanel");
     await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
 }
 

--- a/src/commands/aksKickstart/kickstartLaunch.ts
+++ b/src/commands/aksKickstart/kickstartLaunch.ts
@@ -22,5 +22,8 @@ export async function kickstartLaunch(): Promise<void> {
     const panel = new KickstartGuidedSetupPanel(extension.result.extensionUri);
     const dataProvider = new KickstartGuidedSetupDataProvider();
     panel.show(dataProvider, dataProvider.getProviderDisposable());
+    // Give the view the full editor surface: close the bottom panel (terminal/output) and hide the
+    // side bar. `maximizeEditorHideSidebar` alone leaves the terminal visible, so close it explicitly.
+    await vscode.commands.executeCommand("workbench.action.closePanel");
     await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
 }

--- a/src/commands/utils/retailPrices.ts
+++ b/src/commands/utils/retailPrices.ts
@@ -5,6 +5,20 @@ const API_VERSION = "2023-01-01-preview";
 const CURRENCY_CODE = "USD";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+// The Retail Prices endpoint is public, unauthenticated, and shared, so it is
+// aggressively rate limited (HTTP 429). To stay under the limit we:
+//   1. serialize every outbound request through a single queue and keep a
+//      minimum gap between them (pagination + multiple filters + rapid region
+//      changes otherwise burst dozens of requests at once),
+//   2. retry transient failures with capped exponential backoff + jitter while
+//      honoring any `Retry-After` header the service returns, and
+//   3. coalesce concurrent callers for the same filter onto one request.
+const MIN_REQUEST_SPACING_MS = 250;
+const MAX_RETRIES = 4;
+const BASE_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 20000;
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+
 export interface RetailPriceItem {
     currencyCode: string;
     retailPrice: number;
@@ -32,6 +46,7 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<Errorable<RetailPriceItem[]>>>();
 
 export async function fetchRetailPrices(filter: string): Promise<Errorable<RetailPriceItem[]>> {
     const cached = cache.get(filter);
@@ -39,12 +54,29 @@ export async function fetchRetailPrices(filter: string): Promise<Errorable<Retai
         return { succeeded: true, result: cached.items };
     }
 
+    // Coalesce concurrent callers for the same filter onto a single request so
+    // pagination and rapid region switching don't fan out into duplicate calls.
+    const existing = inFlight.get(filter);
+    if (existing) {
+        return existing;
+    }
+
+    const request = fetchAllPages(filter);
+    inFlight.set(filter, request);
+    try {
+        return await request;
+    } finally {
+        inFlight.delete(filter);
+    }
+}
+
+async function fetchAllPages(filter: string): Promise<Errorable<RetailPriceItem[]>> {
     const items: RetailPriceItem[] = [];
     let nextUrl: string | null = buildInitialUrl(filter);
 
     try {
         while (nextUrl) {
-            const response = await fetch(nextUrl);
+            const response = await fetchWithRetry(nextUrl);
             if (!response.ok) {
                 return {
                     succeeded: false,
@@ -66,6 +98,78 @@ export async function fetchRetailPrices(filter: string): Promise<Errorable<Retai
 
     cache.set(filter, { expiresAt: Date.now() + CACHE_TTL_MS, items });
     return { succeeded: true, result: items };
+}
+
+// Retry transient failures (429 plus transient 5xx/408) with capped exponential
+// backoff. Honors the `Retry-After` header when the service provides one.
+async function fetchWithRetry(url: string): Promise<Response> {
+    let response = await schedule(() => fetch(url));
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
+            return response;
+        }
+        const retryAfterMs = parseRetryAfter(response.headers.get("retry-after"));
+        // Release the connection before waiting so the retry starts clean.
+        await response.body?.cancel();
+        await delay(backoffDelay(attempt, retryAfterMs));
+        response = await schedule(() => fetch(url));
+    }
+    return response;
+}
+
+// Serialize all outbound requests and keep a minimum gap between them so bursts
+// don't trip the rate limiter.
+let requestChain: Promise<unknown> = Promise.resolve();
+let lastRequestAt = 0;
+
+function schedule<T>(task: () => Promise<T>): Promise<T> {
+    const run = async (): Promise<T> => {
+        const wait = lastRequestAt + MIN_REQUEST_SPACING_MS - Date.now();
+        if (wait > 0) {
+            await delay(wait);
+        }
+        try {
+            return await task();
+        } finally {
+            lastRequestAt = Date.now();
+        }
+    };
+
+    const result = requestChain.then(run, run);
+    // Keep the chain alive regardless of how the individual task settled.
+    requestChain = result.then(
+        () => undefined,
+        () => undefined,
+    );
+    return result;
+}
+
+function parseRetryAfter(header: string | null): number | null {
+    if (!header) {
+        return null;
+    }
+    const seconds = Number(header);
+    if (Number.isFinite(seconds)) {
+        return Math.max(0, seconds * 1000);
+    }
+    const dateMs = Date.parse(header);
+    if (!Number.isNaN(dateMs)) {
+        return Math.max(0, dateMs - Date.now());
+    }
+    return null;
+}
+
+function backoffDelay(attempt: number, retryAfterMs: number | null): number {
+    if (retryAfterMs !== null) {
+        return Math.min(retryAfterMs, MAX_BACKOFF_MS);
+    }
+    const exponential = Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS);
+    // Full jitter keeps multiple clients from retrying in lockstep.
+    return Math.random() * exponential;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function buildInitialUrl(filter: string): string {

--- a/src/panels/KickstartClusterPanel.ts
+++ b/src/panels/KickstartClusterPanel.ts
@@ -9,6 +9,7 @@ import {
     ProvisionedClusterInfo,
     handoffClusterToChat,
 } from "../commands/aksKickstart/kickstartChat";
+import { getKubeloginBinaryPath } from "../commands/utils/helper/kubeloginDownload";
 import { MessageHandler, MessageSink } from "../webview-contract/messaging";
 import {
     ClusterLaunchContext,
@@ -50,6 +51,7 @@ export class KickstartClusterPanel extends BasePanel<"kickstartCluster"> {
             subscriptionScanComplete: null,
             preflightComplete: null,
             finishComplete: null,
+            clusterChatReady: null,
             getCostEstimateResponse: null,
             existingReadinessComplete: null,
             awaitingProvisioningAccess: null,
@@ -136,6 +138,14 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
     private provisioningInFlight: Promise<void> | null = null;
     private activeProvisioningToken: CancellationToken | undefined;
     private runGeneration = 0;
+    // True once the active run reported a successful finishComplete. Drives whether a chat handoff
+    // describes the cluster as ready vs. still provisioning in the background.
+    private provisioningComplete = false;
+    // kubelogin is fetched in the background as soon as cluster setup starts so the chat handoff can
+    // point the agent at an already-installed binary (AKS Automatic disables local accounts, so the
+    // agent always needs kubelogin) instead of having it download its own copy.
+    private kubeloginPath: string | null = null;
+    private kubeloginReady: Promise<void> | null = null;
 
     constructor(
         private readonly sessionProvider: ReadyAzureSessionProvider,
@@ -290,7 +300,20 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
     private async handleFinish(webview: MessageSink<ToWebViewMsgDef>, selections: ClusterSelections) {
         this.lastFinish = () => this.handleFinish(webview, selections);
         await this.context.globalState.update(LAST_SUBSCRIPTION_KEY, selections.subscriptionId);
+        // Start fetching kubelogin now (once, reused across retries) so it's ready to hand to the agent
+        // by the time the user continues in chat, without blocking provisioning.
+        this.kubeloginReady ??= this.ensureKubeloginBinary();
         const runId = this.nextRunId++;
+        const toProvisioned = (result: ClusterProvisioningResult): ProvisionedClusterInfo => ({
+            subscriptionName: selections.subscriptionName,
+            subscriptionId: selections.subscriptionId,
+            resourceGroupName: selections.resourceGroupName,
+            clusterName: result.clusterName,
+            clusterPortalUrl: result.clusterPortalUrl,
+            acrName: result.acrName,
+            acrLoginServer: result.acrLoginServer,
+            kubeloginPath: this.kubeloginPath,
+        });
         const run = createClusterProvisioningRun(
             this.sessionProvider,
             selections,
@@ -306,16 +329,21 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
                     () => webview.postAwaitingProvisioningAccess(prompt),
                 );
             },
+            // Fired once the kubelet identity is granted AcrPull, while the cluster is still
+            // provisioning. Lets the user resume chat (Phases 3–4 don't need a ready cluster) in
+            // parallel with the background cluster create + role-assignment propagation.
+            (result) => this.handleClusterChatReady(webview, toProvisioned(result)),
         );
-        await this.startProvisioningRun(webview, run, (result) => ({
-            subscriptionName: selections.subscriptionName,
-            subscriptionId: selections.subscriptionId,
-            resourceGroupName: selections.resourceGroupName,
-            clusterName: result.clusterName,
-            clusterPortalUrl: result.clusterPortalUrl,
-            acrName: result.acrName,
-            acrLoginServer: result.acrLoginServer,
-        }));
+        await this.startProvisioningRun(webview, run, toProvisioned);
+    }
+
+    private handleClusterChatReady(webview: MessageSink<ToWebViewMsgDef>, info: ProvisionedClusterInfo) {
+        // Ignore a late callback from an attempt the user already abandoned (Back to setup nulls the run).
+        if (!this.activeRun) {
+            return;
+        }
+        this.lastProvisioned = info;
+        webview.postClusterChatReady();
     }
 
     private async handleRetry() {
@@ -330,6 +358,7 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
         toProvisioned: (result: ClusterProvisioningResult) => ProvisionedClusterInfo,
     ) {
         this.activeRun = { run, webview, toProvisioned };
+        this.provisioningComplete = false;
         await this.runProvisioningAttempt(undefined);
     }
 
@@ -360,6 +389,7 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
                 }
                 if (result.succeeded) {
                     this.lastProvisioned = active.toProvisioned(result);
+                    this.provisioningComplete = true;
                 }
                 active.webview.postFinishComplete(result);
             } catch (e) {
@@ -401,6 +431,7 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
         this.activeRun = null;
         this.activeProvisioningToken = undefined;
         this.provisioningInFlight = null;
+        this.provisioningComplete = false;
     }
 
     private handleRecheckProvisioningPermission(runId: number) {
@@ -443,6 +474,7 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
     private async handleUseExistingCluster(webview: MessageSink<ToWebViewMsgDef>, selection: ExistingClusterSelection) {
         this.lastFinish = () => this.handleUseExistingCluster(webview, selection);
         await this.context.globalState.update(LAST_SUBSCRIPTION_KEY, selection.subscriptionId);
+        this.kubeloginReady ??= this.ensureKubeloginBinary();
         const runId = this.nextRunId++;
         const run = createExistingClusterAttachRun(
             this.sessionProvider,
@@ -450,6 +482,15 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
             runId,
             webview,
             getKickstartOutputChannel(),
+            (prompt, probe) => {
+                webview.postAwaitingProvisioningAccess(prompt);
+                return this.provisioningGate.waitForAccess(
+                    prompt.runId,
+                    probe,
+                    () => webview.postProvisioningAccessResolved({ runId: prompt.runId }),
+                    () => webview.postAwaitingProvisioningAccess(prompt),
+                );
+            },
         );
         await this.startProvisioningRun(webview, run, (result) => ({
             subscriptionName: selection.subscriptionName,
@@ -459,6 +500,7 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
             clusterPortalUrl: result.clusterPortalUrl,
             acrName: result.acrName,
             acrLoginServer: result.acrLoginServer,
+            kubeloginPath: this.kubeloginPath,
         }));
     }
 
@@ -483,9 +525,20 @@ export class KickstartClusterDataProvider implements PanelDataProvider<"kickstar
         webview.postExistingReadinessComplete({ readiness, requestKey: args.requestKey });
     }
 
+    private async ensureKubeloginBinary(): Promise<void> {
+        const result = await getKubeloginBinaryPath();
+        this.kubeloginPath = result.succeeded ? result.result : null;
+    }
+
     private async handleContinueInChat() {
         if (this.lastProvisioned) {
-            await handoffClusterToChat(this.lastProvisioned);
+            // Make sure the background kubelogin download started at setup has settled so the handoff
+            // can point the agent at the binary (or cleanly omit it if the download failed).
+            await this.kubeloginReady;
+            await handoffClusterToChat(
+                { ...this.lastProvisioned, kubeloginPath: this.kubeloginPath },
+                { stillProvisioning: !this.provisioningComplete },
+            );
         }
     }
 }

--- a/src/panels/kickstartActivity.ts
+++ b/src/panels/kickstartActivity.ts
@@ -82,6 +82,14 @@ function timestamp(): string {
     return `[${new Date().toISOString()}]`;
 }
 
+/** Optional structured progress a `run()` body can report alongside its status detail. */
+export interface ProgressExtra {
+    /** Determinate progress 0–100 for a progress bar. */
+    progress?: number;
+    /** Monospace value (object ID, role GUID, …) shown after the detail. */
+    code?: string;
+}
+
 export interface PollUntilOptions<T> {
     intervalMs: number;
     timeoutMs: number;
@@ -164,14 +172,22 @@ export class StageReporter {
 
     async run<T>(
         action: string,
-        fn: (reportProgress: (detail: string) => void) => Promise<T>,
+        fn: (reportProgress: (detail: string, extra?: ProgressExtra) => void) => Promise<T>,
         describe?: (result: T) => string | undefined,
     ): Promise<T> {
-        const index = this.entries.push({ action, status: "running" }) - 1;
+        const startedAt = Date.now();
+        const index = this.entries.push({ action, status: "running", startedAt }) - 1;
         this.post();
-        const reportProgress = (detail: string): void => {
+        const reportProgress = (detail: string, extra?: ProgressExtra): void => {
             if (this.entries[index]?.status === "running") {
-                this.entries[index] = { action, status: "running", detail };
+                this.entries[index] = {
+                    action,
+                    status: "running",
+                    detail,
+                    progress: extra?.progress,
+                    code: extra?.code,
+                    startedAt,
+                };
                 this.post();
             }
         };
@@ -179,12 +195,12 @@ export class StageReporter {
             const { result, elapsedMs } = await withTiming(this.channel, `[${this.stage}] ${action}`, () =>
                 fn(reportProgress),
             );
-            this.entries[index] = { action, status: "succeeded", elapsedMs, detail: describe?.(result) };
+            this.entries[index] = { action, status: "succeeded", elapsedMs, detail: describe?.(result), startedAt };
             this.post();
             return result;
         } catch (e) {
             const status: ActivityStatus = this.token.isCancelled ? "cancelled" : "failed";
-            this.entries[index] = { action, status, detail: getErrorMessage(e) };
+            this.entries[index] = { action, status, detail: getErrorMessage(e), startedAt };
             this.post();
             throw e;
         }
@@ -194,8 +210,8 @@ export class StageReporter {
         this.finish("succeeded", detail);
     }
 
-    warn(detail?: string): void {
-        this.finish("warning", detail);
+    warn(detail?: string, fullError?: string): void {
+        this.finish("warning", detail, fullError);
     }
 
     fail(detail?: string, fullError?: string): void {
@@ -208,7 +224,24 @@ export class StageReporter {
      * row in the activity list rather than as one timed `run()` entry.
      */
     addEntry(entry: ActivityEntry): void {
-        this.entries.push(entry);
+        this.entries.push({ startedAt: Date.now(), ...entry });
+        this.post();
+    }
+
+    /**
+     * Add an entry, or update the existing one with the same `action` in place. Lets a single
+     * logical step (e.g. image-pull pre-authorization) advance through pending → running → done as
+     * one row instead of stacking duplicate rows. The original {@link ActivityEntry.startedAt} is
+     * preserved across updates unless the caller supplies a new one — so a pending placeholder can
+     * stay timestamp-less until the work actually starts.
+     */
+    upsertEntry(entry: ActivityEntry): void {
+        const index = this.entries.findIndex((e) => e.action === entry.action);
+        if (index >= 0) {
+            this.entries[index] = { ...entry, startedAt: entry.startedAt ?? this.entries[index].startedAt };
+        } else {
+            this.entries.push(entry);
+        }
         this.post();
     }
 

--- a/src/panels/kickstartProvision.ts
+++ b/src/panels/kickstartProvision.ts
@@ -14,6 +14,7 @@ import {
     canCreateRoleAssignmentsAtResourceGroup,
     createRoleAssignment,
     findEligiblePimGrants,
+    getPrincipalRoleAssignmentsForAcr,
     getScopeForAcr,
     getScopeForCluster,
 } from "../commands/utils/roleAssignments";
@@ -33,16 +34,37 @@ import {
     delay,
     formatElapsed,
     pollUntil,
+    ProgressExtra,
     StageReporter,
 } from "./kickstartActivity";
-import { checkDeploymentPermissions } from "../commands/aksCheckPermissions/checkDeploymentPermissions";
+import {
+    ACR_PULL_DATAACTION,
+    checkDeploymentPermissions,
+} from "../commands/aksCheckPermissions/checkDeploymentPermissions";
 
 const DEPLOYMENT_API_VERSION = "2021-04-01";
 
 const VERIFY_POLL_INTERVAL_MS = 3000;
-const VERIFY_POLL_TIMEOUT_MS = 90000;
+// The AcrPull role assignment is created synchronously (an idempotent PUT), which is our authoritative
+// "granted" signal. Observing it replicate through Azure AD is best-effort and non-fatal, so we only
+// give it a short grace poll for live confirmation before downgrading to a soft "still propagating"
+// warning rather than blocking provisioning. A brand-new kubelet identity can take several minutes to
+// replicate, but the user doesn't need to wait that out — Design/Generate don't need pull access, and
+// pulls only happen later at deploy time.
+const PULL_PROPAGATION_GRACE_MS = 45000;
 const CLUSTER_POLL_INTERVAL_MS = 15000;
 const CLUSTER_POLL_TIMEOUT_MS = 1_800_000;
+// Don't pre-assign AcrPull and hand back to chat the instant the kubelet identity appears — it can
+// surface within the first ~30-90s, before we can be confident the create is genuinely underway.
+// Fast-fail creates (quota, capacity, policy) usually surface in the first couple of minutes, so we
+// require the cluster to have been actively "Creating" for at least this long first. That gives a high
+// probability the create will actually finish before we detach the user into chat, at the cost of only
+// ~2 of the ~15 provisioning minutes of phase overlap.
+const MIN_CREATING_DWELL_MS = 120000;
+// AKS Automatic clusters typically take ~15 minutes to provision. We have no server-provided
+// percentage, so we drive a determinate progress bar from elapsed time against this estimate,
+// capped below 100% until the real "Succeeded" state arrives.
+const ESTIMATED_CLUSTER_CREATE_MS = 15 * 60 * 1000;
 
 export type WaitForProvisioningAccess = (
     prompt: ProvisioningAccessPrompt,
@@ -56,7 +78,14 @@ interface DeploymentIdentity {
 
 interface ClusterDeploymentProgress {
     token: CancellationToken;
-    reportProgress: (detail: string) => void;
+    reportProgress: (detail: string, extra?: ProgressExtra) => void;
+    /**
+     * Invoked (at most once) with the cluster's kubelet identity object ID as soon as it appears in
+     * the cluster's `identityProfile` during provisioning, before the cluster reaches "Succeeded".
+     * Lets the caller pre-assign AcrPull early so it propagates through Azure AD while the cluster
+     * finishes creating.
+     */
+    onKubeletIdentity?: (kubeletObjectId: string) => void;
 }
 
 export interface ClusterProvisioningResult {
@@ -144,6 +173,7 @@ export function createClusterProvisioningRun(
     sink: ActivitySink,
     channel: OutputChannel,
     waitForAccess: WaitForProvisioningAccess,
+    onChatReady?: (result: ClusterProvisioningResult) => void,
 ): ProvisioningRun {
     const result: ClusterProvisioningResult = {
         succeeded: false,
@@ -197,7 +227,16 @@ export function createClusterProvisioningRun(
                     return "continue";
                 }
 
-                const prompt = await buildProvisioningAccessPrompt(authClient, selections, runId, channel);
+                const prompt = await buildProvisioningAccessPrompt(
+                    authClient,
+                    {
+                        subscriptionId: selections.subscriptionId,
+                        tenantId: selections.tenantId,
+                        resourceGroupName: selections.resourceGroupName,
+                    },
+                    runId,
+                    channel,
+                );
                 const granted = await stage.run(
                     l10n.t("Waiting for permission to assign roles in {0}", selections.resourceGroupName),
                     () => waitForAccess(prompt, probeRoleAssignmentAccess),
@@ -213,49 +252,6 @@ export function createClusterProvisioningRun(
                 }
                 stage.succeed(l10n.t("You can now assign roles in {0}.", selections.resourceGroupName));
                 return "continue";
-            },
-        },
-        {
-            id: "cluster",
-            title: l10n.t("AKS Automatic cluster"),
-            execute: async (stage, token) => {
-                try {
-                    const kubernetesVersion = await stage.run(
-                        l10n.t("Selecting Kubernetes version"),
-                        () =>
-                            resolveDefaultKubernetesVersion(
-                                sessionProvider,
-                                selections.subscriptionId,
-                                selections.location,
-                            ),
-                        (version) => version,
-                    );
-                    const identity = await stage.run(l10n.t("Resolving your account identity"), () =>
-                        resolveDeploymentIdentity(sessionProvider),
-                    );
-                    // Reuse the same deployment name across retries so a re-run reconciles the existing
-                    // deployment instead of starting a competing one.
-                    context.clusterDeploymentName ??= `${selections.clusterName}-${Math.random().toString(36).substring(5)}`;
-                    const deploymentName = context.clusterDeploymentName;
-                    result.clusterPortalUrl = await stage.run(
-                        l10n.t("Deploying cluster — this can take several minutes"),
-                        (reportProgress) =>
-                            deployAutomaticCluster(
-                                sessionProvider,
-                                selections,
-                                kubernetesVersion,
-                                identity,
-                                true,
-                                deploymentName,
-                                { token, reportProgress },
-                            ),
-                    );
-                    stage.succeed(l10n.t("Cluster {0} is ready.", selections.clusterName));
-                    return "continue";
-                } catch (e) {
-                    stage.fail(getDeploymentErrorMessage(e), getDeploymentErrorDetails(e));
-                    return "halt";
-                }
             },
         },
         {
@@ -290,15 +286,183 @@ export function createClusterProvisioningRun(
             },
         },
         {
+            id: "cluster",
+            title: l10n.t("AKS Automatic cluster"),
+            execute: async (stage, token) => {
+                try {
+                    const kubernetesVersion = await stage.run(
+                        l10n.t("Selecting Kubernetes version"),
+                        () =>
+                            resolveDefaultKubernetesVersion(
+                                sessionProvider,
+                                selections.subscriptionId,
+                                selections.location,
+                            ),
+                        (version) => version,
+                    );
+                    const identity = await stage.run(l10n.t("Resolving your account identity"), () =>
+                        resolveDeploymentIdentity(sessionProvider),
+                    );
+                    // Reuse the same deployment name across retries so a re-run reconciles the existing
+                    // deployment instead of starting a competing one.
+                    context.clusterDeploymentName ??= `${selections.clusterName}-${Math.random().toString(36).substring(5)}`;
+                    const deploymentName = context.clusterDeploymentName;
+
+                    // Pre-authorize image pulls as early as possible. The kubelet identity appears in the
+                    // cluster's identityProfile minutes before provisioning completes, and the ACR already
+                    // exists (created in the previous stage). Assigning AcrPull now lets the role assignment
+                    // propagate through Azure AD while the cluster finishes, so the later verify step
+                    // usually passes immediately instead of waiting on brand-new-identity replication lag.
+                    const preauthAction = l10n.t("Pre-authorize image pulls");
+                    let earlyGrant: Promise<void> | undefined;
+                    const grantAcrPullEarly = (kubeletObjectId: string): void => {
+                        if (earlyGrant) {
+                            return; // one-shot
+                        }
+                        // The kubelet identity surfaced — flip the pending row to "assigning" and stamp
+                        // startedAt now so the row records when the pre-authorization actually ran.
+                        stage.upsertEntry({
+                            action: preauthAction,
+                            status: "running",
+                            detail: l10n.t("Found the kubelet identity — assigning AcrPull…"),
+                            code: kubeletObjectId,
+                            startedAt: Date.now(),
+                        });
+                        earlyGrant = (async () => {
+                            try {
+                                const authClient = getAuthorizationManagementClient(
+                                    sessionProvider,
+                                    selections.subscriptionId,
+                                );
+                                await grantAcrPull(
+                                    authClient,
+                                    selections.subscriptionId,
+                                    kubeletObjectId,
+                                    selections.resourceGroupName,
+                                    selections.acrName,
+                                );
+                                stage.upsertEntry({
+                                    action: preauthAction,
+                                    status: "succeeded",
+                                    detail: l10n.t(
+                                        "Assigned AcrPull to the kubelet identity while the cluster finished provisioning, giving Azure AD time to propagate it.",
+                                    ),
+                                    code: kubeletObjectId,
+                                });
+                                // The kubelet identity now holds AcrPull and the cluster create is well
+                                // underway, so hand back to chat early. The portal URL is deterministic
+                                // from the cluster's ARM id (the create returns the same value later), and
+                                // Phases 3–4 (Design/Generate) don't need the cluster to be ready — letting
+                                // the user resume in chat while the create + RBAC propagation finish in the
+                                // background.
+                                result.clusterPortalUrl ??= getPortalResourceUrl(
+                                    getEnvironment(),
+                                    getScopeForCluster(
+                                        selections.subscriptionId,
+                                        selections.resourceGroupName,
+                                        selections.clusterName,
+                                    ),
+                                );
+                                onChatReady?.(result);
+                                // Confirm the brand-new assignment is actually observable while the cluster
+                                // is still provisioning, so the user sees pull access go live rather than
+                                // just "assigned". Non-fatal: the dedicated verify stage re-checks afterwards.
+                                await confirmEarlyPullAccess(
+                                    stage,
+                                    token,
+                                    {
+                                        subscriptionId: selections.subscriptionId,
+                                        resourceGroup: selections.resourceGroupName,
+                                        clusterName: selections.clusterName,
+                                        acrName: selections.acrName,
+                                    },
+                                    kubeletObjectId,
+                                );
+                            } catch (e) {
+                                // Non-fatal: the dedicated attach/verify stages reconcile this grant afterwards.
+                                stage.upsertEntry({
+                                    action: preauthAction,
+                                    status: "warning",
+                                    detail: l10n.t(
+                                        "Couldn't pre-assign AcrPull yet ({0}); the connect step will assign it once the cluster is ready.",
+                                        getErrorMessage(e),
+                                    ),
+                                    code: kubeletObjectId,
+                                });
+                            }
+                        })();
+                    };
+
+                    result.clusterPortalUrl = await stage.run(
+                        l10n.t("Deploying cluster — this can take several minutes"),
+                        (reportProgress) => {
+                            // Surface the pre-authorization as pending the moment cluster create starts, so
+                            // the user can see we're polling for the kubelet identity to pre-grant pulls.
+                            stage.upsertEntry({
+                                action: preauthAction,
+                                status: "running",
+                                detail: l10n.t(
+                                    "Polling for the cluster's kubelet identity to pre-authorize image pulls…",
+                                ),
+                            });
+                            return deployAutomaticCluster(
+                                sessionProvider,
+                                selections,
+                                kubernetesVersion,
+                                identity,
+                                true,
+                                deploymentName,
+                                { token, reportProgress, onKubeletIdentity: grantAcrPullEarly },
+                            );
+                        },
+                    );
+                    // Let any in-flight early grant + propagation check finish reporting before the stage closes.
+                    await earlyGrant;
+                    if (!earlyGrant) {
+                        // The kubelet identity never surfaced during provisioning (rare); the attach/verify
+                        // stages will assign and confirm pull access once the cluster is ready.
+                        stage.upsertEntry({
+                            action: preauthAction,
+                            status: "warning",
+                            detail: l10n.t(
+                                "The kubelet identity didn't appear before the cluster finished; the connect step will assign pull access.",
+                            ),
+                        });
+                    }
+                    stage.succeed(l10n.t("Cluster {0} is ready.", selections.clusterName));
+                    return "continue";
+                } catch (e) {
+                    stage.fail(getDeploymentErrorMessage(e), getDeploymentErrorDetails(e));
+                    return "halt";
+                }
+            },
+        },
+        {
             id: "attach",
             title: l10n.t("Connect registry to cluster"),
             execute: async (stage) => {
                 try {
-                    await stage.run(l10n.t("Granting the cluster permission to pull images"), () =>
+                    const principalId = await stage.run(l10n.t("Granting the cluster permission to pull images"), () =>
                         attachAcrToCluster(sessionProvider, selections),
                     );
+                    stage.addEntry({
+                        action: l10n.t("Cluster kubelet identity"),
+                        status: "succeeded",
+                        detail: l10n.t("Assigned the AcrPull role to the cluster's kubelet identity."),
+                        code: principalId,
+                    });
+                    stage.addEntry({
+                        action: l10n.t("AcrPull role definition"),
+                        status: "succeeded",
+                        detail: l10n.t("Built-in role granting `{0}`.", ACR_PULL_DATAACTION),
+                        code: acrPullRoleDefinitionName,
+                    });
                     stage.succeed(
-                        l10n.t("{0} can now pull images from {1}.", selections.clusterName, selections.acrName),
+                        l10n.t(
+                            "Assigned AcrPull on {1} to {0}. A brand-new cluster identity can take a few minutes to propagate through Azure AD before pulls succeed.",
+                            selections.clusterName,
+                            selections.acrName,
+                        ),
                     );
                 } catch (e) {
                     stage.fail(getErrorMessage(e));
@@ -329,11 +493,11 @@ export function createClusterProvisioningRun(
 
 async function buildProvisioningAccessPrompt(
     client: AuthorizationManagementClient,
-    selections: ClusterSelections,
+    args: { subscriptionId: string; tenantId: string; resourceGroupName: string },
     runId: number,
     channel: OutputChannel,
 ): Promise<ProvisioningAccessPrompt> {
-    const resourceGroupScope = `/subscriptions/${selections.subscriptionId}/resourceGroups/${selections.resourceGroupName}`;
+    const resourceGroupScope = `/subscriptions/${args.subscriptionId}/resourceGroups/${args.resourceGroupName}`;
     const eligible = await findEligiblePimGrants(client, resourceGroupScope, (msg) => channel.appendLine(msg));
     const eligiblePimGrants: PimEligibleGrant[] =
         !failed(eligible) && eligible.result.length > 0
@@ -343,17 +507,17 @@ async function buildProvisioningAccessPrompt(
                   scopeDisplayName: grant.scopeDisplayName ?? grant.scopeId,
               }))
             : [];
-    const permissionActionUrl = getPortalScopeAccessUrl(getEnvironment(), selections.tenantId, resourceGroupScope);
+    const permissionActionUrl = getPortalScopeAccessUrl(getEnvironment(), args.tenantId, resourceGroupScope);
     const detail =
         eligiblePimGrants.length > 0
             ? l10n.t("Activate an eligible role in Privileged Identity Management, then select Re-check to continue.")
             : l10n.t(
                   "You don't have an eligible role that can assign roles in {0}. Ask an administrator for access, then select Re-check.",
-                  selections.resourceGroupName,
+                  args.resourceGroupName,
               );
     return {
         runId,
-        resourceGroupName: selections.resourceGroupName,
+        resourceGroupName: args.resourceGroupName,
         eligiblePimGrants,
         permissionActionUrl,
         detail,
@@ -366,6 +530,7 @@ export function createExistingClusterAttachRun(
     runId: number,
     sink: ActivitySink,
     channel: OutputChannel,
+    waitForAccess: WaitForProvisioningAccess,
 ): ProvisioningRun {
     const result: ClusterProvisioningResult = {
         succeeded: false,
@@ -448,31 +613,120 @@ export function createExistingClusterAttachRun(
             },
         },
         {
+            id: "roleAccess",
+            title: l10n.t("Role assignment access"),
+            execute: async (stage) => {
+                const authClient = getAuthorizationManagementClient(sessionProvider, selection.subscriptionId);
+
+                // Decide whether this run will need to assign AcrPull. A brand-new ACR always does. For an
+                // existing ACR we re-check the kubelet's live assignments rather than trusting the
+                // point-in-time "connected" snapshot from cluster selection — if it already holds AcrPull
+                // no role assignment is needed and we can skip the permission gate entirely.
+                let needsGrant = selection.createNewAcr;
+                if (!needsGrant) {
+                    try {
+                        const kubeletPrincipalId = await resolveClusterKubeletPrincipalId(
+                            sessionProvider,
+                            selection.subscriptionId,
+                            selection.clusterResourceGroup,
+                            selection.clusterName,
+                        );
+                        needsGrant = !(await kubeletHasAcrPull(
+                            authClient,
+                            kubeletPrincipalId,
+                            selection.acrResourceGroup,
+                            selection.acrName,
+                        ));
+                    } catch {
+                        // Couldn't confirm the current assignment — gate defensively so that a grant we
+                        // end up needing in the attach stage doesn't hard-fail on missing permission.
+                        needsGrant = true;
+                    }
+                }
+
+                if (!needsGrant) {
+                    stage.succeed(
+                        l10n.t(
+                            "{0} already holds AcrPull on {1}; no role assignment is needed.",
+                            selection.clusterName,
+                            selection.acrName,
+                        ),
+                    );
+                    return "continue";
+                }
+
+                // AcrPull is assigned at the registry's resource group, so that's where we need
+                // Microsoft.Authorization/roleAssignments/write.
+                const probeRoleAssignmentAccess = async (): Promise<boolean> => {
+                    try {
+                        const verdict = await canCreateRoleAssignmentsAtResourceGroup(
+                            authClient,
+                            selection.acrResourceGroup,
+                        );
+                        return !failed(verdict) && verdict.result.canCreate;
+                    } catch {
+                        return false;
+                    }
+                };
+
+                if (await probeRoleAssignmentAccess()) {
+                    stage.succeed(l10n.t("You can assign roles in {0}.", selection.acrResourceGroup));
+                    return "continue";
+                }
+
+                const prompt = await buildProvisioningAccessPrompt(
+                    authClient,
+                    {
+                        subscriptionId: selection.subscriptionId,
+                        tenantId: selection.tenantId,
+                        resourceGroupName: selection.acrResourceGroup,
+                    },
+                    runId,
+                    channel,
+                );
+                const granted = await stage.run(
+                    l10n.t("Waiting for permission to assign roles in {0}", selection.acrResourceGroup),
+                    () => waitForAccess(prompt, probeRoleAssignmentAccess),
+                );
+                if (!granted) {
+                    stage.fail(
+                        l10n.t(
+                            "Couldn't connect {0} to {1} because permission to assign roles in {2} wasn't granted.",
+                            selection.clusterName,
+                            selection.acrName,
+                            selection.acrResourceGroup,
+                        ),
+                    );
+                    return "halt";
+                }
+                stage.succeed(l10n.t("You can now assign roles in {0}.", selection.acrResourceGroup));
+                return "continue";
+            },
+        },
+        {
             id: "attach",
             title: l10n.t("Connect registry to cluster"),
             execute: async (stage) => {
                 try {
-                    if (selection.createNewAcr) {
-                        await stage.run(l10n.t("Granting the cluster permission to pull images"), async () => {
-                            const kubeletPrincipalId = await resolveClusterKubeletPrincipalId(
-                                sessionProvider,
-                                selection.subscriptionId,
-                                selection.clusterResourceGroup,
-                                selection.clusterName,
-                            );
-                            const client = getAuthorizationManagementClient(sessionProvider, selection.subscriptionId);
-                            await grantAcrPull(
-                                client,
-                                selection.subscriptionId,
-                                kubeletPrincipalId,
-                                selection.acrResourceGroup,
-                                selection.acrName,
-                            );
-                        });
-                        stage.succeed(
-                            l10n.t("{0} can now pull images from {1}.", selection.clusterName, selection.acrName),
-                        );
-                    } else {
+                    const client = getAuthorizationManagementClient(sessionProvider, selection.subscriptionId);
+                    const kubeletPrincipalId = await resolveClusterKubeletPrincipalId(
+                        sessionProvider,
+                        selection.subscriptionId,
+                        selection.clusterResourceGroup,
+                        selection.clusterName,
+                    );
+                    // Re-check the live assignment on every run (including retries) so a failed verify can
+                    // self-heal: if AcrPull is missing we (idempotently) (re)grant it instead of assuming
+                    // the cluster is already connected.
+                    const alreadyConnected =
+                        !selection.createNewAcr &&
+                        (await kubeletHasAcrPull(
+                            client,
+                            kubeletPrincipalId,
+                            selection.acrResourceGroup,
+                            selection.acrName,
+                        ));
+                    if (alreadyConnected) {
                         stage.succeed(
                             l10n.t(
                                 "{0} is already connected to {1}, so no permission changes are needed.",
@@ -480,7 +734,20 @@ export function createExistingClusterAttachRun(
                                 selection.acrName,
                             ),
                         );
+                        return "continue";
                     }
+                    await stage.run(l10n.t("Granting the cluster permission to pull images"), () =>
+                        grantAcrPull(
+                            client,
+                            selection.subscriptionId,
+                            kubeletPrincipalId,
+                            selection.acrResourceGroup,
+                            selection.acrName,
+                        ),
+                    );
+                    stage.succeed(
+                        l10n.t("{0} can now pull images from {1}.", selection.clusterName, selection.acrName),
+                    );
                     return "continue";
                 } catch (e) {
                     stage.fail(getErrorMessage(e));
@@ -543,11 +810,14 @@ async function runDeploymentVerificationStage(
                 (r) => Boolean(r.error) || r.allPassed === true,
                 {
                     intervalMs: VERIFY_POLL_INTERVAL_MS,
-                    timeoutMs: VERIFY_POLL_TIMEOUT_MS,
+                    timeoutMs: PULL_PROPAGATION_GRACE_MS,
                     token,
                     onWait: (elapsedMs) =>
                         reportProgress(
-                            l10n.t("Waiting for the role assignment to take effect… ({0})", formatElapsed(elapsedMs)),
+                            l10n.t(
+                                "Waiting for the new role assignment to propagate through Azure AD… ({0})",
+                                formatElapsed(elapsedMs),
+                            ),
                         ),
                 },
             );
@@ -566,18 +836,95 @@ async function runDeploymentVerificationStage(
             action: probe.label,
             status: probeStatusToActivityStatus(probe.status),
             detail: probe.reason,
+            code: probe.principalId,
         });
     }
 
     if (probeResult.allPassed) {
         stage.succeed(l10n.t("The cluster can pull images from the registry."));
     } else {
+        const remediation = probes.find((p) => p.remediation)?.remediation;
         stage.warn(
             l10n.t(
-                "The cluster can't pull from the registry yet. Pods may fail to start until the AcrPull role is granted to the cluster's kubelet identity.",
+                "The AcrPull role is assigned, but the cluster can't pull from the registry yet — a brand-new kubelet identity can take several minutes to propagate through Azure AD. This usually clears on its own; retry to check again.",
             ),
+            remediation
+                ? l10n.t("If pulls keep failing, you can re-assign the role manually:\n\n{0}", remediation)
+                : undefined,
         );
     }
+}
+
+/**
+ * Polls the kubelet ACR-pull permission right after the early pre-authorization grant, while the
+ * cluster is still provisioning, and updates a single activity row from "checking" → "live" (or a
+ * soft "still propagating" warning). Lets the user watch the brand-new role assignment become
+ * effective instead of waiting until the post-create verify stage. Non-fatal by design.
+ */
+async function confirmEarlyPullAccess(
+    stage: StageReporter,
+    token: CancellationToken,
+    args: {
+        subscriptionId: string;
+        resourceGroup: string;
+        clusterName: string;
+        acrName?: string;
+        acrResourceGroup?: string;
+    },
+    kubeletObjectId: string,
+): Promise<void> {
+    const action = l10n.t("Confirm image pull access");
+    stage.upsertEntry({
+        action,
+        status: "running",
+        detail: l10n.t("Checking the AcrPull assignment has propagated through Azure AD…"),
+        code: kubeletObjectId,
+        startedAt: Date.now(),
+    });
+
+    const { result, timedOut } = await pollUntil(
+        () => checkDeploymentPermissions(undefined, { ...args, probeScope: "kubelet-pull", silent: true }),
+        (r) => Boolean(r.error) || r.allPassed === true,
+        {
+            intervalMs: VERIFY_POLL_INTERVAL_MS,
+            timeoutMs: PULL_PROPAGATION_GRACE_MS,
+            token,
+            onWait: (elapsedMs) =>
+                stage.upsertEntry({
+                    action,
+                    status: "running",
+                    detail: l10n.t(
+                        "Waiting for the AcrPull assignment to propagate through Azure AD… ({0})",
+                        formatElapsed(elapsedMs),
+                    ),
+                    code: kubeletObjectId,
+                }),
+        },
+    );
+
+    if (result.error) {
+        stage.upsertEntry({ action, status: "warning", detail: result.error, code: kubeletObjectId });
+        return;
+    }
+    if (result.allPassed) {
+        stage.upsertEntry({
+            action,
+            status: "succeeded",
+            detail: args.acrName
+                ? l10n.t("Image pull access is live — the cluster can pull from {0}.", args.acrName)
+                : l10n.t("Image pull access is live."),
+            code: kubeletObjectId,
+        });
+        return;
+    }
+    stage.upsertEntry({
+        action,
+        status: "warning",
+        detail: timedOut
+            ? l10n.t("Still propagating; the verify step will confirm once it settles.")
+            : l10n.t("Not effective yet; the verify step will confirm once it settles."),
+        code: kubeletObjectId,
+    });
 }
 
 function probeStatusToActivityStatus(status: "pass" | "fail" | "unknown"): ActivityStatus {
@@ -702,14 +1049,34 @@ async function tickClusterStatus(
         if (isSettled() || progress.token.isCancelled) {
             return;
         }
-        const elapsed = formatElapsed(performance.now() - start);
+        const elapsedMs = performance.now() - start;
+        const elapsed = formatElapsed(elapsedMs);
+        // ARM exposes no completion percentage for a cluster create, so estimate against a typical
+        // ~15-minute provisioning time. Cap below 100% so the bar never claims completion before the
+        // real "Succeeded" state arrives.
+        const pct = Math.min(95, Math.round((elapsedMs / ESTIMATED_CLUSTER_CREATE_MS) * 100));
         try {
             const cluster = await aksClient.managedClusters.get(selections.resourceGroupName, selections.clusterName);
+            // The kubelet identity is populated partway through provisioning. Surface it to pre-assign
+            // AcrPull and hand back to chat, but only once the cluster has been actively "Creating" for
+            // MIN_CREATING_DWELL_MS — so we detach with high confidence the create is genuinely underway
+            // rather than the instant the identity appears (when a fast-fail create could still be looming).
+            const identityProfile = cluster.identityProfile;
+            const kubeletObjectId =
+                identityProfile && "kubeletidentity" in identityProfile
+                    ? identityProfile.kubeletidentity?.objectId
+                    : undefined;
+            if (kubeletObjectId && elapsedMs >= MIN_CREATING_DWELL_MS && cluster.provisioningState === "Creating") {
+                progress.onKubeletIdentity?.(kubeletObjectId);
+            }
             progress.reportProgress(
                 l10n.t("Cluster status: {0} ({1})", cluster.provisioningState ?? "Creating", elapsed),
+                { progress: pct },
             );
         } catch {
-            progress.reportProgress(l10n.t("Waiting for the cluster to appear… ({0})", elapsed));
+            progress.reportProgress(l10n.t("Waiting for the cluster to appear… ({0})", elapsed), {
+                progress: pct,
+            });
         }
     }
 }
@@ -754,10 +1121,13 @@ async function pollClusterUntilTerminal(
             intervalMs: CLUSTER_POLL_INTERVAL_MS,
             timeoutMs: CLUSTER_POLL_TIMEOUT_MS,
             token: progress?.token ?? new CancellationToken(),
-            onWait: (elapsedMs, state) =>
+            onWait: (elapsedMs, state) => {
+                const pct = Math.min(95, Math.round((elapsedMs / ESTIMATED_CLUSTER_CREATE_MS) * 100));
                 progress?.reportProgress(
                     l10n.t("Cluster status: {0} ({1})", state ?? "Creating", formatElapsed(elapsedMs)),
-                ),
+                    { progress: pct },
+                );
+            },
         },
     );
     if (timedOut) {
@@ -774,7 +1144,7 @@ async function pollClusterUntilTerminal(
 async function attachAcrToCluster(
     sessionProvider: ReadyAzureSessionProvider,
     selections: ClusterSelections,
-): Promise<void> {
+): Promise<string> {
     const principalId = await resolveClusterKubeletPrincipalId(
         sessionProvider,
         selections.subscriptionId,
@@ -789,6 +1159,7 @@ async function attachAcrToCluster(
         selections.resourceGroupName,
         selections.acrName,
     );
+    return principalId;
 }
 
 async function grantAcrPull(
@@ -810,6 +1181,27 @@ async function grantAcrPull(
     if (failed(assignment)) {
         throw new Error(assignment.error);
     }
+}
+
+/**
+ * Returns true iff the given principal already holds the AcrPull role assignment on the registry.
+ * Used to defensively re-check the point-in-time "connected ACR" snapshot before deciding whether a
+ * (re)grant — and the role-assignment-write permission it requires — is actually needed. A failed
+ * lookup returns false so callers gate/grant defensively rather than assuming access exists.
+ */
+async function kubeletHasAcrPull(
+    client: AuthorizationManagementClient,
+    principalId: string,
+    acrResourceGroup: string,
+    acrName: string,
+): Promise<boolean> {
+    const assignments = await getPrincipalRoleAssignmentsForAcr(client, principalId, acrResourceGroup, acrName);
+    if (failed(assignments)) {
+        return false;
+    }
+    return assignments.result.some(
+        (ra) => (ra.roleDefinitionId?.split("/").pop() ?? "").toLowerCase() === acrPullRoleDefinitionName.toLowerCase(),
+    );
 }
 
 export async function resolveClusterKubeletPrincipalId(

--- a/src/panels/templates/AutomaticCreateCluster.json
+++ b/src/panels/templates/AutomaticCreateCluster.json
@@ -11,6 +11,12 @@
                 "description": "The name of the Managed Cluster resource."
             }
         },
+        "nodeResourceGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the resource group containing agent pool nodes. Supplied explicitly so it stays within the 80-character limit instead of relying on the AKS default."
+            }
+        },
         "location": {
             "type": "string",
             "metadata": {
@@ -71,6 +77,7 @@
             "name": "[parameters('resourceName')]",
             "dependsOn": [],
             "properties": {
+                "nodeResourceGroup": "[parameters('nodeResourceGroup')]",
                 "agentPoolProfiles": [
                     {
                         "name": "systempool",

--- a/src/panels/utilities/ClusterSpecCreationBuilder.ts
+++ b/src/panels/utilities/ClusterSpecCreationBuilder.ts
@@ -56,6 +56,9 @@ export class ClusterDeploymentBuilder {
             resourceName: {
                 value: clusterSpec.name,
             },
+            nodeResourceGroup: {
+                value: generateNodeResourceGroup(clusterSpec.resourceGroupName, clusterSpec.name, clusterSpec.location),
+            },
             apiVersion: {
                 value: deploymentApiVersionPreview,
             },

--- a/src/webview-contract/webviewDefinitions/kickstartCluster.ts
+++ b/src/webview-contract/webviewDefinitions/kickstartCluster.ts
@@ -143,6 +143,12 @@ export type ToWebViewMsgDef = {
         acrName: string;
         acrLoginServer: string | null;
     };
+    /**
+     * Fired once the cluster's kubelet identity has been granted AcrPull while the cluster is still
+     * provisioning, signalling that the user can hand back to chat early and let the background
+     * cluster create + role-assignment propagation finish in parallel.
+     */
+    clusterChatReady: void;
     awaitingProvisioningAccess: ProvisioningAccessPrompt;
     provisioningAccessResolved: { runId: number };
     getClustersResponse: { subscriptionId: string; clusters: ExistingCluster[] };

--- a/src/webview-contract/webviewDefinitions/kickstartShared.ts
+++ b/src/webview-contract/webviewDefinitions/kickstartShared.ts
@@ -29,6 +29,19 @@ export interface ActivityEntry {
     detail?: string;
     /** Optional URL — renders the action label as a clickable link. */
     url?: string;
+    /**
+     * Optional monospace value rendered after the detail — e.g. an identity object ID or a role
+     * definition GUID — so the user can see exactly which principal/role the step acted on.
+     */
+    code?: string;
+    /** Determinate progress (0–100) for long-running actions (e.g. cluster create); renders a bar. */
+    progress?: number;
+    /**
+     * Wall-clock time (epoch ms) the action's work began, rendered as a start timestamp. Lets the
+     * user see when a long-running step started (e.g. cluster create) and when a point-in-time event
+     * occurred (e.g. the AcrPull pre-authorization). Left unset while an entry is only pending/waiting.
+     */
+    startedAt?: number;
 }
 
 export interface ActivitySnapshot {

--- a/webview-ui/src/KickstartCluster/ClusterInput.tsx
+++ b/webview-ui/src/KickstartCluster/ClusterInput.tsx
@@ -76,6 +76,16 @@ function getValidatedRgName(value: string): Validatable<string> {
     return valid(value);
 }
 
+// AKS auto-generates the node resource group as MC_<rg>_<cluster>_<location>. Azure caps that name at
+// 80 characters. We supply a truncated name at deploy time (see generateNodeResourceGroup in
+// ClusterSpecCreationBuilder) so it never fails preflight, but we also warn here so the user can pick
+// shorter names up front instead of getting a silently truncated node resource group.
+const MAX_NODE_RESOURCE_GROUP_LENGTH = 80;
+
+function getNodeResourceGroupName(resourceGroupName: string, clusterName: string, location: string): string {
+    return `MC_${resourceGroupName}_${clusterName}_${location}`;
+}
+
 export function randomSuffix(length: number): string {
     const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
     return Array.from({ length }, () => chars.charAt(Math.floor(Math.random() * chars.length))).join("");
@@ -173,6 +183,16 @@ export function ClusterInput(props: ClusterInputProps) {
             ? newResourceGroupName.value
             : ""
         : existingResourceGroup;
+
+    // Once the cluster name, resource group, and region are all known, preview the AKS-generated node
+    // resource group name and warn when it would exceed Azure's 80-character cap (it gets truncated on
+    // deploy, but a heads-up lets the user choose tidier names).
+    const effectiveClusterName = isValid(clusterName) ? clusterName.value : "";
+    const prospectiveNodeResourceGroup =
+        preflightResourceGroupName && effectiveClusterName && currentLocation
+            ? getNodeResourceGroupName(preflightResourceGroupName, effectiveClusterName, currentLocation)
+            : "";
+    const nodeResourceGroupTooLong = prospectiveNodeResourceGroup.length > MAX_NODE_RESOURCE_GROUP_LENGTH;
 
     useEffect(() => {
         if (props.selectedSubscriptionId) {
@@ -664,6 +684,16 @@ export function ClusterInput(props: ClusterInputProps) {
                         }}
                     />
                     {renderValidationMessage(clusterName)}
+                    {nodeResourceGroupTooLong && (
+                        <span className={styles.validationMessage}>
+                            <FontAwesomeIcon className={styles.checkWarning} icon={faExclamationTriangle} />
+                            {l10n.t(
+                                "Heads up: the node resource group name (MC_…) would be {0} characters, over Azure's {1}-character limit, so it will be shortened automatically. Shorten the cluster name or resource group name for a cleaner name.",
+                                prospectiveNodeResourceGroup.length,
+                                MAX_NODE_RESOURCE_GROUP_LENGTH,
+                            )}
+                        </span>
+                    )}
                 </>
             )}
 

--- a/webview-ui/src/KickstartCluster/KickstartCluster.tsx
+++ b/webview-ui/src/KickstartCluster/KickstartCluster.tsx
@@ -178,7 +178,19 @@ export function KickstartCluster(initialState: InitialState) {
                             stages={state.activity.provision?.stages ?? []}
                             onRetryStage={handleRetryStage}
                         />
+                        {state.clusterChatReady && (
+                            <p>
+                                {l10n.t(
+                                    "The cluster's identity now has pull access to your registry, and the cluster is finishing in the background. You can continue in chat now — designing and generating your deployment files doesn't need the cluster to be ready.",
+                                )}
+                            </p>
+                        )}
                         <div className={styles.buttonContainer}>
+                            {state.clusterChatReady && (
+                                <button onClick={() => vscode.postContinueInChatRequest()}>
+                                    {l10n.t("Continue in chat")}
+                                </button>
+                            )}
                             <button className={styles.secondaryButton} onClick={handleBackToSetup}>
                                 {l10n.t("Back to setup")}
                             </button>

--- a/webview-ui/src/KickstartCluster/helpers/state.ts
+++ b/webview-ui/src/KickstartCluster/helpers/state.ts
@@ -76,6 +76,12 @@ export type KickstartClusterState = InitialState & {
     preflightGeneration: number;
     provisioningAccess: ProvisioningAccessPrompt | null;
     finishResult: FinishResult | null;
+    /**
+     * True once the extension reports the cluster's kubelet identity has been granted AcrPull while
+     * the cluster is still provisioning, so the Provisioning view can offer an early "Continue in
+     * chat" handoff. Persists across single-stage retries but resets on a fresh/abandoned run.
+     */
+    clusterChatReady: boolean;
     costEstimate: CostEstimateResult | null;
 };
 
@@ -132,6 +138,7 @@ export const stateUpdater: WebviewStateUpdater<"kickstartCluster", EventDef, Kic
         preflightGeneration: 0,
         provisioningAccess: null,
         finishResult: null,
+        clusterChatReady: false,
         costEstimate: null,
     }),
     vscodeMessageHandler: {
@@ -180,6 +187,7 @@ export const stateUpdater: WebviewStateUpdater<"kickstartCluster", EventDef, Kic
             finishResult: args,
             provisioningAccess: null,
         }),
+        clusterChatReady: (state) => ({ ...state, clusterChatReady: true }),
         awaitingProvisioningAccess: (state, args) => ({ ...state, provisioningAccess: args }),
         provisioningAccessResolved: (state, args) =>
             state.provisioningAccess && state.provisioningAccess.runId !== args.runId
@@ -255,13 +263,19 @@ export const stateUpdater: WebviewStateUpdater<"kickstartCluster", EventDef, Kic
             preflightGeneration: state.preflightGeneration + 1,
             activity: { ...state.activity, preflight: undefined },
         }),
-        setProvisioning: (state) => ({ ...state, stage: Stage.Provisioning, provisioningAccess: null }),
+        setProvisioning: (state) => ({
+            ...state,
+            stage: Stage.Provisioning,
+            provisioningAccess: null,
+            clusterChatReady: false,
+        }),
         retryProvisioning: (state) => ({
             ...state,
             stage: Stage.Provisioning,
             errorMessage: null,
             finishResult: null,
             provisioningAccess: null,
+            clusterChatReady: false,
             activity: { ...state.activity, provision: undefined },
         }),
         // Unlike retryProvisioning, this keeps activity.provision so the re-run's snapshots merge
@@ -281,6 +295,7 @@ export const stateUpdater: WebviewStateUpdater<"kickstartCluster", EventDef, Kic
             errorMessage: null,
             finishResult: null,
             provisioningAccess: null,
+            clusterChatReady: false,
             activity: { ...state.activity, provision: undefined },
         }),
         goToExistingClusterSelection: (state) => ({
@@ -289,6 +304,7 @@ export const stateUpdater: WebviewStateUpdater<"kickstartCluster", EventDef, Kic
             mode: "useExisting",
             errorMessage: null,
             finishResult: null,
+            clusterChatReady: false,
             selectedCluster: null,
             connectedAcrs: null,
             detectingAcrs: false,

--- a/webview-ui/src/components/ActivityStageList.module.css
+++ b/webview-ui/src/components/ActivityStageList.module.css
@@ -68,9 +68,54 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    flex-wrap: wrap;
     column-gap: 0.4rem;
+    row-gap: 0.2rem;
     font-size: 0.9em;
     color: var(--vscode-descriptionForeground);
+}
+
+.activityCode {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.9em;
+    color: var(--vscode-textPreformat-foreground);
+    background: var(--vscode-textCodeBlock-background);
+    border: 1px solid var(--vscode-widget-border);
+    border-radius: 3px;
+    padding: 0 0.3rem;
+    word-break: break-all;
+}
+
+.progressRow {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 0.5rem;
+    flex-basis: 100%;
+    width: 100%;
+    margin-top: 0.15rem;
+}
+
+.progressTrack {
+    flex: 1;
+    height: 0.4rem;
+    border-radius: 0.2rem;
+    background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.25));
+    border: 1px solid var(--vscode-widget-border);
+    overflow: hidden;
+}
+
+.progressFill {
+    display: block;
+    height: 100%;
+    background: var(--vscode-progressBar-background);
+    transition: width 0.3s ease;
+}
+
+.progressLabel {
+    font-variant-numeric: tabular-nums;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
 }
 
 .activityAction {
@@ -79,6 +124,14 @@
 
 .activityEntryDetail {
     color: var(--vscode-descriptionForeground);
+}
+
+.activityStarted {
+    font-variant-numeric: tabular-nums;
+    font-size: 0.95em;
+    color: var(--vscode-descriptionForeground);
+    opacity: 0.8;
+    white-space: nowrap;
 }
 
 .activityElapsed {

--- a/webview-ui/src/components/ActivityStageList.tsx
+++ b/webview-ui/src/components/ActivityStageList.tsx
@@ -55,6 +55,22 @@ export function formatElapsed(ms: number): string {
     return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
+function formatClock(epochMs: number): string {
+    return new Date(epochMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function ProgressBar({ progress }: { progress: number }) {
+    const pct = Math.max(0, Math.min(100, Math.round(progress)));
+    return (
+        <span className={styles.progressRow}>
+            <span className={styles.progressTrack}>
+                <span className={styles.progressFill} style={{ width: `${pct}%` }} />
+            </span>
+            <span className={styles.progressLabel}>{`${pct}%`}</span>
+        </span>
+    );
+}
+
 function StageFullError({ fullError }: { fullError: string }) {
     const [expanded, setExpanded] = useState(false);
     return (
@@ -88,10 +104,17 @@ function EntryRow({ entry }: { entry: ActivityEntry }) {
             ) : (
                 <span className={styles.activityAction}>{entry.action}</span>
             )}
+            {entry.startedAt !== undefined && (
+                <span className={styles.activityStarted} title={l10n.t("Started at {0}", formatClock(entry.startedAt))}>
+                    {formatClock(entry.startedAt)}
+                </span>
+            )}
             {entry.detail && <span className={styles.activityEntryDetail}>{entry.detail}</span>}
+            {entry.code && <code className={styles.activityCode}>{entry.code}</code>}
             {entry.elapsedMs !== undefined && (
                 <span className={styles.activityElapsed}>{formatElapsed(entry.elapsedMs)}</span>
             )}
+            {entry.progress !== undefined && <ProgressBar progress={entry.progress} />}
         </span>
     );
 }


### PR DESCRIPTION
- Add roleAccess gate and self-healing attach stage for existing clusters, mirroring the new-cluster waitForAccess/PIM flow but scoped to the ACR's resource group; skip the gate when the kubelet already holds AcrPull
- Fix AcrPull/AcrPush verify-probe false negative by matching the permission in either the actions or dataActions bucket (built-in AcrPull grants pull/read as an action, not a dataAction)
- Serialize retail price requests with backoff, dedupe, and cache to avoid 429s
- Truncate generated node resource group to 80 chars and warn in cluster input
- Add pull-propagation grace poll and minimum creating dwell; remove misleading ETA
- Hand off to kubelogin and hide terminal panels when launching kickstart
- Update agent and skill docs