### PR TITLE
refactor(kickstart): adopt preview naming for command and setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This extension contributes two declarative Copilot chat agents defined in `agent
 ## kickstart
 
 **File**: `agents/kickstart.agent.md`
-**User-invocable**: Yes (gated by `aks.kickstart.enabled` setting)
+**User-invocable**: Yes (gated by `aks.kickstartEnabledPreview` setting)
 **Tools**: editFiles, search, codebase, fetch, runCommands, problems, usages, vscode_askQuestions, run_in_terminal, get_terminal_output, send_to_terminal, kill_terminal
 **Models**: Claude Sonnet 4, GPT-4o
 
@@ -40,7 +40,7 @@ Invokes: `/kickstart-review`, `/kickstart-safeguard-checklist`, `/kickstart-secu
 | Method | Command/Action | Effect |
 |---|---|---|
 | Agent picker | Select "kickstart" in Copilot dropdown | Starts Phase 1 |
-| Command palette | `AKS: Launch Kickstart Agent` (`aks.kickstartFocus`) | Hides sidebar/panel, opens chat, invokes kickstart |
+| Command palette | `AKS: Launch Kickstart Agent` (`aks.kickstart.launchExperience`) | Hides sidebar/panel, opens chat, invokes kickstart |
 | Prompt file | `kickstart.prompt.md` | Lightweight discovery flow |
 
 ## Skills

--- a/kickstart-guide.md
+++ b/kickstart-guide.md
@@ -34,17 +34,17 @@ User selects "kickstart" agent in Copilot
 The main agent is gated by a VS Code setting:
 
 ```json
-"aks.kickstart.enabled": true  // default
+"aks.kickstartEnabledPreview": false  // default; set true to enable (Preview)
 ```
 
-The `chatAgents` entry uses `"when": "config.aks.kickstart.enabled == true"` so the agent only appears in the Copilot agent picker when the setting is enabled. The reviewer sub-agent has no `when` clause — it's internal and only reachable via handoff.
+The `chatAgents` entry uses `"when": "config.aks.kickstartEnabledPreview == true"` so the agent only appears in the Copilot agent picker when the setting is enabled. The reviewer sub-agent has no `when` clause — it's internal and only reachable via handoff.
 
 ## Entry Points
 
 | Entry Point | How | What happens |
 |---|---|---|
 | **Agent picker** | User selects "kickstart" in Copilot's agent dropdown | Full agent prompt loads, starts at Phase 1 |
-| **Command palette** | User runs `AKS: Launch Kickstart Agent` (`aks.kickstartFocus`) | Hides sidebar/panel, opens chat, sends initial message to kickstart agent |
+| **Command palette** | User runs `AKS: Launch Kickstart Agent` (`aks.kickstart.launchExperience`) | Hides sidebar/panel, opens chat, sends initial message to kickstart agent |
 | **Prompt file** | User runs `kickstart.prompt.md` from the prompt picker | Lightweight version — invokes `/kickstart-discover` and starts the flow |
 
 ## Agent Handoffs
