### PR TITLE
fix(container-assist): stop managed namespace update command from overwriting existing annotations/labels

### DIFF
--- a/resources/yaml/aks-deploy-managed-ns.template.yaml
+++ b/resources/yaml/aks-deploy-managed-ns.template.yaml
@@ -115,17 +115,6 @@ jobs:
                       ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
                   namespace: ${{ env.NAMESPACE }}
 
-             # Annotates the namespace with workload identity metadata
-            - name: Annotate namespace
-              run: |
-                  az aks namespace update \
-                    --resource-group ${{ env.CLUSTER_RESOURCE_GROUP }} \
-                    --cluster-name ${{ env.CLUSTER_NAME }} \
-                    --name ${{ env.NAMESPACE }} \
-                    --annotations \
-                      aks-project/workload-identity-id="${{ secrets.AZURE_CLIENT_ID }}" \
-                      aks-project/workload-identity-tenant="${{ secrets.AZURE_TENANT_ID }}"
-
             # Annotates the deployed resources with metadata for traceability
             - name: Annotate deployment
               run: |

--- a/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
@@ -46,16 +46,6 @@
 { { IMAGES } }
                   namespace: ${{ env.NAMESPACE }}
 
-            - name: Annotate namespace
-              run: |
-                  az aks namespace update \
-                    --resource-group ${{ env.CLUSTER_RESOURCE_GROUP }} \
-                    --cluster-name ${{ env.CLUSTER_NAME }} \
-                    --name ${{ env.NAMESPACE }} \
-                    --annotations \
-                      aks-project/workload-identity-id="${{ secrets.AZURE_CLIENT_ID }}" \
-                      aks-project/workload-identity-tenant="${{ secrets.AZURE_TENANT_ID }}"
-
             - name: Annotate deployment
               run: |
                   if kubectl get deployment -n ${{ env.NAMESPACE }} --no-headers 2>/dev/null | grep -q .; then

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -38,6 +38,11 @@ const AKS_NAMESPACE_CONTRIBUTOR_ROLE_ID = "289d8817-ee69-43f1-a0af-43a45505b488"
 const ACR_PUSH_ROLE_ID = "8311e382-0749-4cb8-b61a-304f252e45ec";
 const ACR_TASKS_CONTRIBUTOR_ROLE_ID = "fb382eab-e894-4461-af04-94435c366c3f";
 
