### PR TITLE
Publish release 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service (AKS)",
     "description": "Create, manage, deploy, and diagnose AKS clusters directly from VS Code",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
## Release 2.3.0

Version bump to **2.3.0** for publishing to the marketplace. Headlined by the preview **Kickstart agent** for AKS Automatic, plus a data-loss fix in managed-namespace deploys, security patches, and cleanup of the deprecated DevHub deployment path.

### Highlights

**Kickstart agent (preview)** — #2212
Feature-flag gated (`aks.kickstartEnabledPreview`) GitHub Copilot chat agent that guides users through deploying an app to AKS Automatic. Adds a Kickstart UI with two panels handling managed AKS Automatic cluster creation and project selection, and hands off to Copilot chat with validation for repo selection, permissions/role management, and cluster creation.

**Fixes**
- **container-assist**: stop the managed-namespace update step from wiping existing annotations/labels on every push (#2277). The destructive per-deploy `az aks namespace update` (ARM PUT) is replaced by a one-time typed read-modify-write in OIDC setup that preserves existing metadata and fails closed.
- **shell**: handle `err.code` as `string | number` after the `@types/node` 26 bump, fixing the webpack build (#2259).
- **webpack**: correct the `aks-deploy.template.yaml` source path so `npm run package` builds the VSIX again (#2258).
- **security**: resolve all 12 `npm audit` vulnerabilities (2 low / 7 moderate / 3 high → 0), including arm-resourcegraph and js-yaml upgrades (#2249).

**Cleanup**
- Remove the unused DevHub Automated Deployments flow — backend, panel, webview contract/UI, manual-test scaffolding, and stale dependency (#2228).
- Follow-up cleanup of orphaned l10n strings and docs; rename the "Automated Deployments" submenu to "Deployment Tools" to reflect the remaining Draft/ACR/ArgoCD tools (#2230).

**Discoverability**
- Update marketplace `displayName` to `Azure Kubernetes Service (AKS)` and refresh the description so the extension ranks for the "AKS" query (#2226).

**Tests & infra**
- Make LM-unavailable container-assist tests deterministic by stubbing `vscode.lm.selectChatModels` (#2223, #2266).
- 36 Dependabot dependency bumps across root and `webview-ui`.

### Notes
- `CHANGELOG.md` is intentionally not updated (deprecated since 1.6.14). Release notes live in the GitHub Release.
- After merge, the internal 1ES signed pipeline publishes to the marketplace.

Thanks to @bosesuneha, @Tatsinnit, and @tejhan for contributions, testing, and reviews.