@@ -214,9 +214,9 @@ The agents use VS Code Copilot's built-in tools (not custom extension tools):
 ```
 ├── package.json                        # chatAgents + chatSkills + settings
 ├── tsconfig.json
-├── src/extension.ts                    # Activation + aks.kickstartFocus command
+├── src/extension.ts                    # Activation + aks.kickstart.launchExperience command
 ├── agents/
-│   ├── kickstart.agent.md              # Main agent (gated by kickstart.enabled)
+│   ├── kickstart.agent.md              # Main agent (gated by kickstartEnabledPreview)
 │   └── kickstart-reviewer.agent.md     # Internal reviewer sub-agent
 ├── skills/
 │   ├── kickstart-discover/SKILL.md     # Phase skills (7)

--- a/package.json
+++ b/package.json
@@ -193,10 +193,10 @@
                     "default": "copilot",
                     "description": "Default language model vendor for Container Assist (e.g. copilot)."
                 },
-                "aks.kickstart.enabled": {
+                "aks.kickstartEnabledPreview": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable the Kickstart agent for AI-guided AKS Automatic deployment onboarding."
+                    "description": "Set to true to enable the Kickstart agent for AI-guided AKS Automatic deployment onboarding. (Preview feature)"
                 },
                 "aks.aksmcpserver.releaseTag": {
                     "type": "string",
@@ -502,7 +502,7 @@
                 "category": "AKS"
             },
             {
-                "command": "aks.kickstartFocus",
+                "command": "aks.kickstart.launchExperience",
                 "title": "AKS: Launch Kickstart Agent",
                 "category": "AKS"
             },
@@ -563,12 +563,12 @@
                     "when": "never"
                 },
                 {
-                    "command": "aks.kickstartFocus",
-                    "when": "config.aks.kickstart.enabled == true"
+                    "command": "aks.kickstart.launchExperience",
+                    "when": "config.aks.kickstartEnabledPreview == true"
                 },
                 {
                     "command": "aks.kickstartCluster",
-                    "when": "config.aks.kickstart.enabled == true"
+                    "when": "config.aks.kickstartEnabledPreview == true"
                 }
             ],
             "explorer/context": [
@@ -1067,35 +1067,35 @@
                 "name": "kickstart",
                 "description": "AI-guided onboarding to deploy your app on AKS Automatic. Walks you through discover, design, generate, review, handoff, and deploy.",
                 "path": "./agents/kickstart.agent.md",
-                "when": "config.aks.kickstart.enabled == true"
+                "when": "config.aks.kickstartEnabledPreview == true"
             },
             {
                 "name": "kickstart-reviewer",
                 "description": "Internal agent: Reviews Kickstart-generated deployment artifacts for correctness, security, and AKS Automatic compliance. Invoked by kickstart only.",
                 "path": "./agents/kickstart-reviewer.agent.md",
-                "when": "config.aks.kickstart.enabled == true"
+                "when": "config.aks.kickstartEnabledPreview == true"
             }
         ],
         "chatSkills": [
-            { "path": "./skills/kickstart-discover/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-design/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-generate/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-review/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-handoff/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-deploy/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-configure-infra/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-cluster-status/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-samples/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-workload-identity/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-acr-integration/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-bicep-authoring/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-security-hardening/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-                { "path": "./skills/kickstart-pim-activation/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-github-pr-conventions/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-phase-acceleration/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-collaborator-voice/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-file-generation/SKILL.md", "when": "config.aks.kickstart.enabled == true" },
-            { "path": "./skills/kickstart-safeguard-checklist/SKILL.md", "when": "config.aks.kickstart.enabled == true" }
+            { "path": "./skills/kickstart-discover/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-design/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-generate/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-review/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-handoff/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-deploy/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-configure-infra/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-cluster-status/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-samples/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-workload-identity/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-acr-integration/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-bicep-authoring/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-security-hardening/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+                { "path": "./skills/kickstart-pim-activation/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-github-pr-conventions/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-phase-acceleration/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-collaborator-voice/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-file-generation/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" },
+            { "path": "./skills/kickstart-safeguard-checklist/SKILL.md", "when": "config.aks.kickstartEnabledPreview == true" }
         ]
     },
     "scripts": {

--- a/src/commands/aksKickstart/kickstartCluster.ts
+++ b/src/commands/aksKickstart/kickstartCluster.ts
@@ -9,10 +9,10 @@ import { getGitApi } from "../utils/git";
 import { getExtension } from "../utils/host";
 
 export async function kickstartCluster(context: vscode.ExtensionContext, launchContextArg?: unknown): Promise<void> {
-    const config = vscode.workspace.getConfiguration("aks.kickstart");
-    if (!config.get<boolean>("enabled", true)) {
+    const config = vscode.workspace.getConfiguration("aks");
+    if (!config.get<boolean>("kickstartEnabledPreview", false)) {
         window.showWarningMessage(
-            "The Kickstart agent is disabled. Enable it via the 'aks.kickstart.enabled' setting.",
+            "The Kickstart agent is disabled. Enable it via the 'aks.kickstartEnabledPreview' setting.",
         );
         return;
     }

--- a/src/commands/aksKickstart/kickstartLaunch.ts
+++ b/src/commands/aksKickstart/kickstartLaunch.ts
@@ -5,10 +5,10 @@ import { failed } from "../utils/errorable";
 import { getExtension } from "../utils/host";
 
 export async function kickstartLaunch(): Promise<void> {
-    const config = vscode.workspace.getConfiguration("aks.kickstart");
-    if (!config.get<boolean>("enabled", true)) {
+    const config = vscode.workspace.getConfiguration("aks");
+    if (!config.get<boolean>("kickstartEnabledPreview", false)) {
         window.showWarningMessage(
-            "The Kickstart agent is disabled. Enable it via the 'aks.kickstart.enabled' setting.",
+            "The Kickstart agent is disabled. Enable it via the 'aks.kickstartEnabledPreview' setting.",
         );
         return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,9 @@ export async function activate(context: vscode.ExtensionContext) {
     activateAzureSessionProvider(context);
     const sessionProvider = getSessionProvider();
 
-    context.subscriptions.push(vscode.commands.registerCommand("aks.kickstartFocus", () => kickstartLaunch()));
+    context.subscriptions.push(
+        vscode.commands.registerCommand("aks.kickstart.launchExperience", () => kickstartLaunch()),
+    );
     context.subscriptions.push(
         vscode.commands.registerCommand("aks.kickstartCluster", (launchContext?: unknown) =>
             kickstartCluster(context, launchContext),


### PR DESCRIPTION
## What

Aligns the Kickstart launch command and enablement flag with the extension's established **preview** naming convention.

| | Before | After |
|---|---|---|
| Command | `aks.kickstartFocus` | `aks.kickstart.launchExperience` |
| Setting | `aks.kickstart.enabled` | `aks.kickstartEnabledPreview` |

The launch command (`aks.kickstart.launchExperience`) remains gated on the preview flag (`aks.kickstartEnabledPreview`) being `true`.

## Why

The other preview features already use the `aks.<feature>EnabledPreview` convention (`aks.containerAssistEnabledPreview`, `aks.copilotEnabledPreview`), read as `getConfiguration("aks").get("<feature>EnabledPreview")`. Kickstart was the odd one out (`aks.kickstart.enabled`). This brings it in line and gives the launch entry point a descriptive command id.

## Changes

- `package.json`: setting definition, command contribution, and every gating `when` clause (command-palette menus, `chatAgents`, all 19 `chatSkills`).
- `src/extension.ts`: command registration id.
- `src/commands/aksKickstart/kickstartLaunch.ts` and `kickstartCluster.ts`: runtime config reads (`getConfiguration("aks").get("kickstartEnabledPreview", false)`) and warning messages.
- Docs: `AGENTS.md`, `kickstart-guide.md`.

## Notes

- **Default preserved as `false`** (honoring the recent "Fix: default flag" change) — Kickstart stays opt-in.
- `aks.kickstartCluster` (the cluster-setup view command) is intentionally left unchanged; it is out of scope for this naming alignment.
- No behavior change beyond the rename.

## Validation

- `tsc -p ./ --noEmit` — clean
- `npm run lint` — clean
- `package.json` — valid JSON