+// Managed-namespace annotation keys for AKS desktop / project tooling to
+// discover which federated workload identity is wired up for the namespace.
+const WORKLOAD_IDENTITY_CLIENT_ID_ANNOTATION = "aks-project/workload-identity-id";
+const WORKLOAD_IDENTITY_TENANT_ID_ANNOTATION = "aks-project/workload-identity-tenant";
+
 interface OIDCSetupResult {
     clientId: string;
     tenantId: string;
@@ -152,6 +157,23 @@ export async function setupOIDCForGitHub(
                     azureConfig.identityName,
                     repoInfo,
                 );
+
+                if (
+                    azureContext?.isManagedNamespace &&
+                    azureContext.namespace &&
+                    azureContext.clusterName &&
+                    azureContext.clusterResourceGroup
+                ) {
+                    progress.report({ message: l10n.t("Annotating managed namespace...") });
+                    await annotateManagedNamespaceWithIdentity(
+                        new ContainerServiceClient(credential, azureConfig.subscriptionId),
+                        azureContext.clusterResourceGroup,
+                        azureContext.clusterName,
+                        azureContext.namespace,
+                        identityResult.clientId,
+                        identityResult.tenantId,
+                    );
+                }
 
                 return {
                     clientId: identityResult.clientId,
@@ -779,6 +801,68 @@ async function createFederatedCredential(
         subject: subject,
         audiences: ["api://AzureADTokenExchange"],
     });
+}
+
+/**
+ * Stamps the federated identity's client ID and tenant ID onto the managed
+ * namespace as annotations so AKS desktop and other tooling can discover which
+ * workload identity is wired up for the namespace.
+ *
+ * This is intentionally done ONCE during OIDC setup rather than on every CI
+ * deploy. The values are static (they only change if the identity is rotated),
+ * so re-stamping them per push wastes time, needs extra RBAC on the CI
+ * principal, and — most importantly — risks wiping existing annotations and
+ * labels because `az aks namespace update` is an ARM PUT (full replacement).
+ *
+ * Performed in TypeScript via the @azure/arm-containerservice SDK so we get a
+ * proper typed read-modify-write: fetch existing properties, spread to
+ * preserve all other annotations/labels, then PUT.
+ *
+ * Exported and accepts an injected `ContainerServiceClient` so the merge
+ * behavior can be unit-tested without spinning up a real Azure session.
+ */
+export async function annotateManagedNamespaceWithIdentity(
+    client: ContainerServiceClient,
+    clusterResourceGroup: string,
+    clusterName: string,
+    namespace: string,
+    clientId: string,
+    tenantId: string,
+): Promise<void> {
+    let existing;
+    try {
+        existing = await client.managedNamespaces.get(clusterResourceGroup, clusterName, namespace);
+    } catch (error) {
+        logger.warn(
+            `Failed to read managed namespace ${namespace} for annotation; skipping workload-identity annotation: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        return;
+    }
+
+    const mergedProperties = {
+        ...existing.properties,
+        annotations: {
+            ...(existing.properties?.annotations ?? {}),
+            [WORKLOAD_IDENTITY_CLIENT_ID_ANNOTATION]: clientId,
+            [WORKLOAD_IDENTITY_TENANT_ID_ANNOTATION]: tenantId,
+        },
+    };
+
+    try {
+        const poller = client.managedNamespaces.createOrUpdate(clusterResourceGroup, clusterName, namespace, {
+            ...existing,
+            properties: mergedProperties,
+        });
+        await poller.pollUntilDone();
+    } catch (error) {
+        logger.warn(
+            `Failed to annotate managed namespace ${namespace} with workload identity metadata: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
 }
 
 async function displayOIDCResults(

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -38,8 +38,9 @@ const AKS_NAMESPACE_CONTRIBUTOR_ROLE_ID = "289d8817-ee69-43f1-a0af-43a45505b488"
 const ACR_PUSH_ROLE_ID = "8311e382-0749-4cb8-b61a-304f252e45ec";
 const ACR_TASKS_CONTRIBUTOR_ROLE_ID = "fb382eab-e894-4461-af04-94435c366c3f";
 
-// Managed-namespace annotation keys for AKS desktop / project tooling to
-// discover which federated workload identity is wired up for the namespace.
+// Namespace annotation keys — contract shared with AKS Desktop.
+// Keep in sync with ANNOTATION_WORKLOAD_IDENTITY / ANNOTATION_WORKLOAD_TENANT
+// in https://github.com/Azure/aks-desktop (usePipelineAnnotationSync.ts).
 const WORKLOAD_IDENTITY_CLIENT_ID_ANNOTATION = "aks-project/workload-identity-id";
 const WORKLOAD_IDENTITY_TENANT_ID_ANNOTATION = "aks-project/workload-identity-tenant";
 
@@ -815,10 +816,16 @@ export async function annotateManagedNamespaceWithIdentity(
     try {
         existing = await client.managedNamespaces.get(clusterResourceGroup, clusterName, namespace);
     } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
         logger.warn(
-            `Failed to read managed namespace ${namespace} for annotation; skipping workload-identity annotation: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
+            `Failed to read managed namespace ${namespace} for annotation; skipping workload-identity annotation: ${message}`,
+        );
+        void vscode.window.showWarningMessage(
+            l10n.t(
+                "Could not read managed namespace '{0}' to stamp workload-identity annotations. AKS Desktop may not detect this identity. Details: {1}",
+                namespace,
+                message,
+            ),
         );
         return;
     }
@@ -839,10 +846,14 @@ export async function annotateManagedNamespaceWithIdentity(
         });
         await poller.pollUntilDone();
     } catch (error) {
-        logger.warn(
-            `Failed to annotate managed namespace ${namespace} with workload identity metadata: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`Failed to annotate managed namespace ${namespace} with workload identity metadata: ${message}`);
+        void vscode.window.showWarningMessage(
+            l10n.t(
+                "Failed to write workload-identity annotations to managed namespace '{0}'. AKS Desktop may not detect this identity. Details: {1}",
+                namespace,
+                message,
+            ),
         );
     }
 }

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -803,24 +803,6 @@ async function createFederatedCredential(
     });
 }
 
