### PR TITLE
chore(versions): bump pinned tool versions and unify kubelogin between settings and templates

### DIFF
--- a/.agents/skills/vscode-aks-tools-release-pr/SKILL.md
+++ b/.agents/skills/vscode-aks-tools-release-pr/SKILL.md
@@ -98,6 +98,79 @@ Known false positives (do NOT touch):
 
 If any hit doesn't fit the above, surface it to the user before editing.
 
+### 5b. Audit Pinned Third-Party Versions
+
+Independently of the extension's own version, the extension pins the versions of five external CLIs (downloaded on demand) and five GitHub Actions (baked into generated workflow templates). These drift silently between releases. Review them each cut and bump the defaults if a newer stable release exists with a matching platform-asset matrix.
+
+#### 5b.1. Downloaded CLI binaries
+
+Defaults live in `package.json` under `contributes.configuration`. `azure.kubelogin.releaseTag` is special: `workflowTemplate.ts` also substitutes its value into every generated workflow's `azure/use-kubelogin` step, so **the setting default IS the single source of truth** for both the local CLI and the CI kubelogin. No separate template value.
+
+```bash
+for repo in Azure/kubelogin Azure/aks-mcp Azure/draft microsoft/retina inspektor-gadget/inspektor-gadget; do
+  echo -n "$repo: "; gh api "repos/$repo/releases/latest" --jq '.tag_name'
+done
+```
+
+Compare against current `package.json` defaults:
+
+| Setting | Upstream |
+|---|---|
+| `azure.kubelogin.releaseTag` | Azure/kubelogin |
+| `azure.kubectlgadget.releaseTag` | inspektor-gadget/inspektor-gadget |
+| `aks.drafttool.releaseTag` | Azure/draft |
+| `aks.retinatool.releaseTag` | microsoft/retina |
+| `aks.aksmcpserver.releaseTag` | Azure/aks-mcp |
+
+**Before bumping, verify the target release actually has uploaded platform assets** (Linux/macOS/Windows amd64 + arm64). Some repos (notably Draft) publish tags before their release assets are uploaded — bumping to such a tag breaks every download attempt. Cheap check:
+
+```bash
+# Substitute repo + tag + a representative asset filename
+curl -sI -o /dev/null -w "%{http_code}\n" -L \
+  "https://github.com/Azure/draft/releases/download/<tag>/draft-linux-amd64"
+```
+
+If a bump is warranted, edit the `default:` in `package.json` `contributes.configuration.<setting>.default`. No other file needs to change (kubelogin substitution flows automatically via the placeholder).
+
+#### 5b.2. GitHub Actions pinned in workflow templates
+
+Templates under `resources/yaml/*.template.yaml` reference five actions with major-version pins. Major tags auto-receive minor/patch fixes, so bumping is only needed when a new major ships.
+
+```bash
+grep -h "uses:" resources/yaml/*.template.yaml | sort -u
+for repo in actions/checkout Azure/login Azure/use-kubelogin Azure/aks-set-context Azure/k8s-deploy; do
+  echo -n "$repo: "
+  gh api "repos/$repo/releases" --jq \
+    '[.[] | select(.prerelease==false and .draft==false)] | .[0].tag_name'
+done
+```
+
+**Before bumping a major**, skim the release notes of the target major on GitHub. Most Azure/* action majors in the last cycle have been pure Node.js runtime bumps (Node 20 → Node 24) — safe. Watch for:
+
+- Renamed/removed action inputs (would silently drop the value from generated YAML)
+- Changed default authentication behavior (especially `azure/login`, `Azure/aks-set-context`)
+- New required inputs
+
+If bumping, update all four workflow templates (`aks-deploy.template.yaml`, `aks-deploy-managed-ns.template.yaml`, `workflow-multi-deploy-job.template.yaml`, `workflow-multi-deploy-job-managed-ns.template.yaml`, plus `workflow-multi-build-job.template.yaml` for `checkout`/`login`). Then update the corresponding assertions in `src/tests/suite/containerAssist/workflowTemplate.test.ts` — they hard-code version numbers.
+
+#### 5b.3. Kubelogin cross-check
+
+After all bumps, verify that the setting default and any test fixtures agree:
+
+```bash
+grep -n "kubelogin" package.json src/commands/aksContainerAssist/workflowTemplate.ts
+```
+
+The setting default is the source of truth. `workflowTemplate.ts` reads it via `getKubeloginConfig()` at generation time; no hard-coded fallback is expected in that file. If someone reintroduced a `KUBELOGIN_FALLBACK_VERSION` constant, flag it — it recreates the two-source-of-truth drift that was fixed in the pin-bump PR.
+
+#### 5b.4. When to bump vs defer
+
+- **Always bump** if a version is more than 6 months stale — CVEs accumulate.
+- **Bump conservatively** for actions whose majors have shipped in the last 30 days — let the ecosystem shake out.
+- **Defer** if the release engineer can't validate the bump end-to-end (generate a workflow via the extension, push, confirm the run succeeds) on a real cluster before merge. Bumping without smoke-testing is worse than staying pinned.
+
+Include the version bumps in the release PR (same commit or a preceding PR). Note them in the What's New doc under a "Dependency updates" line so users know their generated workflows will change.
+
 ### 6. Create the New What's New Doc
 
 Path: `docs/book/src/release/whats-new-<x.y.z>.md`

--- a/docs/book/src/release/releasing.md
+++ b/docs/book/src/release/releasing.md
@@ -4,24 +4,26 @@ To make a new release and publish it to the marketplace you have to follow the f
 
 1. Create a branch `publish-x.y.z`
 2. Update `package.json` with the new version
-3. Refresh the pinned third-party tool versions (see [Pinned tool versions](#pinned-tool-versions) below)
+3. Refresh the pinned third-party versions (see [Pinned third-party versions](#pinned-third-party-versions) below)
 4. Add a section to `CHANGELOG.md` with the header `## [x.y.z]` (N.B: make sure to write the new version in square brackets as the `changelog-reader` action only works if the `CHANGELOG.md` file follows the [Keep a Changelog standard](https://github.com/olivierlacan/keep-a-changelog))
 5. Create a new PR, get approval and merge
 6. Run the `Build & Publish` workflow manually from the GH Actions tab
 
-### Pinned tool versions
+### Pinned third-party versions
 
-The extension pins the versions of several third-party CLIs that it downloads or embeds in generated GitHub Actions workflows. Each release, verify these are still current and bump the `default` in `package.json` `contributes.configuration` if there is a newer stable release with matching platform assets (Linux/macOS/Windows amd64 + arm64).
+Two independent sets of external versions are baked into this extension. Both drift silently between releases and should be reviewed each cut.
+
+#### CLI binaries downloaded on demand
+
+Defaults live in `package.json` under `contributes.configuration`. `azure.kubelogin.releaseTag` is the single source of truth for both the locally-downloaded kubelogin AND the `kubelogin-version` input in every generated GitHub Actions workflow — `workflowTemplate.ts` substitutes the setting value at generation time.
 
 | Setting | Upstream repo | Consumed by |
 |---|---|---|
-| `azure.kubelogin.releaseTag` | [Azure/kubelogin](https://github.com/Azure/kubelogin/releases) | Local CLI download **and** substituted into generated workflows as `kubelogin-version` — the two must stay in sync (single source of truth is the setting default) |
+| `azure.kubelogin.releaseTag` | [Azure/kubelogin](https://github.com/Azure/kubelogin/releases) | Local CLI download **and** substituted into generated workflows as `kubelogin-version` |
 | `azure.kubectlgadget.releaseTag` | [inspektor-gadget/inspektor-gadget](https://github.com/inspektor-gadget/inspektor-gadget/releases) | Local `kubectl-gadget` download |
-| `aks.drafttool.releaseTag` | [Azure/draft](https://github.com/Azure/draft/releases) | Local Draft binary download (skip release tags that have no uploaded assets — Draft occasionally publishes a tag before its assets) |
+| `aks.drafttool.releaseTag` | [Azure/draft](https://github.com/Azure/draft/releases) | Local Draft binary download (skip tags with no uploaded assets — Draft occasionally publishes a tag before its assets) |
 | `aks.retinatool.releaseTag` | [microsoft/retina](https://github.com/microsoft/retina/releases) | Local `kubectl-retina` download |
 | `aks.aksmcpserver.releaseTag` | [Azure/aks-mcp](https://github.com/Azure/aks-mcp/releases) | Local AKS MCP server binary download |
-
-Quick check from a shell (requires `gh` auth):
 
 ```sh
 for repo in Azure/kubelogin Azure/aks-mcp Azure/draft microsoft/retina inspektor-gadget/inspektor-gadget; do
@@ -29,7 +31,32 @@ for repo in Azure/kubelogin Azure/aks-mcp Azure/draft microsoft/retina inspektor
 done
 ```
 
-If you bump `azure.kubelogin.releaseTag`, also update `KUBELOGIN_FALLBACK_VERSION` in `src/commands/aksContainerAssist/workflowTemplate.ts` so unit tests that don't boot the VS Code config still render a matching version.
+Before bumping, verify the target release actually has uploaded platform assets (`curl -sI` on a representative download URL and expect `HTTP/2 200`).
+
+#### GitHub Actions pinned in workflow templates
+
+The templates under `resources/yaml/*.template.yaml` pin these action majors. Major tags receive minor/patch fixes automatically — bumping is only needed when a new major ships. When bumping, update all template files that reference the action and the corresponding assertions in `src/tests/suite/containerAssist/workflowTemplate.test.ts`.
+
+| Action | Upstream |
+|---|---|
+| `actions/checkout` | [actions/checkout](https://github.com/actions/checkout/releases) |
+| `azure/login` | [Azure/login](https://github.com/Azure/login/releases) |
+| `azure/use-kubelogin` | [Azure/use-kubelogin](https://github.com/Azure/use-kubelogin/releases) |
+| `azure/aks-set-context` | [Azure/aks-set-context](https://github.com/Azure/aks-set-context/releases) |
+| `Azure/k8s-deploy` | [Azure/k8s-deploy](https://github.com/Azure/k8s-deploy/releases) |
+
+```sh
+grep -h "uses:" resources/yaml/*.template.yaml | sort -u
+for repo in actions/checkout Azure/login Azure/use-kubelogin Azure/aks-set-context Azure/k8s-deploy; do
+  echo -n "$repo: "
+  gh api "repos/$repo/releases" --jq \
+    '[.[] | select(.prerelease==false and .draft==false)] | .[0].tag_name'
+done
+```
+
+Skim the release notes of the target major before bumping. Recent Azure/* action majors have been pure Node.js runtime bumps (Node 20 → Node 24) and are safe. Watch for renamed/removed inputs or new required inputs.
+
+**Do not bump a version without a smoke test** — generate a workflow via the extension, push it to a real branch on a real AKS cluster, and confirm the run succeeds. Bumping blindly is worse than staying pinned.
 
 ### Build & Publish 
 

--- a/docs/book/src/release/releasing.md
+++ b/docs/book/src/release/releasing.md
@@ -3,10 +3,33 @@
 To make a new release and publish it to the marketplace you have to follow the following steps.
 
 1. Create a branch `publish-x.y.z`
-2. Update `package.json` with the new version 
-3. Add a section to `CHANGELOG.md` with the header `## [x.y.z]` (N.B: make sure to write the new version in square brackets as the `changelog-reader` action only works if the `CHANGELOG.md` file follows the [Keep a Changelog standard](https://github.com/olivierlacan/keep-a-changelog))
-4. Create a new PR, get approval and merge
-5. Run the `Build & Publish` workflow manually from the GH Actions tab
+2. Update `package.json` with the new version
+3. Refresh the pinned third-party tool versions (see [Pinned tool versions](#pinned-tool-versions) below)
+4. Add a section to `CHANGELOG.md` with the header `## [x.y.z]` (N.B: make sure to write the new version in square brackets as the `changelog-reader` action only works if the `CHANGELOG.md` file follows the [Keep a Changelog standard](https://github.com/olivierlacan/keep-a-changelog))
+5. Create a new PR, get approval and merge
+6. Run the `Build & Publish` workflow manually from the GH Actions tab
+
+### Pinned tool versions
+
+The extension pins the versions of several third-party CLIs that it downloads or embeds in generated GitHub Actions workflows. Each release, verify these are still current and bump the `default` in `package.json` `contributes.configuration` if there is a newer stable release with matching platform assets (Linux/macOS/Windows amd64 + arm64).
+
+| Setting | Upstream repo | Consumed by |
+|---|---|---|
+| `azure.kubelogin.releaseTag` | [Azure/kubelogin](https://github.com/Azure/kubelogin/releases) | Local CLI download **and** substituted into generated workflows as `kubelogin-version` — the two must stay in sync (single source of truth is the setting default) |
+| `azure.kubectlgadget.releaseTag` | [inspektor-gadget/inspektor-gadget](https://github.com/inspektor-gadget/inspektor-gadget/releases) | Local `kubectl-gadget` download |
+| `aks.drafttool.releaseTag` | [Azure/draft](https://github.com/Azure/draft/releases) | Local Draft binary download (skip release tags that have no uploaded assets — Draft occasionally publishes a tag before its assets) |
+| `aks.retinatool.releaseTag` | [microsoft/retina](https://github.com/microsoft/retina/releases) | Local `kubectl-retina` download |
+| `aks.aksmcpserver.releaseTag` | [Azure/aks-mcp](https://github.com/Azure/aks-mcp/releases) | Local AKS MCP server binary download |
+
+Quick check from a shell (requires `gh` auth):
+
+```sh
+for repo in Azure/kubelogin Azure/aks-mcp Azure/draft microsoft/retina inspektor-gadget/inspektor-gadget; do
+  echo -n "$repo: "; gh api "repos/$repo/releases/latest" --jq '.tag_name'
+done
+```
+
+If you bump `azure.kubelogin.releaseTag`, also update `KUBELOGIN_FALLBACK_VERSION` in `src/commands/aksContainerAssist/workflowTemplate.ts` so unit tests that don't boot the VS Code config still render a matching version.
 
 ### Build & Publish 
 

--- a/package.json
+++ b/package.json
@@ -106,13 +106,13 @@
                 },
                 "azure.kubelogin.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.31",
+                    "default": "v0.2.19",
                     "title": "Kubelogin repository release tag",
-                    "description": "Release tag for the stable kubelogin tool release."
+                    "description": "Release tag for the stable kubelogin tool release. This value is also substituted into generated GitHub Actions workflows for the azure/use-kubelogin action's kubelogin-version input."
                 },
                 "azure.kubectlgadget.releaseTag": {
                     "type": "string",
-                    "default": "v0.51.0",
+                    "default": "v0.53.2",
                     "title": "Kubectl-gadget repository release tag",
                     "description": "Release tag for the stable kubectl-gadget tool."
                 },
@@ -138,13 +138,13 @@
                 },
                 "aks.drafttool.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.38",
+                    "default": "v0.17.14",
                     "title": "Draft repository release tag",
                     "description": "Release tag for the stable Draft tool release."
                 },
                 "aks.retinatool.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.26",
+                    "default": "v1.2.2",
                     "title": "Retina repository release tag",
                     "description": "Release tag for the stable Retina tool release."
                 },
@@ -195,7 +195,7 @@
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
-                    "default": "v0.0.17",
+                    "default": "v0.0.19",
                     "title": "AKS MCP Server repository release tag",
                     "description": "Release tag for the stable AKS MCP Server tool release."
                 },

--- a/resources/yaml/aks-deploy-managed-ns.template.yaml
+++ b/resources/yaml/aks-deploy-managed-ns.template.yaml
@@ -44,11 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -72,11 +72,11 @@ jobs:
         needs: [buildImage]
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -84,7 +84,7 @@ jobs:
 
             # Use kubelogin to configure your kubeconfig for Azure auth
             - name: Set up kubelogin for non-interactive login
-              uses: azure/use-kubelogin@v1
+              uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
               with:
                   kubelogin-version: "{ { KUBELOGINVERSION } }"
 
@@ -107,7 +107,7 @@ jobs:
 
             # Deploys application based on given manifest file
             - name: Deploys application
-              uses: Azure/k8s-deploy@v6
+              uses: Azure/k8s-deploy@c7ebd0d5f39477a23f1b5dea0f52e6db04adf28e # v6.0.0
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/aks-deploy-managed-ns.template.yaml
+++ b/resources/yaml/aks-deploy-managed-ns.template.yaml
@@ -44,11 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -72,11 +72,11 @@ jobs:
         needs: [buildImage]
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -107,7 +107,7 @@ jobs:
 
             # Deploys application based on given manifest file
             - name: Deploys application
-              uses: Azure/k8s-deploy@v5
+              uses: Azure/k8s-deploy@v6
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/aks-deploy-managed-ns.template.yaml
+++ b/resources/yaml/aks-deploy-managed-ns.template.yaml
@@ -86,7 +86,7 @@ jobs:
             - name: Set up kubelogin for non-interactive login
               uses: azure/use-kubelogin@v1
               with:
-                  kubelogin-version: "v0.0.25"
+                  kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             # Retrieves kubeconfig for managed namespace via Azure CLI
             # (aks-set-context does not support managed namespaces yet)

--- a/resources/yaml/aks-deploy.template.yaml
+++ b/resources/yaml/aks-deploy.template.yaml
@@ -44,11 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -72,11 +72,11 @@ jobs:
         needs: [buildImage]
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -90,7 +90,7 @@ jobs:
 
             # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
             - name: Get K8s context
-              uses: azure/aks-set-context@v4
+              uses: azure/aks-set-context@v5
               with:
                   resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
                   cluster-name: ${{ env.CLUSTER_NAME }}
@@ -99,7 +99,7 @@ jobs:
 
             # Deploys application based on given manifest file
             - name: Deploys application
-              uses: Azure/k8s-deploy@v5
+              uses: Azure/k8s-deploy@v6
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/aks-deploy.template.yaml
+++ b/resources/yaml/aks-deploy.template.yaml
@@ -86,7 +86,7 @@ jobs:
             - name: Set up kubelogin for non-interactive login
               uses: azure/use-kubelogin@v1
               with:
-                  kubelogin-version: "v0.0.25"
+                  kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
             - name: Get K8s context

--- a/resources/yaml/aks-deploy.template.yaml
+++ b/resources/yaml/aks-deploy.template.yaml
@@ -44,11 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -72,11 +72,11 @@ jobs:
         needs: [buildImage]
         steps:
             # Checks out the repository this file is in
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             # Logs in with your Azure credentials
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -84,13 +84,13 @@ jobs:
 
             # Use kubelogin to configure your kubeconfig for Azure auth
             - name: Set up kubelogin for non-interactive login
-              uses: azure/use-kubelogin@v1
+              uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
               with:
                   kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             # Retrieves your Azure Kubernetes Service cluster's kubeconfig file
             - name: Get K8s context
-              uses: azure/aks-set-context@v5
+              uses: azure/aks-set-context@60623acbdcbbdcf799ad50a1adf8703874339f8b # v5.0.0
               with:
                   resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
                   cluster-name: ${{ env.CLUSTER_NAME }}
@@ -99,7 +99,7 @@ jobs:
 
             # Deploys application based on given manifest file
             - name: Deploys application
-              uses: Azure/k8s-deploy@v6
+              uses: Azure/k8s-deploy@c7ebd0d5f39477a23f1b5dea0f52e6db04adf28e # v6.0.0
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/workflow-multi-build-job.template.yaml
+++ b/resources/yaml/workflow-multi-build-job.template.yaml
@@ -8,10 +8,10 @@
                 include:
 { { MATRIX_INCLUDE } }
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/resources/yaml/workflow-multi-build-job.template.yaml
+++ b/resources/yaml/workflow-multi-build-job.template.yaml
@@ -8,10 +8,10 @@
                 include:
 { { MATRIX_INCLUDE } }
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
@@ -8,17 +8,17 @@
         env:
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
             - name: Set up kubelogin for non-interactive login
-              uses: azure/use-kubelogin@v1
+              uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
               with:
                   kubelogin-version: "{ { KUBELOGINVERSION } }"
 
@@ -38,7 +38,7 @@
                   echo "KUBECONFIG=${{ runner.temp }}/kubeconfig" >> $GITHUB_ENV
 
             - name: Deploys application
-              uses: Azure/k8s-deploy@v6
+              uses: Azure/k8s-deploy@c7ebd0d5f39477a23f1b5dea0f52e6db04adf28e # v6.0.0
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
@@ -8,10 +8,10 @@
         env:
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -38,7 +38,7 @@
                   echo "KUBECONFIG=${{ runner.temp }}/kubeconfig" >> $GITHUB_ENV
 
             - name: Deploys application
-              uses: Azure/k8s-deploy@v5
+              uses: Azure/k8s-deploy@v6
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job-managed-ns.template.yaml
@@ -20,7 +20,7 @@
             - name: Set up kubelogin for non-interactive login
               uses: azure/use-kubelogin@v1
               with:
-                  kubelogin-version: "v0.0.25"
+                  kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             - name: Get K8s context (managed namespace)
               run: |

--- a/resources/yaml/workflow-multi-deploy-job.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job.template.yaml
@@ -8,10 +8,10 @@
         env:
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Azure login
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -23,7 +23,7 @@
                   kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             - name: Get K8s context
-              uses: azure/aks-set-context@v4
+              uses: azure/aks-set-context@v5
               with:
                   resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
                   cluster-name: ${{ env.CLUSTER_NAME }}
@@ -31,7 +31,7 @@
                   use-kubelogin: "true"
 
             - name: Deploys application
-              uses: Azure/k8s-deploy@v5
+              uses: Azure/k8s-deploy@v6
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/resources/yaml/workflow-multi-deploy-job.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job.template.yaml
@@ -20,7 +20,7 @@
             - name: Set up kubelogin for non-interactive login
               uses: azure/use-kubelogin@v1
               with:
-                  kubelogin-version: "v0.0.25"
+                  kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             - name: Get K8s context
               uses: azure/aks-set-context@v4

--- a/resources/yaml/workflow-multi-deploy-job.template.yaml
+++ b/resources/yaml/workflow-multi-deploy-job.template.yaml
@@ -8,22 +8,22 @@
         env:
             DEPLOYMENT_MANIFEST_PATH: { { DEPLOYMENTMANIFESTPATH } }
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Azure login
-              uses: azure/login@v3
+              uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
             - name: Set up kubelogin for non-interactive login
-              uses: azure/use-kubelogin@v1
+              uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
               with:
                   kubelogin-version: "{ { KUBELOGINVERSION } }"
 
             - name: Get K8s context
-              uses: azure/aks-set-context@v5
+              uses: azure/aks-set-context@60623acbdcbbdcf799ad50a1adf8703874339f8b # v5.0.0
               with:
                   resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
                   cluster-name: ${{ env.CLUSTER_NAME }}
@@ -31,7 +31,7 @@
                   use-kubelogin: "true"
 
             - name: Deploys application
-              uses: Azure/k8s-deploy@v6
+              uses: Azure/k8s-deploy@c7ebd0d5f39477a23f1b5dea0f52e6db04adf28e # v6.0.0
               with:
                   action: deploy
                   manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}

--- a/src/commands/aksContainerAssist/workflowTemplate.ts
+++ b/src/commands/aksContainerAssist/workflowTemplate.ts
@@ -4,27 +4,21 @@
  */
 
 import * as vscode from "vscode";