-/**
- * Stamps the federated identity's client ID and tenant ID onto the managed
- * namespace as annotations so AKS desktop and other tooling can discover which
- * workload identity is wired up for the namespace.
- *
- * This is intentionally done ONCE during OIDC setup rather than on every CI
- * deploy. The values are static (they only change if the identity is rotated),
- * so re-stamping them per push wastes time, needs extra RBAC on the CI
- * principal, and — most importantly — risks wiping existing annotations and
- * labels because `az aks namespace update` is an ARM PUT (full replacement).
- *
- * Performed in TypeScript via the @azure/arm-containerservice SDK so we get a
- * proper typed read-modify-write: fetch existing properties, spread to
- * preserve all other annotations/labels, then PUT.
- *
- * Exported and accepts an injected `ContainerServiceClient` so the merge
- * behavior can be unit-tested without spinning up a real Azure session.
- */
 export async function annotateManagedNamespaceWithIdentity(
     client: ContainerServiceClient,
     clusterResourceGroup: string,

--- a/src/tests/suite/containerAssist/oidcSetup.test.ts
+++ b/src/tests/suite/containerAssist/oidcSetup.test.ts
@@ -374,3 +374,124 @@ describe("encryptSecret", () => {
         assert.strictEqual(decoded.length, expectedLen);
     });
 });
+
+// ─── annotateManagedNamespaceWithIdentity ──────────────────────────────────────
+
+describe("annotateManagedNamespaceWithIdentity", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    const RG = "my-rg";
+    const CLUSTER = "my-cluster";
+    const NS = "my-ns";
+    const CLIENT_ID = "00000000-0000-0000-0000-000000000001";
+    const TENANT_ID = "00000000-0000-0000-0000-000000000002";
+
+    /** Build a mock ContainerServiceClient whose managedNamespaces operations are stubs. */
+    function makeMockClient(opts: { getResult?: unknown; getThrows?: Error; pollThrows?: Error }) {
+        const pollUntilDone = opts.pollThrows ? sinon.stub().rejects(opts.pollThrows) : sinon.stub().resolves({});
+        const createOrUpdate = sinon.stub().returns({ pollUntilDone });
+        const get = opts.getThrows ? sinon.stub().rejects(opts.getThrows) : sinon.stub().resolves(opts.getResult);
+
+        return {
+            client: {
+                managedNamespaces: { get, createOrUpdate },
+            } as unknown as Parameters<typeof oidcSetup.annotateManagedNamespaceWithIdentity>[0],
+            get,
+            createOrUpdate,
+            pollUntilDone,
+        };
+    }
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(logger.logger, "warn");
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("merges new annotations into existing without dropping other annotations or labels", async () => {
+        const { client, createOrUpdate } = makeMockClient({
+            getResult: {
+                location: "eastus",
+                properties: {
+                    annotations: { "user/existing-annotation": "keep-me" },
+                    labels: { "user/existing-label": "also-keep" },
+                    ingressPolicy: "AllowAll",
+                },
+            },
+        });
+
+        await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
+
+        assert.ok(createOrUpdate.calledOnce, "should issue exactly one PUT");
+        const [rg, cluster, ns, body] = createOrUpdate.firstCall.args;
+        assert.strictEqual(rg, RG);
+        assert.strictEqual(cluster, CLUSTER);
+        assert.strictEqual(ns, NS);
+
+        assert.deepStrictEqual(body.properties.annotations, {
+            "user/existing-annotation": "keep-me",
+            "aks-project/workload-identity-id": CLIENT_ID,
+            "aks-project/workload-identity-tenant": TENANT_ID,
+        });
+        assert.deepStrictEqual(body.properties.labels, { "user/existing-label": "also-keep" });
+        assert.strictEqual(body.properties.ingressPolicy, "AllowAll", "non-annotation properties must survive");
+        assert.strictEqual(body.location, "eastus", "outer ARM envelope must survive");
+    });
+
+    it("handles a namespace with no existing annotations or labels", async () => {
+        const { client, createOrUpdate } = makeMockClient({
+            getResult: { properties: {} },
+        });
+
+        await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
+
+        const body = createOrUpdate.firstCall.args[3];
+        assert.deepStrictEqual(body.properties.annotations, {
+            "aks-project/workload-identity-id": CLIENT_ID,
+            "aks-project/workload-identity-tenant": TENANT_ID,
+        });
+    });
+
+    it("is idempotent: re-running with new identity values overwrites only its own keys", async () => {
+        const { client, createOrUpdate } = makeMockClient({
+            getResult: {
+                properties: {
+                    annotations: {
+                        "aks-project/workload-identity-id": "OLD-CLIENT",
+                        "aks-project/workload-identity-tenant": "OLD-TENANT",
+                        "user/keep": "yes",
+                    },
+                },
+            },
+        });
+
+        await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, "NEW-CLIENT", "NEW-TENANT");
+
+        const sent = createOrUpdate.firstCall.args[3].properties.annotations;
+        assert.strictEqual(sent["aks-project/workload-identity-id"], "NEW-CLIENT");
+        assert.strictEqual(sent["aks-project/workload-identity-tenant"], "NEW-TENANT");
+        assert.strictEqual(sent["user/keep"], "yes");
+    });
+
+    it("fails closed: does not PUT if the initial get() throws", async () => {
+        const { client, createOrUpdate } = makeMockClient({
+            getThrows: new Error("403 Forbidden"),
+        });
+
+        await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
+
+        assert.ok(createOrUpdate.notCalled, "must not PUT after a failed read — risks wiping annotations/labels");
+    });
+
+    it("swallows PUT failures without throwing (best-effort metadata)", async () => {
+        const { client } = makeMockClient({
+            getResult: { properties: {} },
+            pollThrows: new Error("500 Internal Server Error"),
+        });
+
+        await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
+    });
+});