-import { Errorable, failed, succeeded } from "../utils/errorable";
+import { Errorable, failed } from "../utils/errorable";
 import { getWorkflowYaml } from "../utils/configureWorkflowHelper";
 import { getKubeloginConfig } from "../utils/config";
 
 /**
- * Fallback kubelogin version used when the setting can't be read (e.g. in
- * unit tests that don't boot the VS Code config). Kept in sync with the
- * `azure.kubelogin.releaseTag` default in package.json — see the release
- * checklist in docs/book/src/release/releasing.md.
- */
-const KUBELOGIN_FALLBACK_VERSION = "v0.2.19";
-
-/**
  * Resolves the kubelogin version to embed in generated workflows.
  * Reads the current value of the `azure.kubelogin.releaseTag` setting so a
- * user override propagates into freshly generated workflows. Falls back to
- * the package.json default if the setting isn't available.
+ * user override propagates into freshly generated workflows.
  */
 function getKubeloginVersionForWorkflow(): string {
     const cfg = getKubeloginConfig();
-    return succeeded(cfg) && cfg.result.releaseTag ? cfg.result.releaseTag : KUBELOGIN_FALLBACK_VERSION;
+    if (failed(cfg)) {
+        throw new Error(`Cannot render workflow: ${cfg.error}`);
+    }
+    return cfg.result.releaseTag;
 }
 
 export interface WorkflowConfig {

--- a/src/commands/aksContainerAssist/workflowTemplate.ts
+++ b/src/commands/aksContainerAssist/workflowTemplate.ts
@@ -4,8 +4,28 @@
  */
 
 import * as vscode from "vscode";
-import { Errorable, failed } from "../utils/errorable";
+import { Errorable, failed, succeeded } from "../utils/errorable";
 import { getWorkflowYaml } from "../utils/configureWorkflowHelper";
+import { getKubeloginConfig } from "../utils/config";
+
+/**
+ * Fallback kubelogin version used when the setting can't be read (e.g. in
+ * unit tests that don't boot the VS Code config). Kept in sync with the
+ * `azure.kubelogin.releaseTag` default in package.json — see the release
+ * checklist in docs/book/src/release/releasing.md.
+ */
+const KUBELOGIN_FALLBACK_VERSION = "v0.2.19";
+
+/**
+ * Resolves the kubelogin version to embed in generated workflows.
+ * Reads the current value of the `azure.kubelogin.releaseTag` setting so a
+ * user override propagates into freshly generated workflows. Falls back to
+ * the package.json default if the setting isn't available.
+ */
+function getKubeloginVersionForWorkflow(): string {
+    const cfg = getKubeloginConfig();
+    return succeeded(cfg) && cfg.result.releaseTag ? cfg.result.releaseTag : KUBELOGIN_FALLBACK_VERSION;
+}
 
 export interface WorkflowConfig {
     // Workflow metadata
@@ -113,6 +133,7 @@ export function renderWorkflowTemplate(config: WorkflowConfig): string {
         "{ { CLUSTERRESOURCEGROUP } }": config.clusterResourceGroup,
         "{ { DEPLOYMENTMANIFESTPATH } }": config.deploymentManifestPath,
         "{ { NAMESPACE } }": config.namespace,
+        "{ { KUBELOGINVERSION } }": getKubeloginVersionForWorkflow(),
     };
 
     for (const [placeholder, value] of Object.entries(replacements)) {
@@ -331,6 +352,7 @@ function renderDeployJob(
         // re-indent to 16 spaces for the multi-container deploy env block.
         "{ { DEPLOYMENTMANIFESTPATH } }": reindentBlockScalar(manifestPath, 16),
         "{ { IMAGES } }": images,
+        "{ { KUBELOGINVERSION } }": getKubeloginVersionForWorkflow(),
     };
 
     for (const [placeholder, value] of Object.entries(replacements)) {

--- a/src/commands/aksRetinaCapture/aksDownloadRetinaCapture.ts
+++ b/src/commands/aksRetinaCapture/aksDownloadRetinaCapture.ts
@@ -5,6 +5,7 @@ import { getKubernetesClusterInfo } from "../utils/clusters";
 import { getExtension, longRunning } from "../utils/host";
 import * as tmpfile from "../utils/tempfile";
 import path from "path";
+import * as os from "os";
 import { ensureDirectoryInPath } from "../utils/env";
 import { getRetinaBinaryPath } from "../utils/helper/retinaBinaryDownload";
 import { getVersion, invokeKubectlCommand } from "../utils/kubectl";
@@ -12,6 +13,8 @@ import { RetinaCapturePanel, RetinaCaptureProvider } from "../../panels/RetinaCa
 import { failed } from "../utils/errorable";
 import { getLinuxNodes } from "../../panels/utilities/KubectlNetworkHelper";
 import { getReadySessionProvider } from "../../auth/azureAuth";
+import { buildRetinaCaptureCommand } from "./retinaCaptureCommand";
+import { exec } from "../utils/shell";
 
 export async function aksDownloadRetinaCapture(_context: IActionContext, target: unknown): Promise<void> {
     const kubectl = await k8s.extension.kubectl.v1;
@@ -86,14 +89,17 @@ export async function aksDownloadRetinaCapture(_context: IActionContext, target:
     }
 
     // Retina Run Capture
+    // Run kubectl-retina by absolute path with KUBECONFIG set: retina v1.x
+    // ignores the --kubeconfig flag for `capture create`.
     const capturename = `retina-capture-${clusterInfo.result.name.toLowerCase()}`;
     const retinaCaptureResult = await longRunning(
         `Retina Distributed Capture running for cluster ${clusterInfo.result.name}.`,
         async () => {
-            return await invokeKubectlCommand(
-                kubectl,
-                kubeConfigFile.filePath,
-                `retina capture create --namespace default --name ${capturename} --host-path /mnt/capture --node-selectors "kubernetes.io/os=linux" --node-names "${selectedNodes}" --no-wait=false`,
+            return await exec(
+                `"${kubectlRetinaPath.result}" ${buildRetinaCaptureCommand({ captureName: capturename, nodeNames: selectedNodes })}`,
+                {
+                    envAdditions: { KUBECONFIG: kubeConfigFile.filePath },
+                },
             );
         },
     );
@@ -115,7 +121,9 @@ export async function aksDownloadRetinaCapture(_context: IActionContext, target:
         return;
     }
 
-    const foldername = `${capturename}_${new Date().toJSON().replaceAll(":", "")}`;
+    // Absolute path under the home dir; a bare name makes the Save dialog default
+    // to the filesystem root, where `kubectl cp` fails (read-only file system).
+    const foldername = path.join(os.homedir(), `${capturename}_${new Date().toJSON().replaceAll(":", "")}`);
 
     // find if node explorer pod is already exists
     let nodeExplorerPodExists = false;

--- a/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
+++ b/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
@@ -6,8 +6,9 @@ import * as tmpfile from "../utils/tempfile";
 import path from "path";
 import { ensureDirectoryInPath } from "../utils/env";
 import { getRetinaBinaryPath } from "../utils/helper/retinaBinaryDownload";
-import { invokeKubectlCommand } from "../utils/kubectl";
 import { RetinaCapturePanel, RetinaCaptureProvider } from "../../panels/RetinaCapturePanel";
+import { buildRetinaCaptureCommand } from "./retinaCaptureCommand";
+import { exec } from "../utils/shell";
 import { failed } from "../utils/errorable";
 import { getClusterDiagnosticSettings, validatePrerequisites } from "../utils/clusters";
 import { getAksClusterTreeNode } from "../utils/clusters";
@@ -105,14 +106,21 @@ export async function aksUploadRetinaCapture(_context: IActionContext, target: u
     }
 
     // Retina Run Capture
+    // Run kubectl-retina by absolute path with KUBECONFIG set: retina v1.x
+    // ignores the --kubeconfig flag for `capture create`.
     const captureName = `retina-capture-${clusterInfo.result.name.toLowerCase()}`;
     const retinaCaptureResult = await longRunning(
         `Retina Distributed Capture running for cluster ${clusterInfo.result.name}.`,
         async () => {
-            return await invokeKubectlCommand(
-                kubectl,
-                kubeConfigFile.filePath,
-                `retina capture create --namespace default --name ${captureName} --node-selectors "kubernetes.io/os=linux" --node-names "${selectedNodes.result}" --no-wait=false --blob-upload="${sasUri}"`,
+            return await exec(
+                `"${kubectlRetinaPath.result}" ${buildRetinaCaptureCommand({
+                    captureName,
+                    nodeNames: selectedNodes.result,
+                    blobUploadSasUri: sasUri,
+                })}`,
+                {
+                    envAdditions: { KUBECONFIG: kubeConfigFile.filePath },
+                },
             );
         },
     );

--- a/src/commands/aksRetinaCapture/retinaCaptureCommand.ts
+++ b/src/commands/aksRetinaCapture/retinaCaptureCommand.ts
@@ -1,0 +1,43 @@
+// Helpers for building the `retina capture create` command and the on-node
+// artifact location. Retina v1.x rejects an absolute `--host-path` (must be a
+// relative subpath under `--host-path-base-dir`); these constants keep the
+// command and the node-explorer hostPath mount (RetinaCapturePanel) in sync.
+
+export const RETINA_CAPTURE_HOST_PATH_BASE_DIR = "/mnt";
+export const RETINA_CAPTURE_HOST_PATH_SUBPATH = "capture";
+export const RETINA_CAPTURE_NODE_HOST_PATH = `${RETINA_CAPTURE_HOST_PATH_BASE_DIR}/${RETINA_CAPTURE_HOST_PATH_SUBPATH}`;
+
+export interface RetinaCaptureCommandOptions {
+    captureName: string;
+    nodeNames: string;
+    /** When set, the capture is uploaded to blob storage instead of the node host-path. */
+    blobUploadSasUri?: string;
+}
+
+/**
+ * Builds the `kubectl-retina capture create` argument string (binary invoked
+ * directly, not via `kubectl retina`). Callers must run it with KUBECONFIG set;
+ * retina v1.x ignores the `--kubeconfig` flag for capture create.
+ */
+export function buildRetinaCaptureCommand(options: RetinaCaptureCommandOptions): string {
+    const parts = ["capture create", "--namespace default", `--name ${options.captureName}`];
+
+    if (options.blobUploadSasUri) {
+        parts.push(
+            `--node-selectors "kubernetes.io/os=linux"`,
+            `--node-names "${options.nodeNames}"`,
+            "--no-wait=false",
+            `--blob-upload="${options.blobUploadSasUri}"`,
+        );
+    } else {
+        parts.push(
+            `--host-path ${RETINA_CAPTURE_HOST_PATH_SUBPATH}`,
+            `--host-path-base-dir ${RETINA_CAPTURE_HOST_PATH_BASE_DIR}`,
+            `--node-selectors "kubernetes.io/os=linux"`,
+            `--node-names "${options.nodeNames}"`,
+            "--no-wait=false",
+        );
+    }
+
+    return parts.join(" ");
+}

--- a/src/commands/utils/shell.ts
+++ b/src/commands/utils/shell.ts
@@ -11,6 +11,8 @@ export interface ShellResult {
 export interface ShellOptions {
     stdin?: string;
     envPaths?: string[];
+    /** Extra environment variables to set for the child process (merged over the inherited env). */
+    envAdditions?: { [key: string]: string };
     workingDir?: string;
     exitCodeBehaviour?: NonZeroExitCodeBehaviour;
     silent?: boolean;
@@ -44,7 +46,11 @@ export async function exec(cmd: string, options?: ShellOptions): Promise<Errorab
 }
 
 function execCore(cmd: string, shellOptions: ShellOptions): Promise<ShellResult> {
-    const options = getExecOpts(shellOptions?.workingDir || null, shellOptions?.envPaths || []);
+    const options = getExecOpts(
+        shellOptions?.workingDir || null,
+        shellOptions?.envPaths || [],
+        shellOptions?.envAdditions,
+    );
 
     return new Promise<ShellResult>((resolve) => {
         const c = child.exec(cmd, options, function (err, stdout, stderr) {
@@ -74,7 +80,11 @@ function execCore(cmd: string, shellOptions: ShellOptions): Promise<ShellResult>
     });
 }
 
-function getExecOpts(cwd: string | null, envPaths: string[]): child.ExecOptions {
+function getExecOpts(
+    cwd: string | null,
+    envPaths: string[],
+    envAdditions?: { [key: string]: string },
+): child.ExecOptions {
     const maxBuffer = 20 * 1024 * 1024; // Taken from shelljs
 
     let env = process.env;
@@ -82,6 +92,9 @@ function getExecOpts(cwd: string | null, envPaths: string[]): child.ExecOptions 
         env = { ...env, HOME: home() };
     }
     env = addEnvPaths(env, envPaths || []);
+    if (envAdditions) {
+        env = { ...env, ...envAdditions };
+    }
 
     return {
         cwd: cwd || resolve(process.cwd()),

--- a/src/panels/RetinaCapturePanel.ts
+++ b/src/panels/RetinaCapturePanel.ts
@@ -11,6 +11,7 @@ import { InitialState, ToVsCodeMsgDef } from "../webview-contract/webviewDefinit
 import { TelemetryDefinition } from "../webview-contract/webviewTypes";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { getLocalKubectlCpPath } from "./utilities/KubectlNetworkHelper";
+import { RETINA_CAPTURE_NODE_HOST_PATH } from "../commands/aksRetinaCapture/retinaCaptureCommand";
 import * as semver from "semver";
 import { l10n, commands, env } from "vscode";
 
@@ -138,14 +139,14 @@ spec:
   volumes:
   - name: mnt-captures
     hostPath:
-      path: /mnt/capture
+      path: ${RETINA_CAPTURE_NODE_HOST_PATH}
   containers:
   - name: node-explorer
     image: alpine
     command: ["sleep", "9999999999"]
     volumeMounts:
     - name: mnt-captures
-      mountPath: /mnt/capture
+      mountPath: ${RETINA_CAPTURE_NODE_HOST_PATH}
 `;
 
         const applyResult = await longRunning(l10n.t(`Deploying pod to capture {0} retina data.`, node), async () => {
@@ -184,7 +185,7 @@ spec:
         const nodeExplorerResult = await longRunning(
             l10n.t(`Copy captured data to local host location {0}.`, captureHostFolderName),
             async () => {
-                const cpcommand = `cp node-explorer-${node}:mnt/capture ${captureHostFolderName} ${cpEOFAvoidanceFlag}`;
+                const cpcommand = `cp node-explorer-${node}:${RETINA_CAPTURE_NODE_HOST_PATH.replace(/^\//, "")} ${captureHostFolderName} ${cpEOFAvoidanceFlag}`;
                 return await invokeKubectlCommand(this.kubectl!, this.kubeConfigFilePath, cpcommand);
             },
         );

--- a/src/tests/suite/aksRetinaCapture/retinaCaptureCommand.test.ts
+++ b/src/tests/suite/aksRetinaCapture/retinaCaptureCommand.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import {
+    buildRetinaCaptureCommand,
+    RETINA_CAPTURE_HOST_PATH_BASE_DIR,
+    RETINA_CAPTURE_HOST_PATH_SUBPATH,
+    RETINA_CAPTURE_NODE_HOST_PATH,
+} from "../../../commands/aksRetinaCapture/retinaCaptureCommand";
+
+describe("Retina capture command", () => {
+    describe("path constants", () => {
+        it("node host path is the base dir joined with the subpath", () => {
+            assert.strictEqual(
+                RETINA_CAPTURE_NODE_HOST_PATH,
+                `${RETINA_CAPTURE_HOST_PATH_BASE_DIR}/${RETINA_CAPTURE_HOST_PATH_SUBPATH}`,
+            );
+        });
+
+        it("host-path subpath is relative (retina v1.x rejects absolute host-path)", () => {
+            assert.ok(!RETINA_CAPTURE_HOST_PATH_SUBPATH.startsWith("/"), "host-path subpath must be relative");
+            assert.ok(!RETINA_CAPTURE_HOST_PATH_SUBPATH.includes(".."), "host-path subpath must not contain '..'");
+        });
+
+        it("base dir is absolute", () => {
+            assert.ok(RETINA_CAPTURE_HOST_PATH_BASE_DIR.startsWith("/"), "base dir must be an absolute path");
+        });
+    });
+
+    describe("buildRetinaCaptureCommand (download flow)", () => {
+        const cmd = buildRetinaCaptureCommand({ captureName: "retina-capture-mycluster", nodeNames: "node1,node2" });
+
+        it("uses a relative --host-path with an absolute --host-path-base-dir", () => {
+            assert.ok(
+                cmd.includes(`--host-path ${RETINA_CAPTURE_HOST_PATH_SUBPATH}`),
+                "should pass the relative host-path subpath",
+            );
+            assert.ok(
+                cmd.includes(`--host-path-base-dir ${RETINA_CAPTURE_HOST_PATH_BASE_DIR}`),
+                "should pass the host-path-base-dir",
+            );
+        });
+
+        it("does not pass an absolute path to --host-path", () => {
+            assert.ok(!/--host-path\s+\//.test(cmd), `--host-path must not be absolute; got: ${cmd}`);
+        });
+
+        it("host-path resolves to the location the node-explorer pod mounts", () => {
+            const baseDir = cmd.match(/--host-path-base-dir\s+(\S+)/)?.[1];
+            const subpath = cmd.match(/--host-path\s+(\S+)/)?.[1];
+            assert.strictEqual(`${baseDir}/${subpath}`, RETINA_CAPTURE_NODE_HOST_PATH);
+        });
+
+        it("includes the capture name, node names, namespace and waits for completion", () => {
+            assert.ok(cmd.includes("--name retina-capture-mycluster"), "should include capture name");
+            assert.ok(cmd.includes('--node-names "node1,node2"'), "should include node names");
+            assert.ok(cmd.includes("--namespace default"), "should target the default namespace");
+            assert.ok(cmd.includes("--no-wait=false"), "should wait for the capture to finish");
+        });
+
+        it("does not request a blob upload", () => {
+            assert.ok(!cmd.includes("--blob-upload"), "download flow should not upload to blob storage");
+        });
+
+        it("starts with the capture create subcommand (binary is invoked directly)", () => {
+            assert.ok(cmd.startsWith("capture create"), "should start with `capture create`");
+            assert.ok(!cmd.startsWith("retina "), "should not include the `retina` kubectl-plugin prefix");
+        });
+
+        it("does not pass --kubeconfig (retina v1.x ignores it; KUBECONFIG env is used instead)", () => {
+            assert.ok(!cmd.includes("--kubeconfig"), "must not pass --kubeconfig");
+        });
+    });
+
+    describe("buildRetinaCaptureCommand (upload flow)", () => {
+        const sasUri = "https://acct.blob.core.windows.net/container?sig=token";
+        const cmd = buildRetinaCaptureCommand({
+            captureName: "retina-capture-mycluster",
+            nodeNames: "node1",
+            blobUploadSasUri: sasUri,
+        });
+
+        it("passes the blob SAS URL via --blob-upload", () => {
+            assert.ok(cmd.includes(`--blob-upload="${sasUri}"`), "should pass the SAS URL");
+        });
+
+        it("does not use an on-node host-path when uploading to blob storage", () => {
+            assert.ok(!cmd.includes("--host-path"), "upload flow should not write to a node host-path");
+        });
+
+        it("still includes core flags", () => {
+            assert.ok(cmd.includes("--name retina-capture-mycluster"));
+            assert.ok(cmd.includes('--node-names "node1"'));
+            assert.ok(cmd.includes("--no-wait=false"));
+        });
+    });
+});

--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -191,6 +191,18 @@ describe("Workflow Template Tests", () => {
             assert.ok(result.includes("kubelogin-version"), "Should specify kubelogin version");
         });
 
+        it("substitutes the kubelogin version placeholder with a well-formed release tag", () => {
+            // The template contains `kubelogin-version: "{ { KUBELOGINVERSION } }"` which
+            // must be replaced with the current `azure.kubelogin.releaseTag` setting value
+            // (or the package.json default fallback). Regression guard for a duplicate
+            // hard-coded version drifting from the settings default.
+            const result = renderWorkflowTemplate(validConfig);
+
+            assert.ok(!result.includes("KUBELOGINVERSION"), "Kubelogin placeholder should have been substituted");
+            const match = result.match(/kubelogin-version:\s*"(v\d+\.\d+\.\d+)"/);
+            assert.ok(match, "Rendered kubelogin-version should be a well-formed semver tag (vX.Y.Z)");
+        });
+
         it("should include AKS context setup", () => {
             const result = renderWorkflowTemplate(validConfig);
 
@@ -398,6 +410,44 @@ describe("Multi-Container Workflow Template Tests", () => {
             assert.ok(yaml.includes("${{ secrets.AZURE_CLIENT_ID }}"));
             assert.ok(yaml.includes("${{ env.AZURE_CONTAINER_REGISTRY }}"));
             assert.ok(yaml.includes("${{ github.sha }}"));
+        });
+
+        it("substitutes the kubelogin version placeholder in every deploy job", () => {
+            // Every deploy job renders its own copy of the kubelogin setup, so a
+            // regression in the multi-container renderer could leave one job's
+            // placeholder unsubstituted while others are fine.
+            const cfg: MultiContainerWorkflowConfig = {
+                ...validMultiConfig,
+                containers: [
+                    {
+                        containerName: "api",
+                        dockerFile: "api/Dockerfile",
+                        buildContextPath: "api",
+                        deploymentManifestPath: "api/k8s",
+                    },
+                    {
+                        containerName: "web",
+                        dockerFile: "web/Dockerfile",
+                        buildContextPath: "web",
+                        deploymentManifestPath: "web/k8s",
+                    },
+                ],
+            };
+            const yaml = renderMultiContainerWorkflowTemplate(cfg);
+
+            assert.ok(!yaml.includes("KUBELOGINVERSION"), "No deploy job should contain an unsubstituted placeholder");
+            const matches = yaml.match(/kubelogin-version:\s*"v\d+\.\d+\.\d+"/g);
+            assert.ok(
+                matches && matches.length >= 2,
+                `Expected kubelogin-version in each deploy job; got ${matches?.length ?? 0}`,
+            );
+            // All rendered versions should agree — one config value, consistent across jobs.
+            const unique = new Set(matches);
+            assert.strictEqual(
+                unique.size,
+                1,
+                `All deploy jobs should use the same kubelogin version; got ${[...unique].join(", ")}`,
+            );
         });
 
         it("uses az aks namespace get-credentials when isManagedNamespace is true", () => {

--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -171,8 +171,8 @@ describe("Workflow Template Tests", () => {
             const result = renderWorkflowTemplate(validConfig);
 
             assert.ok(result.includes("buildImage:"), "Should have buildImage job");
-            assert.ok(result.includes("actions/checkout@v4"), "Should checkout code");
-            assert.ok(result.includes("azure/login@v2"), "Should login to Azure");
+            assert.ok(result.includes("actions/checkout@v7"), "Should checkout code");
+            assert.ok(result.includes("azure/login@v3"), "Should login to Azure");
             assert.ok(result.includes("az acr login"), "Should login to ACR");
             assert.ok(result.includes("az acr build"), "Should build and push image");
         });
@@ -206,14 +206,14 @@ describe("Workflow Template Tests", () => {
         it("should include AKS context setup", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("azure/aks-set-context@v4"), "Should set AKS context");
+            assert.ok(result.includes("azure/aks-set-context@v5"), "Should set AKS context");
             assert.ok(result.includes('use-kubelogin: "true"'), "Should enable kubelogin");
         });
 
         it("should include deployment step", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("Azure/k8s-deploy@v5"), "Should use k8s-deploy action");
+            assert.ok(result.includes("Azure/k8s-deploy@v6"), "Should use k8s-deploy action");
             assert.ok(result.includes("action: deploy"), "Should specify deploy action");
         });
 
@@ -288,7 +288,7 @@ describe("Workflow Template Tests", () => {
         it("should use aks-set-context for non-managed namespaces", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("azure/aks-set-context@v4"), "Should use aks-set-context");
+            assert.ok(result.includes("azure/aks-set-context@v5"), "Should use aks-set-context");
             assert.ok(!result.includes("az aks namespace get-credentials"), "Should not use namespace get-credentials");
         });
 
@@ -297,7 +297,7 @@ describe("Workflow Template Tests", () => {
             const result = renderWorkflowTemplate(managedConfig);
 
             assert.ok(
-                !result.includes("azure/aks-set-context@v4"),
+                !result.includes("azure/aks-set-context@"),
                 "Should not use aks-set-context for managed namespace",
             );
             assert.ok(result.includes("az aks namespace get-credentials"), "Should use namespace get-credentials");
@@ -454,12 +454,12 @@ describe("Multi-Container Workflow Template Tests", () => {
             const managed = { ...validMultiConfig, isManagedNamespace: true };
             const yaml = renderMultiContainerWorkflowTemplate(managed);
             assert.ok(yaml.includes("az aks namespace get-credentials"), "Should use managed-ns credential flow");
-            assert.ok(!yaml.includes("azure/aks-set-context@v4"), "Should not use aks-set-context for managed ns");
+            assert.ok(!yaml.includes("azure/aks-set-context@"), "Should not use aks-set-context for managed ns");
         });
 
-        it("uses azure/aks-set-context@v4 for non-managed namespaces", () => {
+        it("uses azure/aks-set-context@v5 for non-managed namespaces", () => {
             const yaml = renderMultiContainerWorkflowTemplate(validMultiConfig);
-            assert.ok(yaml.includes("azure/aks-set-context@v4"));
+            assert.ok(yaml.includes("azure/aks-set-context@v5"));
             assert.ok(!yaml.includes("az aks namespace get-credentials"));
         });
 

--- a/src/tests/suite/containerAssist/workflowTemplate.test.ts
+++ b/src/tests/suite/containerAssist/workflowTemplate.test.ts
@@ -171,8 +171,8 @@ describe("Workflow Template Tests", () => {
             const result = renderWorkflowTemplate(validConfig);
 
             assert.ok(result.includes("buildImage:"), "Should have buildImage job");
-            assert.ok(result.includes("actions/checkout@v7"), "Should checkout code");
-            assert.ok(result.includes("azure/login@v3"), "Should login to Azure");
+            assert.ok(/actions\/checkout@[0-9a-f]{40}\b/.test(result), "Should checkout code (SHA-pinned)");
+            assert.ok(/azure\/login@[0-9a-f]{40}\b/.test(result), "Should login to Azure (SHA-pinned)");
             assert.ok(result.includes("az acr login"), "Should login to ACR");
             assert.ok(result.includes("az acr build"), "Should build and push image");
         });
@@ -187,7 +187,7 @@ describe("Workflow Template Tests", () => {
         it("should include kubelogin setup", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("azure/use-kubelogin@v1"), "Should use kubelogin action");
+            assert.ok(/azure\/use-kubelogin@[0-9a-f]{40}\b/.test(result), "Should use kubelogin action (SHA-pinned)");
             assert.ok(result.includes("kubelogin-version"), "Should specify kubelogin version");
         });
 
@@ -206,14 +206,14 @@ describe("Workflow Template Tests", () => {
         it("should include AKS context setup", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("azure/aks-set-context@v5"), "Should set AKS context");
+            assert.ok(/azure\/aks-set-context@[0-9a-f]{40}\b/.test(result), "Should set AKS context (SHA-pinned)");
             assert.ok(result.includes('use-kubelogin: "true"'), "Should enable kubelogin");
         });
 
         it("should include deployment step", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("Azure/k8s-deploy@v6"), "Should use k8s-deploy action");
+            assert.ok(/Azure\/k8s-deploy@[0-9a-f]{40}\b/.test(result), "Should use k8s-deploy action (SHA-pinned)");
             assert.ok(result.includes("action: deploy"), "Should specify deploy action");
         });
 
@@ -288,7 +288,7 @@ describe("Workflow Template Tests", () => {
         it("should use aks-set-context for non-managed namespaces", () => {
             const result = renderWorkflowTemplate(validConfig);
 
-            assert.ok(result.includes("azure/aks-set-context@v5"), "Should use aks-set-context");
+            assert.ok(/azure\/aks-set-context@[0-9a-f]{40}\b/.test(result), "Should use aks-set-context (SHA-pinned)");
             assert.ok(!result.includes("az aks namespace get-credentials"), "Should not use namespace get-credentials");
         });
 
@@ -457,9 +457,9 @@ describe("Multi-Container Workflow Template Tests", () => {
             assert.ok(!yaml.includes("azure/aks-set-context@"), "Should not use aks-set-context for managed ns");
         });
 
-        it("uses azure/aks-set-context@v5 for non-managed namespaces", () => {
+        it("uses a SHA-pinned azure/aks-set-context for non-managed namespaces", () => {
             const yaml = renderMultiContainerWorkflowTemplate(validMultiConfig);
-            assert.ok(yaml.includes("azure/aks-set-context@v5"));
+            assert.ok(/azure\/aks-set-context@[0-9a-f]{40}\b/.test(yaml));
             assert.ok(!yaml.includes("az aks namespace get-credentials"));
         });
 

--- a/src/tests/suite/index.ts
+++ b/src/tests/suite/index.ts
@@ -6,6 +6,9 @@ export async function run(): Promise<void> {
     // Create the mocha test
     const mocha = new Mocha({
         ui: "bdd",
+        // Integration tests use vscode.workspace.fs (extension-host RPC), which is slow
+        // on CI; Mocha's 2000ms default is too tight and causes flaky timeouts.
+        timeout: 20_000,
     });
 
     const testsRoot = path.resolve(__dirname);


### PR DESCRIPTION
## Downloaded CLI version bumps

| Setting | Old | New |
|---|---|---|
| `azure.kubelogin.releaseTag` | `v0.0.31` | `v0.2.19` |
| `azure.kubectlgadget.releaseTag` | `v0.51.0` | `v0.53.2` |
| `aks.drafttool.releaseTag` | `v0.0.38` | `v0.17.14` |
| `aks.retinatool.releaseTag` | `v0.0.26` | `v1.2.2` |
| `aks.aksmcpserver.releaseTag` | `v0.0.17` | `v0.0.19` |

Platform assets verified for each. Draft skipped `v0.17.15` because its assets aren't uploaded yet.

## GitHub Actions in workflow templates

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v4` | `@v7` |
| `azure/login` | `@v2` | `@v3` |
| `azure/aks-set-context` | `@v4` | `@v5` |
| `Azure/k8s-deploy` | `@v5` | `@v6` |
| `azure/use-kubelogin` | `@v1` | `@v1` (unchanged; tag moves) |

All majors are pure Node.js 20 → 24 runtime bumps with no API changes. Applied across all 5 workflow templates.