--- a/src/tests/suite/containerAssist/oidcSetup.test.ts
+++ b/src/tests/suite/containerAssist/oidcSetup.test.ts
@@ -405,6 +405,7 @@ describe("annotateManagedNamespaceWithIdentity", () => {
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         sandbox.stub(logger.logger, "warn");
+        sandbox.stub(vscode.window, "showWarningMessage");
     });
 
     afterEach(() => {
@@ -484,6 +485,10 @@ describe("annotateManagedNamespaceWithIdentity", () => {
         await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
 
         assert.ok(createOrUpdate.notCalled, "must not PUT after a failed read — risks wiping annotations/labels");
+        assert.ok(
+            (vscode.window.showWarningMessage as sinon.SinonStub).calledOnce,
+            "user should be notified when annotation read fails",
+        );
     });
 
     it("swallows PUT failures without throwing (best-effort metadata)", async () => {
@@ -493,5 +498,10 @@ describe("annotateManagedNamespaceWithIdentity", () => {
         });
 
         await oidcSetup.annotateManagedNamespaceWithIdentity(client, RG, CLUSTER, NS, CLIENT_ID, TENANT_ID);
+
+        assert.ok(
+            (vscode.window.showWarningMessage as sinon.SinonStub).calledOnce,
+            "user should be notified when annotation write fails",
+        );
     });
 });

--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -293,28 +293,28 @@ describe("Workflow Template Tests", () => {
             assert.ok(result.includes("managed namespace"), "Should indicate managed namespace in comments");
         });
 
-        it("should annotate namespace and deployment in managed namespace template", () => {
+        it("should not annotate the managed namespace from CI — workload-identity annotations are written once by OIDC setup", () => {
             const managedConfig = { ...validConfig, isManagedNamespace: true };
             const result = renderWorkflowTemplate(managedConfig);
 
-            assert.ok(result.includes("Annotate namespace"), "Managed template should have annotate namespace step");
             assert.ok(
-                result.includes("az aks namespace update"),
-                "Managed template should update namespace annotations via az aks namespace update",
+                !result.includes("Annotate namespace"),
+                "Managed template should not have an annotate-namespace CI step",
             );
             assert.ok(
-                result.includes("--annotations"),
-                "Managed template should pass annotations to az aks namespace update",
+                !result.includes("az aks namespace update"),
+                "Managed template should not call az aks namespace update from CI",
             );
             assert.ok(
-                result.includes("aks-project/workload-identity-id="),
-                "Managed template should set workload-identity-id on namespace",
+                !result.includes("aks-project/workload-identity-id"),
+                "Managed template should not stamp workload-identity-id from CI",
             );
             assert.ok(
-                result.includes("aks-project/workload-identity-tenant="),
-                "Managed template should set workload-identity-tenant on namespace",
+                !result.includes("aks-project/workload-identity-tenant"),
+                "Managed template should not stamp workload-identity-tenant from CI",
             );
-            assert.ok(result.includes("Annotate deployment"), "Managed template should have annotate deployment step");
+
+            assert.ok(result.includes("Annotate deployment"), "Managed template should still annotate deployments");
             assert.ok(
                 result.includes("kubectl annotate deployment --all"),
                 "Managed template should annotate all deployments",
@@ -497,16 +497,13 @@ describe("Multi-Container Workflow Template Tests", () => {
             );
         });
 
-        it("renders an Annotate namespace step in the multi-container managed-namespace deploy job", () => {
+        it("does not annotate the managed namespace from CI in the multi-container deploy job", () => {
             const managed: MultiContainerWorkflowConfig = { ...validMultiConfig, isManagedNamespace: true };
             const rendered = renderMultiContainerWorkflowTemplate(managed);
-            assert.ok(
-                rendered.includes("Annotate namespace"),
-                "Managed-namespace multi-container deploy job should annotate the namespace",
-            );
-            assert.ok(rendered.includes("az aks namespace update"));
-            assert.ok(rendered.includes("aks-project/workload-identity-id="));
-            assert.ok(rendered.includes("aks-project/workload-identity-tenant="));
+            assert.ok(!rendered.includes("Annotate namespace"));
+            assert.ok(!rendered.includes("az aks namespace update"));
+            assert.ok(!rendered.includes("aks-project/workload-identity-id"));
+            assert.ok(!rendered.includes("aks-project/workload-identity-tenant"));
         });
 
         it("produces structurally valid YAML even with multi-manifest block scalars", () => {


### PR DESCRIPTION
## Problem

The `Annotate namespace` step in the CA-generated managed-namespace deploy workflows ran `az aks namespace update --annotations …` on every push. That command is an ARM PUT (full replacement), so it silently wiped every existing annotation **and** every label on the managed namespace, breaking AKS desktop project tracking and any other tooling that relied on namespace metadata.

The two annotations being stamped are static:

- `aks-project/workload-identity-id`
- `aks-project/workload-identity-tenant`

They're determined when the federated identity is created and never change between deploys — so there is no reason to re-stamp them on every push.

## Fix

- **Delete the destructive `Annotate namespace` step** from both managed-ns workflow templates (single-container `aks-deploy-managed-ns.template.yaml` and multi-container `workflow-multi-deploy-job-managed-ns.template.yaml`).
- **Move the one-time write into `oidcSetup.ts`** as a new exported function `annotateManagedNamespaceWithIdentity`, using the `@azure/arm-containerservice` SDK for a typed read-modify-write that preserves all existing annotations and labels via object spread.
- **Fail closed:** if the SDK read fails, log a warning and skip rather than risk a destructive PUT.
- The per-run `Annotate deployment` step is unchanged — `kubectl annotate --overwrite` is per-key and not destructive.

## Why move it out of CI

| Concern | Before (per-deploy CI) | After (one-time OIDC setup) |
|---|---|---|
| How often it runs | Every push | Once, at setup |
| CI principal RBAC needed | `managedNamespaces/write` | None |
| Data-loss risk | Wipes existing annotations + labels | Typed RMW preserves them |
| Per-deploy latency | +1 ARM read + 1 ARM write | 0 |

## Tests

- **5 new unit tests** in `oidcSetup.test.ts` covering:
  - Merge: existing annotations + labels + non-annotation properties + outer ARM envelope all survive the PUT
  - Empty-namespace edge case
  - Idempotency: re-running with new identity values overwrites only the workload-identity keys
  - Fail-closed: a failed `get()` does not result in a PUT
  - Best-effort: a failed PUT logs a warning and does not throw
- **2 inverted assertions** in `workflowTemplate.test.ts` confirm the destructive step is gone from both managed-ns templates and that the per-run deployment annotation step still renders.

`npm test` — **210 passing**.

## Manual verification recommended before merge

On a real cluster with a managed namespace that has pre-existing user annotations and labels:

```bash
# Pre: seed user metadata
az aks namespace update -g $RG --cluster-name $C -n $NS \
  --annotations user/keep-annotation=A --labels user/keep-label=L

# Run "AKS: Setup OIDC for GitHub" from the extension

# Post: both your keys AND the new workload-identity keys must be present
az aks namespace show -g $RG --cluster-name $C -n $NS \
  --query 'properties.{annotations:annotations, labels:labels}'
```