### PR TITLE
chore: add .npmrc pointing to Microsoft CFS npm proxy

### DIFF
--- a/.azurepipelines/1es-pipeline.yml
+++ b/.azurepipelines/1es-pipeline.yml
@@ -76,7 +76,7 @@ extends:
 
                         - script: |
                               set -e
-                              npx @vscode/vsce@latest package
+                              npx @vscode/vsce@3.9.2 package
                               VSIX_PATH=$(find . -type f -name "*.vsix" -print -quit)
                               if [ -z "$VSIX_PATH" ]; then
                                 echo "ERROR: No .vsix file found!" >&2
@@ -95,7 +95,7 @@ extends:
                               set -e
                               VSIX_PATH=$(find "$(Pipeline.Workspace)/vscode-extension-signed/" -type f -name "*.vsix" -print -quit)
                               echo "Generating manifest for: $VSIX_PATH"
-                              npx @vscode/vsce@latest generate-manifest -i "$VSIX_PATH" -o "$(Pipeline.Workspace)/vscode-extension-signed/extension.manifest"
+                              npx @vscode/vsce@3.9.2 generate-manifest -i "$VSIX_PATH" -o "$(Pipeline.Workspace)/vscode-extension-signed/extension.manifest"
                           displayName: "Generate extension manifest"
 
                         - script: |
@@ -142,7 +142,7 @@ extends:
                               echo "Publishing VSIX package: $VSIX_PATH"
                               MANIFEST_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.manifest"
                               SIGNATURE_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.signature.p7s"
-                              npx @vscode/vsce@latest publish --pat "$TOKEN" --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
+                              npx @vscode/vsce@3.9.2 publish --pat "$TOKEN" --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
                           displayName: "Publish VSIX to Marketplace"
                           env:
                               TOKEN: ${{ parameters.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
           marketplace.visualstudio.com:443
           nodejs.org:443
           objects.githubusercontent.com:443
+          packagefeedproxy.microsoft.io:443
           registry.npmjs.org:443
           update.code.visualstudio.com:443
           vscode.download.prss.microsoft.com:443

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           registry.npmjs.org:443
           update.code.visualstudio.com:443
           vscode.download.prss.microsoft.com:443
+          *.vsblob.vsassets.io:443
 
     - name: Checkout Branch
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://packagefeedproxy.microsoft.io/npm/
+always-auth=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,14 +90,14 @@
         },
         "node_modules/@azu/format-text": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azu/format-text/-/format-text-1.0.2.tgz",
             "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@azu/style-format": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azu/style-format/-/style-format-1.0.1.tgz",
             "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
             "dev": true,
             "license": "WTFPL",
@@ -107,7 +107,7 @@
         },
         "node_modules/@azure-rest/ai-translation-text": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure-rest/ai-translation-text/-/ai-translation-text-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure-rest/ai-translation-text/-/ai-translation-text-1.0.1.tgz",
             "integrity": "sha512-lUs1FfBXjik6EReUEYP1ogkhaSPHZdUV+EB215y7uejuyHgG1RXD2aLsqXQrluZwXcLMdN+bTzxylKBc5xDhgQ==",
             "dev": true,
             "license": "MIT",
@@ -124,7 +124,7 @@
         },
         "node_modules/@azure-rest/core-client": {
             "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure-rest/core-client/-/core-client-2.7.0.tgz",
             "integrity": "sha512-rL0lJqh1E8HLXNgjIw8cRyGAV/v+m6p1xRu/8OhsnmN8XHhwkyYJkAoGM+zrew96v7jZYPmVfy7pv7v4Iccfsg==",
             "license": "MIT",
             "dependencies": {
@@ -141,7 +141,7 @@
         },
         "node_modules/@azure/abort-controller": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
             "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
             "license": "MIT",
             "dependencies": {
@@ -153,7 +153,7 @@
         },
         "node_modules/@azure/arm-authorization": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-authorization/-/arm-authorization-9.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-authorization/-/arm-authorization-9.0.0.tgz",
             "integrity": "sha512-GdiCA8IA1gO+qcCbFEPj+iLC4+3ByjfKzmeAnkP7MdlL84Yo30Huo/EwbZzwRjYybXYUBuFxGPBB+yeTT4Ebxg==",
             "license": "MIT",
             "dependencies": {
@@ -169,7 +169,7 @@
         },
         "node_modules/@azure/arm-compute": {
             "version": "24.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-compute/-/arm-compute-24.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-compute/-/arm-compute-24.1.0.tgz",
             "integrity": "sha512-RabLRMQ05DF13VgV5BKKJ1/+7KG5LkwCaYTPNQxwbUTYm0vgH4WEypBMCiWHklt5FoBL8EFyfux2f1gWVU4JkQ==",
             "license": "MIT",
             "dependencies": {
@@ -188,7 +188,7 @@
         },
         "node_modules/@azure/arm-containerregistry": {
             "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-11.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-containerregistry/-/arm-containerregistry-11.0.0.tgz",
             "integrity": "sha512-T3M5PW+SrAxqSoI+d96nF/c3Z+4uXx9w0gwC7g7JY9CznPzA4ycsiYuFXn1ddynzzNcuKZFoa4xMVZAiLr8nag==",
             "license": "MIT",
             "dependencies": {
@@ -206,7 +206,7 @@
         },
         "node_modules/@azure/arm-containerregistry/node_modules/@azure/core-lro": {
             "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-2.7.2.tgz",
             "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
             "license": "MIT",
             "dependencies": {
@@ -221,7 +221,7 @@
         },
         "node_modules/@azure/arm-containerservice": {
             "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-25.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-containerservice/-/arm-containerservice-25.1.0.tgz",
             "integrity": "sha512-dPZAp2mOD3mj5XoY2p/ZzWV5/8IjFjHtnpTVOu+NyEfNkb5PiOy+IR2lOAk8PKVsguOiWqijknr2jSmCUfVdpQ==",
             "license": "MIT",
             "dependencies": {
@@ -240,7 +240,7 @@
         },
         "node_modules/@azure/arm-containerservicefleet": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-containerservicefleet/-/arm-containerservicefleet-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-containerservicefleet/-/arm-containerservicefleet-2.0.0.tgz",
             "integrity": "sha512-9P4/WcVQa5FCYO2phRwGBAZRcW30jxHPSXiery+nvEA+hWCVp3kFxYRnRAxdD2ExcmwPLzHHnYtu2FXqvQB0Tg==",
             "license": "MIT",
             "dependencies": {
@@ -259,7 +259,7 @@
         },
         "node_modules/@azure/arm-features": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-features/-/arm-features-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-features/-/arm-features-3.1.0.tgz",
             "integrity": "sha512-qw2JbK80G1DwevhPvofLJg9uSlfNKHN5fQJQ5CQoT5OkuTNz+48p+1B30JTwtClSv5/7G4Th3ECL6sZOO80NCw==",
             "license": "MIT",
             "dependencies": {
@@ -275,7 +275,7 @@
         },
         "node_modules/@azure/arm-monitor": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-monitor/-/arm-monitor-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-monitor/-/arm-monitor-7.0.0.tgz",
             "integrity": "sha512-RtCLRc/29bqaaf5iuUOmJvc5XDolN/icFhlKC/rXXKTtmwB3sKymaOZbNHnOM4P0nJYpS5QIo7Nzvh4M3Wj+FA==",
             "license": "MIT",
             "dependencies": {
@@ -293,7 +293,7 @@
         },
         "node_modules/@azure/arm-monitor/node_modules/@azure/abort-controller": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "license": "MIT",
             "dependencies": {
@@ -305,7 +305,7 @@
         },
         "node_modules/@azure/arm-monitor/node_modules/@azure/core-lro": {
             "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-2.7.2.tgz",
             "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
             "license": "MIT",
             "dependencies": {
@@ -320,7 +320,7 @@
         },
         "node_modules/@azure/arm-monitor/node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
             "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
             "license": "MIT",
             "dependencies": {
@@ -332,7 +332,7 @@
         },
         "node_modules/@azure/arm-msi": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-msi/-/arm-msi-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-msi/-/arm-msi-2.2.0.tgz",
             "integrity": "sha512-Wqg9j9qR+k1IxZXwKtegZWj6k1d6UUGOz4uHPmhyJOeiQrtZHXBcaWSZhtqJo5sy888TD6jVIQV/4znhbKYL9g==",
             "license": "MIT",
             "dependencies": {
@@ -348,7 +348,7 @@
         },
         "node_modules/@azure/arm-resourcegraph": {
             "version": "5.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resourcegraph/-/arm-resourcegraph-5.0.0-beta.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-resourcegraph/-/arm-resourcegraph-5.0.0-beta.5.tgz",
             "integrity": "sha512-8RllIu+ZsQm3LpmLE3uaO10l3VPxwzFNkBNKEGAmzsDGio29GT2LB6qj5P2lYsq3u3jLSbkrABtRvi/sxzHA6w==",
             "license": "MIT",
             "dependencies": {
@@ -365,7 +365,7 @@
         },
         "node_modules/@azure/arm-resources": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-resources/-/arm-resources-7.0.0.tgz",
             "integrity": "sha512-ezC1YLuPp1bh0GQFALcBvBxAB+9H5O0ynS40jp1t6hTlYe2t61cSplM3M4+4+nt9FCFZOjQSgAwj4KWYb8gruA==",
             "license": "MIT",
             "dependencies": {
@@ -383,7 +383,7 @@
         },
         "node_modules/@azure/arm-resources-subscriptions": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
             "integrity": "sha512-vKiu/3Yh84IV3IuJJ+0Fgs/ZQpvuGzoZ3dAoBksIV++Uu/Qz9RcQVz7pj+APWYIuODuR9I0eGKswZvzynzekug==",
             "license": "MIT",
             "dependencies": {
@@ -399,7 +399,7 @@
         },
         "node_modules/@azure/arm-resources/node_modules/@azure/core-lro": {
             "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-2.7.2.tgz",
             "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
             "license": "MIT",
             "dependencies": {
@@ -414,7 +414,7 @@
         },
         "node_modules/@azure/arm-storage": {
             "version": "20.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-20.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-storage/-/arm-storage-20.1.0.tgz",
             "integrity": "sha512-I2vqwVBB2AxN+aM5PN3rqqqZS3p/1ix4u8Qn7jOaUirkLrkmHnmTzw+aQitza8o1OxkOQ0rR5diikdA5+DcGmw==",
             "license": "MIT",
             "dependencies": {
@@ -433,7 +433,7 @@
         },
         "node_modules/@azure/arm-subscriptions": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/arm-subscriptions/-/arm-subscriptions-6.0.0.tgz",
             "integrity": "sha512-QkhMIRvP6koytI5EXC99ZxJDC1eBigYG6KEoHSF1fAKKeQgtZzaczTfX8Pc7zjZpks5J91kMcMk99UEj8+ahPw==",
             "license": "MIT",
             "dependencies": {
@@ -451,7 +451,7 @@
         },
         "node_modules/@azure/arm-subscriptions/node_modules/@azure/core-lro": {
             "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-2.7.2.tgz",
             "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
             "license": "MIT",
             "dependencies": {
@@ -466,7 +466,7 @@
         },
         "node_modules/@azure/container-registry": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/container-registry/-/container-registry-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/container-registry/-/container-registry-1.1.2.tgz",
             "integrity": "sha512-XGhsf29YEs+2E0nyyTIS7MiWOiE2dUpN7CEy26p/muMalDu+PfrIbacXAxHZ2fVeS3VrddcImlqT+i3BXjdDXg==",
             "license": "MIT",
             "dependencies": {
@@ -485,7 +485,7 @@
         },
         "node_modules/@azure/core-auth": {
             "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-auth/-/core-auth-1.10.1.tgz",
             "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
             "license": "MIT",
             "dependencies": {
@@ -499,7 +499,7 @@
         },
         "node_modules/@azure/core-client": {
             "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-client/-/core-client-1.10.2.tgz",
             "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
             "license": "MIT",
             "dependencies": {
@@ -517,7 +517,7 @@
         },
         "node_modules/@azure/core-http-compat": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
             "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
             "license": "MIT",
             "dependencies": {
@@ -533,7 +533,7 @@
         },
         "node_modules/@azure/core-lro": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-3.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-3.3.1.tgz",
             "integrity": "sha512-bulm3klLqIAhzI3iQMYQ42i+V9EnevScsHdI9amFfjaw6OJqPBK1038cq5qachoKV3yt/iQQEDittHmZW2aSuA==",
             "license": "MIT",
             "dependencies": {
@@ -548,7 +548,7 @@
         },
         "node_modules/@azure/core-paging": {
             "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-paging/-/core-paging-1.6.2.tgz",
             "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
             "license": "MIT",
             "dependencies": {
@@ -560,7 +560,7 @@
         },
         "node_modules/@azure/core-rest-pipeline": {
             "version": "1.24.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
             "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
             "license": "MIT",
             "dependencies": {
@@ -578,7 +578,7 @@
         },
         "node_modules/@azure/core-tracing": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
             "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
             "license": "MIT",
             "dependencies": {
@@ -590,7 +590,7 @@
         },
         "node_modules/@azure/core-util": {
             "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-util/-/core-util-1.13.1.tgz",
             "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
             "license": "MIT",
             "dependencies": {
@@ -604,7 +604,7 @@
         },
         "node_modules/@azure/core-xml": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-xml/-/core-xml-1.5.1.tgz",
             "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
             "license": "MIT",
             "dependencies": {
@@ -617,7 +617,7 @@
         },
         "node_modules/@azure/identity": {
             "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/identity/-/identity-4.13.1.tgz",
             "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
             "license": "MIT",
             "dependencies": {
@@ -639,7 +639,7 @@
         },
         "node_modules/@azure/logger": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/logger/-/logger-1.3.0.tgz",
             "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
             "license": "MIT",
             "dependencies": {
@@ -652,14 +652,14 @@
         },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
             "deprecated": "This package has been deprecated. new Azure Management SDK package from [Azure SDK for JavaScript](https://github.com/azure/azure-sdk-for-js) now have the cloud settings built-in, [for example](https://github.com/Azure/azure-sdk-for-js/blob/dc5f9743b05ea78f938eba31cbe704150889490c/sdk/sql/arm-sql/src/static-helpers/cloudSettingHelpers.ts).",
             "license": "MIT"
         },
         "node_modules/@azure/msal-browser": {
             "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/msal-browser/-/msal-browser-5.15.0.tgz",
             "integrity": "sha512-2NYT6v+eeQn8kmNddr9LnbXSvXbVELpmFMmfFvtRxD7I/5+5GlkMlncApeuRFj+mY6C9syOwQip1a0Y+TIbyiA==",
             "license": "MIT",
             "dependencies": {
@@ -671,7 +671,7 @@
         },
         "node_modules/@azure/msal-common": {
             "version": "16.10.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.10.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/msal-common/-/msal-common-16.10.0.tgz",
             "integrity": "sha512-iYtjpanlv6963Jprs0MvzIap07V+QhultjQctfbEDQCflsDAEeO3R7XnVA5gk30fhoBFLdgJT7VqO0TGsEsN9w==",
             "license": "MIT",
             "engines": {
@@ -680,7 +680,7 @@
         },
         "node_modules/@azure/msal-node": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/msal-node/-/msal-node-5.3.0.tgz",
             "integrity": "sha512-fXtJX811pX8y8QlrQqBSH6+plvWyKZDI0IxkheAcyAw9OtcpXyFivmTC7eGUqutLWaDlKXuQ3yOESD4zAmkjHg==",
             "license": "MIT",
             "dependencies": {
@@ -693,7 +693,7 @@
         },
         "node_modules/@azure/storage-blob": {
             "version": "12.33.0",
-            "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
             "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
             "license": "MIT",
             "dependencies": {
@@ -718,7 +718,7 @@
         },
         "node_modules/@azure/storage-blob/node_modules/@azure/core-lro": {
             "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/core-lro/-/core-lro-2.7.2.tgz",
             "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
             "license": "MIT",
             "dependencies": {
@@ -733,7 +733,7 @@
         },
         "node_modules/@azure/storage-common": {
             "version": "12.4.1",
-            "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@azure/storage-common/-/storage-common-12.4.1.tgz",
             "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
             "license": "MIT",
             "dependencies": {
@@ -753,7 +753,7 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/code-frame/-/code-frame-7.29.7.tgz",
             "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
@@ -768,7 +768,7 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
@@ -778,7 +778,7 @@
         },
         "node_modules/@babel/runtime": {
             "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/runtime/-/runtime-7.29.7.tgz",
             "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
             "license": "MIT",
             "engines": {
@@ -787,13 +787,13 @@
         },
         "node_modules/@balena/dockerignore": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
             "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
             "license": "Apache-2.0"
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
             "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
             "dev": true,
             "license": "MIT",
@@ -803,7 +803,7 @@
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "devOptional": true,
             "license": "MIT",
@@ -822,7 +822,7 @@
         },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "devOptional": true,
             "license": "MIT",
@@ -832,7 +832,7 @@
         },
         "node_modules/@eslint/compat": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/compat/-/compat-2.1.0.tgz",
             "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -852,7 +852,7 @@
         },
         "node_modules/@eslint/config-array": {
             "version": "0.23.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-array/-/config-array-0.23.5.tgz",
             "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -867,7 +867,7 @@
         },
         "node_modules/@eslint/config-array/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "devOptional": true,
             "license": "MIT",
@@ -877,7 +877,7 @@
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "devOptional": true,
             "license": "MIT",
@@ -890,7 +890,7 @@
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "devOptional": true,
             "license": "BlueOak-1.0.0",
@@ -906,7 +906,7 @@
         },
         "node_modules/@eslint/config-helpers": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
             "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -919,7 +919,7 @@
         },
         "node_modules/@eslint/core": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/core/-/core-1.2.1.tgz",
             "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -931,7 +931,7 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
             "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
             "dev": true,
             "license": "MIT",
@@ -955,7 +955,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ajv": {
             "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-6.15.0.tgz",
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
@@ -972,7 +972,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/globals/-/globals-14.0.0.tgz",
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
@@ -985,14 +985,14 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@eslint/js": {
             "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/js/-/js-10.0.1.tgz",
             "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
             "dev": true,
             "license": "MIT",
@@ -1013,7 +1013,7 @@
         },
         "node_modules/@eslint/object-schema": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/object-schema/-/object-schema-3.0.5.tgz",
             "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1023,7 +1023,7 @@
         },
         "node_modules/@eslint/plugin-kit": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
             "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1037,7 +1037,7 @@
         },
         "node_modules/@grpc/grpc-js": {
             "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
             "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1050,7 +1050,7 @@
         },
         "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
             "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
             "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1068,7 +1068,7 @@
         },
         "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
             "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/protobufjs/-/protobufjs-7.6.4.tgz",
             "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -1091,7 +1091,7 @@
         },
         "node_modules/@grpc/proto-loader": {
             "version": "0.7.15",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
             "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1109,7 +1109,7 @@
         },
         "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
             "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/protobufjs/-/protobufjs-7.6.4.tgz",
             "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -1132,7 +1132,7 @@
         },
         "node_modules/@hono/node-server": {
             "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@hono/node-server/-/node-server-1.19.14.tgz",
             "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
             "license": "MIT",
             "engines": {
@@ -1144,7 +1144,7 @@
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/core/-/core-0.19.2.tgz",
             "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1157,7 +1157,7 @@
         },
         "node_modules/@humanfs/node": {
             "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/node/-/node-0.16.8.tgz",
             "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1172,7 +1172,7 @@
         },
         "node_modules/@humanfs/types": {
             "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/types/-/types-0.15.0.tgz",
             "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1182,7 +1182,7 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1196,7 +1196,7 @@
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -1210,13 +1210,13 @@
         },
         "node_modules/@iarna/toml": {
             "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@iarna/toml/-/toml-2.2.5.tgz",
             "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
             "license": "ISC"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
@@ -1234,7 +1234,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -1247,14 +1247,14 @@
         },
         "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
@@ -1272,7 +1272,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "license": "MIT",
@@ -1290,7 +1290,7 @@
         },
         "node_modules/@isaacs/fs-minipass": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
             "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
             "license": "ISC",
             "dependencies": {
@@ -1302,7 +1302,7 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "license": "MIT",
@@ -1313,7 +1313,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "license": "MIT",
@@ -1323,7 +1323,7 @@
         },
         "node_modules/@jridgewell/source-map": {
             "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/source-map/-/source-map-0.3.11.tgz",
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
@@ -1334,14 +1334,14 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
@@ -1352,7 +1352,7 @@
         },
         "node_modules/@js-sdsl/ordered-map": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
             "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
             "license": "MIT",
             "funding": {
@@ -1362,7 +1362,7 @@
         },
         "node_modules/@jsep-plugin/assignment": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
             "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
             "license": "MIT",
             "engines": {
@@ -1374,7 +1374,7 @@
         },
         "node_modules/@jsep-plugin/regex": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jsep-plugin/regex/-/regex-1.0.4.tgz",
             "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
             "license": "MIT",
             "engines": {
@@ -1386,7 +1386,7 @@
         },
         "node_modules/@kubernetes-models/apimachinery": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@kubernetes-models/apimachinery/-/apimachinery-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@kubernetes-models/apimachinery/-/apimachinery-2.2.0.tgz",
             "integrity": "sha512-7Yj3aMz/nCTdr221wHOMsw5vAMJnLqANMI3BTuCmYjbP+7/tGAaOsiFwT75F4TJH45Dk1P6wcAEqDeCD1ur82Q==",
             "license": "MIT",
             "dependencies": {
@@ -1400,7 +1400,7 @@
         },
         "node_modules/@kubernetes-models/base": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@kubernetes-models/base/-/base-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@kubernetes-models/base/-/base-5.0.1.tgz",
             "integrity": "sha512-Yfzmh965y/hT8qs9eE+Ms9sO1iT31c/sPoJerBFRGS9KechXXfxHgeqtpOzq+eByQ1INblkcZ09rt2V0FxG0lA==",
             "license": "MIT",
             "dependencies": {
@@ -1414,7 +1414,7 @@
         },
         "node_modules/@kubernetes-models/validate": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@kubernetes-models/validate/-/validate-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@kubernetes-models/validate/-/validate-4.0.0.tgz",
             "integrity": "sha512-rsfF5t3sd5c+3ejUgcy8q0cVG2/BxT064L4Xz+CuKEe014u8T4MtFZiWjWZFpfMXSGKzFYEA6DJYm9CqjmIfZg==",
             "license": "MIT",
             "dependencies": {
@@ -1434,7 +1434,7 @@
         },
         "node_modules/@kubernetes/client-node": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@kubernetes/client-node/-/client-node-1.4.0.tgz",
             "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1458,7 +1458,7 @@
         },
         "node_modules/@kubernetes/client-node/node_modules/@types/node": {
             "version": "24.13.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node/-/node-24.13.2.tgz",
             "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
             "license": "MIT",
             "dependencies": {
@@ -1467,7 +1467,7 @@
         },
         "node_modules/@kubernetes/client-node/node_modules/node-fetch": {
             "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "license": "MIT",
             "dependencies": {
@@ -1487,13 +1487,13 @@
         },
         "node_modules/@kubernetes/client-node/node_modules/undici-types": {
             "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "license": "MIT"
         },
         "node_modules/@microsoft/1ds-core-js": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/1ds-core-js/-/1ds-core-js-4.4.2.tgz",
             "integrity": "sha512-8cF2XKBMOOASA3l/SLqybGeZ5e+vhtpYeHTBCM1WoQJ5M8suw181FBKgdyz8XP0fTgv1LTOHqPDSmddMiFaJ/g==",
             "license": "MIT",
             "dependencies": {
@@ -1506,7 +1506,7 @@
         },
         "node_modules/@microsoft/1ds-post-js": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/1ds-post-js/-/1ds-post-js-4.4.2.tgz",
             "integrity": "sha512-mGB3yczMTQchEaFwCmcc5wOm6WXLrUeLpCnuAEMscPij0JzrWnSJ0lvNHcuOGpT/8yJTyuzJohG8/ePIYyRITQ==",
             "license": "MIT",
             "dependencies": {
@@ -1519,7 +1519,7 @@
         },
         "node_modules/@microsoft/applicationinsights-channel-js": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.2.tgz",
             "integrity": "sha512-Q7Q9gV45WSgSmOP2abu0y9tdbFh8sPELMgKUCDy62FsNd3xmE8X3zLtkzc7mcXPlpTeoDXwMCYjCRIAYd6d2lQ==",
             "license": "MIT",
             "dependencies": {
@@ -1535,7 +1535,7 @@
         },
         "node_modules/@microsoft/applicationinsights-common": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.2.tgz",
             "integrity": "sha512-HEoJwACjpAIAId0XAw2+DDydwmilwCpBK3XdQpuXAJlrXhvElw5Yd+ZLmP1J9FjWFh0eJaws1uE9FjW+qqAiFw==",
             "license": "MIT",
             "dependencies": {
@@ -1550,7 +1550,7 @@
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.2.tgz",
             "integrity": "sha512-Iw3gq1JREKLbXiVpr3F0+Ezuzphe+o25n9me9H5Kkjmck6tIkuGQea01SNfeemE4wf2mop2QQSvTcKxT8tNN1g==",
             "license": "MIT",
             "dependencies": {
@@ -1565,7 +1565,7 @@
         },
         "node_modules/@microsoft/applicationinsights-shims": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
             "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
             "license": "MIT",
             "dependencies": {
@@ -1574,7 +1574,7 @@
         },
         "node_modules/@microsoft/applicationinsights-web-basic": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.2.tgz",
             "integrity": "sha512-ONJbCSdJ/KMOVT7b8oVVPa2Etp99SHhehprpQn51QrHTiJtTehBLOmovBBIKQZuwWm0ZLKOaoUBWHCkRXUqNAw==",
             "license": "MIT",
             "dependencies": {
@@ -1591,7 +1591,7 @@
         },
         "node_modules/@microsoft/dynamicproto-js": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.5.tgz",
             "integrity": "sha512-V+Zr7PDKIEaItVwF/OyWQlKeugNRYg7KJJ+RhEIL2FMW6NlG8FN2l4XA9Z42hNtsjwJFlcUiF38pmM/AaXsF7g==",
             "license": "MIT",
             "dependencies": {
@@ -1600,7 +1600,7 @@
         },
         "node_modules/@microsoft/microsoft-graph-client": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.7.tgz",
             "integrity": "sha512-/AazAV/F+HK4LIywF9C+NYHcJo038zEnWkteilcxC1FM/uK/4NVGDKGrxx7nNq1ybspAroRKT4I1FHfxQzxkUw==",
             "license": "MIT",
             "dependencies": {
@@ -1627,7 +1627,7 @@
         },
         "node_modules/@microsoft/vscode-azext-utils": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
             "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
@@ -1654,7 +1654,7 @@
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
             "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
@@ -1666,7 +1666,7 @@
         },
         "node_modules/@microsoft/vscode-processutils": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-processutils/-/vscode-processutils-0.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@microsoft/vscode-processutils/-/vscode-processutils-0.2.2.tgz",
             "integrity": "sha512-kvADRfnSAUcusBzBAn0eDsh880MjTw1tvYGUes6yxUBALkg7RiQPuy2p3gDR4+p+VZqb2T2youY4jgq3/6jnKw==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
@@ -1676,7 +1676,7 @@
         },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
             "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
             "license": "MIT",
             "dependencies": {
@@ -1716,7 +1716,7 @@
         },
         "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
@@ -1733,7 +1733,7 @@
         },
         "node_modules/@modelcontextprotocol/sdk/node_modules/content-type": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "license": "MIT",
             "engines": {
@@ -1742,7 +1742,7 @@
         },
         "node_modules/@nevware21/ts-async": {
             "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
             "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
             "license": "MIT",
             "dependencies": {
@@ -1751,7 +1751,7 @@
         },
         "node_modules/@nevware21/ts-utils": {
             "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
             "integrity": "sha512-+bUMKIiKAgoW5uNEb5xxzBzdwdLS9SKRcOy8SxLE+KqSlIdUYV5O9nxJVq1RUYcO2DtL5DlrK1GbgcVEHv6GVA==",
             "funding": [
                 {
@@ -1767,7 +1767,7 @@
         },
         "node_modules/@nodable/entities": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nodable/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
             "funding": [
                 {
@@ -1779,7 +1779,7 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
             "license": "MIT",
@@ -1793,7 +1793,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
             "license": "MIT",
@@ -1803,7 +1803,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "license": "MIT",
@@ -1817,7 +1817,7 @@
         },
         "node_modules/@octokit/auth-token": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/auth-token/-/auth-token-6.0.0.tgz",
             "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
             "license": "MIT",
             "engines": {
@@ -1826,7 +1826,7 @@
         },
         "node_modules/@octokit/core": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/core/-/core-7.0.6.tgz",
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "license": "MIT",
             "dependencies": {
@@ -1844,7 +1844,7 @@
         },
         "node_modules/@octokit/endpoint": {
             "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/endpoint/-/endpoint-11.0.3.tgz",
             "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
             "license": "MIT",
             "dependencies": {
@@ -1857,7 +1857,7 @@
         },
         "node_modules/@octokit/graphql": {
             "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/graphql/-/graphql-9.0.3.tgz",
             "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
             "license": "MIT",
             "dependencies": {
@@ -1871,13 +1871,13 @@
         },
         "node_modules/@octokit/openapi-types": {
             "version": "27.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
             "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
             "license": "MIT"
         },
         "node_modules/@octokit/plugin-paginate-rest": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
             "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
             "license": "MIT",
             "dependencies": {
@@ -1892,7 +1892,7 @@
         },
         "node_modules/@octokit/plugin-request-log": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
             "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
             "license": "MIT",
             "engines": {
@@ -1904,7 +1904,7 @@
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
             "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
             "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
             "license": "MIT",
             "dependencies": {
@@ -1919,7 +1919,7 @@
         },
         "node_modules/@octokit/request": {
             "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/request/-/request-10.0.10.tgz",
             "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
             "license": "MIT",
             "dependencies": {
@@ -1936,7 +1936,7 @@
         },
         "node_modules/@octokit/request-error": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/request-error/-/request-error-7.1.0.tgz",
             "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
             "license": "MIT",
             "dependencies": {
@@ -1948,7 +1948,7 @@
         },
         "node_modules/@octokit/rest": {
             "version": "22.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/rest/-/rest-22.0.1.tgz",
             "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
             "license": "MIT",
             "dependencies": {
@@ -1963,7 +1963,7 @@
         },
         "node_modules/@octokit/types": {
             "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@octokit/types/-/types-16.0.0.tgz",
             "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
             "license": "MIT",
             "dependencies": {
@@ -1972,7 +1972,7 @@
         },
         "node_modules/@open-policy-agent/opa-wasm": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@open-policy-agent/opa-wasm/-/opa-wasm-1.10.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@open-policy-agent/opa-wasm/-/opa-wasm-1.10.0.tgz",
             "integrity": "sha512-ymR/nFS3nO9o24j9xowGGQaf+Gmb813QcxUpVZkfRlJkawKWqSIllnEH15agyWjijmOIyhA+OBErenx6N3jphw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1982,7 +1982,7 @@
         },
         "node_modules/@open-policy-agent/opa-wasm/node_modules/yaml": {
             "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yaml/-/yaml-1.10.3.tgz",
             "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "license": "ISC",
             "engines": {
@@ -1991,13 +1991,13 @@
         },
         "node_modules/@pinojs/redact": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@pinojs/redact/-/redact-0.4.0.tgz",
             "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
             "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
             "license": "MIT",
@@ -2008,31 +2008,31 @@
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
             "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/base64/-/base64-1.1.2.tgz",
             "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/codegen/-/codegen-2.0.5.tgz",
             "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
             "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/fetch/-/fetch-1.1.1.tgz",
             "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -2041,31 +2041,31 @@
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/path/-/path-1.1.2.tgz",
             "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/pool/-/pool-1.1.0.tgz",
             "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@protobufjs/utf8/-/utf8-1.1.1.tgz",
             "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@secretlint/config-creator": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
             "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
             "dev": true,
             "license": "MIT",
@@ -2078,7 +2078,7 @@
         },
         "node_modules/@secretlint/config-loader": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
             "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
             "dev": true,
             "license": "MIT",
@@ -2096,7 +2096,7 @@
         },
         "node_modules/@secretlint/core": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/core/-/core-10.2.2.tgz",
             "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
             "dev": true,
             "license": "MIT",
@@ -2112,7 +2112,7 @@
         },
         "node_modules/@secretlint/formatter": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/formatter/-/formatter-10.2.2.tgz",
             "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
             "dev": true,
             "license": "MIT",
@@ -2135,7 +2135,7 @@
         },
         "node_modules/@secretlint/formatter/node_modules/chalk": {
             "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
@@ -2148,7 +2148,7 @@
         },
         "node_modules/@secretlint/node": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/node/-/node-10.2.2.tgz",
             "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
             "dev": true,
             "license": "MIT",
@@ -2168,21 +2168,21 @@
         },
         "node_modules/@secretlint/profiler": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/profiler/-/profiler-10.2.2.tgz",
             "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@secretlint/resolver": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/resolver/-/resolver-10.2.2.tgz",
             "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@secretlint/secretlint-formatter-sarif": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
             "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
             "dev": true,
             "license": "MIT",
@@ -2192,7 +2192,7 @@
         },
         "node_modules/@secretlint/secretlint-rule-no-dotenv": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
             "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
             "dev": true,
             "license": "MIT",
@@ -2205,7 +2205,7 @@
         },
         "node_modules/@secretlint/secretlint-rule-preset-recommend": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
             "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
             "dev": true,
             "license": "MIT",
@@ -2215,7 +2215,7 @@
         },
         "node_modules/@secretlint/source-creator": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
             "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
             "dev": true,
             "license": "MIT",
@@ -2229,7 +2229,7 @@
         },
         "node_modules/@secretlint/types": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@secretlint/types/-/types-10.2.2.tgz",
             "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
             "dev": true,
             "license": "MIT",
@@ -2239,7 +2239,7 @@
         },
         "node_modules/@selderee/plugin-htmlparser2": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
             "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
             "license": "MIT",
             "dependencies": {
@@ -2252,7 +2252,7 @@
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
             "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
             "license": "MIT",
@@ -2265,7 +2265,7 @@
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@sinonjs/commons/-/commons-3.0.1.tgz",
             "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -2275,7 +2275,7 @@
         },
         "node_modules/@sinonjs/fake-timers": {
             "version": "15.4.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
             "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -2285,7 +2285,7 @@
         },
         "node_modules/@sinonjs/samsam": {
             "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@sinonjs/samsam/-/samsam-10.0.2.tgz",
             "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -2296,7 +2296,7 @@
         },
         "node_modules/@sinonjs/samsam/node_modules/type-detect": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-detect/-/type-detect-4.1.0.tgz",
             "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
             "dev": true,
             "license": "MIT",
@@ -2306,7 +2306,7 @@
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.23",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@swc/helpers/-/helpers-0.5.23.tgz",
             "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2315,14 +2315,14 @@
         },
         "node_modules/@textlint/ast-node-types": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
             "integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
             "integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
             "dev": true,
             "license": "MIT",
@@ -2345,7 +2345,7 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -2355,14 +2355,14 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pluralize/-/pluralize-2.0.0.tgz",
             "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -2375,21 +2375,21 @@
         },
         "node_modules/@textlint/module-interop": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@textlint/module-interop/-/module-interop-15.7.1.tgz",
             "integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/resolver": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@textlint/resolver/-/resolver-15.7.1.tgz",
             "integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/types": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@textlint/types/-/types-15.7.1.tgz",
             "integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
             "dev": true,
             "license": "MIT",
@@ -2399,7 +2399,7 @@
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/chai/-/chai-5.2.3.tgz",
             "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "license": "MIT",
@@ -2410,7 +2410,7 @@
         },
         "node_modules/@types/decompress": {
             "version": "4.2.7",
-            "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/decompress/-/decompress-4.2.7.tgz",
             "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
             "dev": true,
             "license": "MIT",
@@ -2420,14 +2420,14 @@
         },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
             "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
@@ -2438,33 +2438,33 @@
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/js-yaml": {
             "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/js-yaml/-/js-yaml-4.0.9.tgz",
             "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "license": "MIT"
         },
         "node_modules/@types/libsodium-wrappers": {
             "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
             "integrity": "sha512-+2IDfSULPUskSjIYfZl9suIUsIE5PXwoKZiE/j0MZWd+M9nEGvJDsk/ztMZKNhL1lBL+1CaypW0dQSjqPW2dMg==",
             "deprecated": "This is a stub types definition. libsodium-wrappers provides its own type definitions, so you do not need this installed.",
             "dev": true,
@@ -2475,14 +2475,14 @@
         },
         "node_modules/@types/mocha": {
             "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mocha/-/mocha-10.0.10.tgz",
             "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node/-/node-26.1.0.tgz",
             "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
             "license": "MIT",
             "dependencies": {
@@ -2491,7 +2491,7 @@
         },
         "node_modules/@types/node-fetch": {
             "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node-fetch/-/node-fetch-2.6.13.tgz",
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
             "license": "MIT",
             "dependencies": {
@@ -2501,28 +2501,28 @@
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/sarif": {
             "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/semver": {
             "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/sinon": {
             "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-22.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/sinon/-/sinon-22.0.0.tgz",
             "integrity": "sha512-TDbVpbccc2HfiqHR09Argj3mHV1KMW7sCCKj52fsl8lbRLkEn7fB1966EWhOKWUBcqfBueZuPoA7/OK1CKiy3g==",
             "dev": true,
             "license": "MIT",
@@ -2532,14 +2532,14 @@
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "15.0.1",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
             "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/stream-buffers": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
             "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
             "license": "MIT",
             "dependencies": {
@@ -2548,14 +2548,14 @@
         },
         "node_modules/@types/tmp": {
             "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/tmp/-/tmp-0.2.6.tgz",
             "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/uuid": {
             "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/uuid/-/uuid-11.0.0.tgz",
             "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
             "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
             "dev": true,
@@ -2566,14 +2566,14 @@
         },
         "node_modules/@types/vscode": {
             "version": "1.125.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/vscode/-/vscode-1.125.0.tgz",
             "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/xml2js": {
             "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/xml2js/-/xml2js-0.4.14.tgz",
             "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
             "license": "MIT",
             "dependencies": {
@@ -2582,7 +2582,7 @@
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
             "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
             "dev": true,
             "license": "MIT",
@@ -2611,7 +2611,7 @@
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
@@ -2621,7 +2621,7 @@
         },
         "node_modules/@typescript-eslint/parser": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/parser/-/parser-8.63.0.tgz",
             "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "dev": true,
             "license": "MIT",
@@ -2646,7 +2646,7 @@
         },
         "node_modules/@typescript-eslint/project-service": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
             "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "dev": true,
             "license": "MIT",
@@ -2668,7 +2668,7 @@
         },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
             "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "dev": true,
             "license": "MIT",
@@ -2686,7 +2686,7 @@
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
             "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "dev": true,
             "license": "MIT",
@@ -2703,7 +2703,7 @@
         },
         "node_modules/@typescript-eslint/type-utils": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
             "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
             "dev": true,
             "license": "MIT",
@@ -2728,7 +2728,7 @@
         },
         "node_modules/@typescript-eslint/types": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/types/-/types-8.63.0.tgz",
             "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "dev": true,
             "license": "MIT",
@@ -2742,7 +2742,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
             "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "dev": true,
             "license": "MIT",
@@ -2770,7 +2770,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
@@ -2780,7 +2780,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
             "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
             "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
@@ -2793,7 +2793,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -2809,7 +2809,7 @@
         },
         "node_modules/@typescript-eslint/utils": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/utils/-/utils-8.63.0.tgz",
             "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
             "dev": true,
             "license": "MIT",
@@ -2833,7 +2833,7 @@
         },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
             "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "dev": true,
             "license": "MIT",
@@ -2851,7 +2851,7 @@
         },
         "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
@@ -2864,7 +2864,7 @@
         },
         "node_modules/@typespec/ts-http-runtime": {
             "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
             "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
             "license": "MIT",
             "dependencies": {
@@ -2878,7 +2878,7 @@
         },
         "node_modules/@vscode/extension-telemetry": {
             "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/extension-telemetry/-/extension-telemetry-1.5.2.tgz",
             "integrity": "sha512-fO4huHz5apb5RtddC8DuUeSbBqYQw1EiBaOOGngq57nGbsDgcvm0jAibTY/kigJyjY0fQ4Vx7owQcCJRUrkT4g==",
             "license": "MIT",
             "dependencies": {
@@ -2894,13 +2894,13 @@
         },
         "node_modules/@vscode/l10n": {
             "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/l10n/-/l10n-0.0.18.tgz",
             "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
             "license": "MIT"
         },
         "node_modules/@vscode/l10n-dev": {
             "version": "0.0.35",
-            "resolved": "https://registry.npmjs.org/@vscode/l10n-dev/-/l10n-dev-0.0.35.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/l10n-dev/-/l10n-dev-0.0.35.tgz",
             "integrity": "sha512-s6uzBXsVDSL69Z85HSqpc5dfKswQkeucY8L00t1TWzGalw7wkLQUKMRwuzqTq+AMwQKrRd7Po14cMoTcd11iDw==",
             "dev": true,
             "license": "MIT",
@@ -2922,7 +2922,7 @@
         },
         "node_modules/@vscode/l10n-dev/node_modules/brace-expansion": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-2.1.1.tgz",
             "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
@@ -2932,7 +2932,7 @@
         },
         "node_modules/@vscode/l10n-dev/node_modules/glob": {
             "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
@@ -2954,14 +2954,14 @@
         },
         "node_modules/@vscode/l10n-dev/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/@vscode/l10n-dev/node_modules/minimatch": {
             "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
@@ -2977,7 +2977,7 @@
         },
         "node_modules/@vscode/l10n-dev/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -2994,7 +2994,7 @@
         },
         "node_modules/@vscode/test-electron": {
             "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/test-electron/-/test-electron-2.5.2.tgz",
             "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
             "dev": true,
             "license": "MIT",
@@ -3011,7 +3011,7 @@
         },
         "node_modules/@vscode/vsce": {
             "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce/-/vsce-3.9.2.tgz",
             "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
@@ -3058,7 +3058,7 @@
         },
         "node_modules/@vscode/vsce-sign": {
             "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
             "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
             "dev": true,
             "hasInstallScript": true,
@@ -3077,7 +3077,7 @@
         },
         "node_modules/@vscode/vsce-sign-alpine-arm64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
             "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
             "cpu": [
                 "arm64"
@@ -3091,7 +3091,7 @@
         },
         "node_modules/@vscode/vsce-sign-alpine-x64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
             "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
             "cpu": [
                 "x64"
@@ -3105,7 +3105,7 @@
         },
         "node_modules/@vscode/vsce-sign-darwin-arm64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
             "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
             "cpu": [
                 "arm64"
@@ -3119,7 +3119,7 @@
         },
         "node_modules/@vscode/vsce-sign-darwin-x64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
             "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
             "cpu": [
                 "x64"
@@ -3133,7 +3133,7 @@
         },
         "node_modules/@vscode/vsce-sign-linux-arm": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
             "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
             "cpu": [
                 "arm"
@@ -3147,7 +3147,7 @@
         },
         "node_modules/@vscode/vsce-sign-linux-arm64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
             "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
             "cpu": [
                 "arm64"
@@ -3161,7 +3161,7 @@
         },
         "node_modules/@vscode/vsce-sign-linux-x64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
             "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
             "cpu": [
                 "x64"
@@ -3175,7 +3175,7 @@
         },
         "node_modules/@vscode/vsce-sign-win32-arm64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
             "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
             "cpu": [
                 "arm64"
@@ -3189,7 +3189,7 @@
         },
         "node_modules/@vscode/vsce-sign-win32-x64": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
             "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
             "cpu": [
                 "x64"
@@ -3203,7 +3203,7 @@
         },
         "node_modules/@vscode/vsce/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
@@ -3213,7 +3213,7 @@
         },
         "node_modules/@vscode/vsce/node_modules/brace-expansion": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
@@ -3226,7 +3226,7 @@
         },
         "node_modules/@vscode/vsce/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -3242,7 +3242,7 @@
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/ast/-/ast-1.14.1.tgz",
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
@@ -3253,28 +3253,28 @@
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
@@ -3286,14 +3286,14 @@
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
@@ -3306,7 +3306,7 @@
         },
         "node_modules/@webassemblyjs/ieee754": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
@@ -3316,7 +3316,7 @@
         },
         "node_modules/@webassemblyjs/leb128": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
@@ -3326,14 +3326,14 @@
         },
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
@@ -3350,7 +3350,7 @@
         },
         "node_modules/@webassemblyjs/wasm-gen": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
@@ -3364,7 +3364,7 @@
         },
         "node_modules/@webassemblyjs/wasm-opt": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
@@ -3377,7 +3377,7 @@
         },
         "node_modules/@webassemblyjs/wasm-parser": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
@@ -3392,7 +3392,7 @@
         },
         "node_modules/@webassemblyjs/wast-printer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
@@ -3403,21 +3403,21 @@
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/accepts": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/accepts/-/accepts-2.0.0.tgz",
             "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "license": "MIT",
             "dependencies": {
@@ -3430,7 +3430,7 @@
         },
         "node_modules/acorn": {
             "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn/-/acorn-8.17.0.tgz",
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "devOptional": true,
             "license": "MIT",
@@ -3443,7 +3443,7 @@
         },
         "node_modules/acorn-import-phases": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "dev": true,
             "license": "MIT",
@@ -3456,7 +3456,7 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "devOptional": true,
             "license": "MIT",
@@ -3466,7 +3466,7 @@
         },
         "node_modules/agent-base": {
             "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
             "engines": {
@@ -3475,7 +3475,7 @@
         },
         "node_modules/ajv": {
             "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
             "dependencies": {
@@ -3491,7 +3491,7 @@
         },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "license": "MIT",
             "dependencies": {
@@ -3508,7 +3508,7 @@
         },
         "node_modules/ajv-formats-draft2019": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz",
             "integrity": "sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==",
             "license": "MIT",
             "dependencies": {
@@ -3523,7 +3523,7 @@
         },
         "node_modules/ajv-i18n": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
             "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
             "license": "MIT",
             "peerDependencies": {
@@ -3532,7 +3532,7 @@
         },
         "node_modules/ajv-keywords": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
             "license": "MIT",
@@ -3545,7 +3545,7 @@
         },
         "node_modules/ansi-escapes": {
             "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
             "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "dev": true,
             "license": "MIT",
@@ -3561,7 +3561,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
@@ -3574,7 +3574,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "license": "MIT",
             "dependencies": {
@@ -3589,7 +3589,7 @@
         },
         "node_modules/anynum": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/anynum/-/anynum-1.0.1.tgz",
             "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
             "funding": [
                 {
@@ -3601,13 +3601,13 @@
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
         "node_modules/asn1": {
             "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "license": "MIT",
             "dependencies": {
@@ -3616,7 +3616,7 @@
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "license": "MIT",
@@ -3626,7 +3626,7 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
             "license": "MIT",
@@ -3636,13 +3636,13 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
             "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
             "license": "MIT",
             "engines": {
@@ -3651,7 +3651,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "license": "MIT",
             "dependencies": {
@@ -3666,7 +3666,7 @@
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
             "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
             "dev": true,
             "license": "MIT",
@@ -3677,7 +3677,7 @@
         },
         "node_modules/b4a": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/b4a/-/b4a-1.8.1.tgz",
             "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -3691,14 +3691,14 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/bare-events": {
             "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-events/-/bare-events-2.9.1.tgz",
             "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -3712,7 +3712,7 @@
         },
         "node_modules/bare-fs": {
             "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-fs/-/bare-fs-4.7.2.tgz",
             "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3736,7 +3736,7 @@
         },
         "node_modules/bare-os": {
             "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-os/-/bare-os-3.9.1.tgz",
             "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
             "license": "Apache-2.0",
             "engines": {
@@ -3745,7 +3745,7 @@
         },
         "node_modules/bare-path": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-path/-/bare-path-3.0.1.tgz",
             "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3754,7 +3754,7 @@
         },
         "node_modules/bare-stream": {
             "version": "2.13.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-stream/-/bare-stream-2.13.3.tgz",
             "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3781,7 +3781,7 @@
         },
         "node_modules/bare-url": {
             "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bare-url/-/bare-url-2.4.5.tgz",
             "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3790,7 +3790,7 @@
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "funding": [
                 {
@@ -3810,7 +3810,7 @@
         },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.40",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
             "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
             "dev": true,
             "license": "Apache-2.0",
@@ -3823,7 +3823,7 @@
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3832,13 +3832,13 @@
         },
         "node_modules/before-after-hook": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/before-after-hook/-/before-after-hook-4.0.0.tgz",
             "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
             "license": "Apache-2.0"
         },
         "node_modules/big.js": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/big.js/-/big.js-5.2.2.tgz",
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true,
             "license": "MIT",
@@ -3848,7 +3848,7 @@
         },
         "node_modules/binaryextensions": {
             "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/binaryextensions/-/binaryextensions-6.11.0.tgz",
             "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
             "dev": true,
             "license": "Artistic-2.0",
@@ -3864,7 +3864,7 @@
         },
         "node_modules/bl": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bl/-/bl-1.2.3.tgz",
             "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
             "license": "MIT",
             "dependencies": {
@@ -3874,13 +3874,13 @@
         },
         "node_modules/bl/node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "license": "MIT"
         },
         "node_modules/bl/node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "license": "MIT",
             "dependencies": {
@@ -3895,13 +3895,13 @@
         },
         "node_modules/bl/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
         "node_modules/bl/node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "license": "MIT",
             "dependencies": {
@@ -3910,7 +3910,7 @@
         },
         "node_modules/body-parser": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/body-parser/-/body-parser-2.3.0.tgz",
             "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
@@ -3934,7 +3934,7 @@
         },
         "node_modules/body-parser/node_modules/iconv-lite": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
             "dependencies": {
@@ -3950,21 +3950,21 @@
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/boundary": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/boundary/-/boundary-2.0.0.tgz",
             "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
             "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
@@ -3975,7 +3975,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "license": "MIT",
@@ -3988,14 +3988,14 @@
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/browserslist": {
             "version": "4.28.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/browserslist/-/browserslist-4.28.4.tgz",
             "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "dev": true,
             "funding": [
@@ -4029,7 +4029,7 @@
         },
         "node_modules/buffer": {
             "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "funding": [
                 {
@@ -4053,7 +4053,7 @@
         },
         "node_modules/buffer-alloc": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "license": "MIT",
             "dependencies": {
@@ -4063,13 +4063,13 @@
         },
         "node_modules/buffer-alloc-unsafe": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
             "license": "MIT"
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "license": "MIT",
             "engines": {
@@ -4078,26 +4078,26 @@
         },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/buffer-fill": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
             "license": "MIT"
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buildcheck/-/buildcheck-0.0.7.tgz",
             "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
             "optional": true,
             "engines": {
@@ -4106,7 +4106,7 @@
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "license": "MIT",
             "dependencies": {
@@ -4121,7 +4121,7 @@
         },
         "node_modules/bytes": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "license": "MIT",
             "engines": {
@@ -4130,7 +4130,7 @@
         },
         "node_modules/call-bind": {
             "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind/-/call-bind-1.0.9.tgz",
             "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "license": "MIT",
             "dependencies": {
@@ -4148,7 +4148,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "license": "MIT",
             "dependencies": {
@@ -4161,7 +4161,7 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
@@ -4177,7 +4177,7 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
@@ -4187,7 +4187,7 @@
         },
         "node_modules/camelcase": {
             "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
@@ -4200,7 +4200,7 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
             "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "dev": true,
             "funding": [
@@ -4221,7 +4221,7 @@
         },
         "node_modules/chai": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chai/-/chai-6.2.2.tgz",
             "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
             "license": "MIT",
@@ -4231,7 +4231,7 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
@@ -4248,7 +4248,7 @@
         },
         "node_modules/cheerio": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cheerio/-/cheerio-1.2.0.tgz",
             "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
             "dev": true,
             "license": "MIT",
@@ -4274,7 +4274,7 @@
         },
         "node_modules/cheerio-select": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cheerio-select/-/cheerio-select-2.1.0.tgz",
             "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -4292,7 +4292,7 @@
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
@@ -4308,7 +4308,7 @@
         },
         "node_modules/chownr": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chownr/-/chownr-3.0.0.tgz",
             "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -4317,7 +4317,7 @@
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
@@ -4327,7 +4327,7 @@
         },
         "node_modules/cidr-regex": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cidr-regex/-/cidr-regex-3.1.1.tgz",
             "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4339,7 +4339,7 @@
         },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cli-cursor/-/cli-cursor-5.0.0.tgz",
             "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
             "license": "MIT",
@@ -4355,7 +4355,7 @@
         },
         "node_modules/cli-spinners": {
             "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cli-spinners/-/cli-spinners-2.9.2.tgz",
             "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "dev": true,
             "license": "MIT",
@@ -4368,7 +4368,7 @@
         },
         "node_modules/cli-truncate": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cli-truncate/-/cli-truncate-5.2.0.tgz",
             "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
             "dev": true,
             "license": "MIT",
@@ -4385,7 +4385,7 @@
         },
         "node_modules/cli-truncate/node_modules/string-width": {
             "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-8.2.1.tgz",
             "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
             "dev": true,
             "license": "MIT",
@@ -4402,7 +4402,7 @@
         },
         "node_modules/cliui": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "license": "ISC",
             "dependencies": {
@@ -4413,7 +4413,7 @@
         },
         "node_modules/cliui/node_modules/ansi-regex": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-3.0.1.tgz",
             "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
             "license": "MIT",
             "engines": {
@@ -4422,7 +4422,7 @@
         },
         "node_modules/cliui/node_modules/is-fullwidth-code-point": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
             "license": "MIT",
             "engines": {
@@ -4431,7 +4431,7 @@
         },
         "node_modules/cliui/node_modules/string-width": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "license": "MIT",
             "dependencies": {
@@ -4444,7 +4444,7 @@
         },
         "node_modules/cliui/node_modules/strip-ansi": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
             "license": "MIT",
             "dependencies": {
@@ -4456,7 +4456,7 @@
         },
         "node_modules/clone-deep": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/clone-deep/-/clone-deep-4.0.1.tgz",
             "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
             "license": "MIT",
@@ -4471,7 +4471,7 @@
         },
         "node_modules/clone-deep/node_modules/is-plain-object": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "license": "MIT",
@@ -4484,7 +4484,7 @@
         },
         "node_modules/cockatiel": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cockatiel/-/cockatiel-3.2.1.tgz",
             "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
             "dev": true,
             "license": "MIT",
@@ -4494,7 +4494,7 @@
         },
         "node_modules/code-point-at": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
             "license": "MIT",
             "engines": {
@@ -4503,7 +4503,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "license": "MIT",
             "dependencies": {
@@ -4515,13 +4515,13 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "license": "MIT",
             "dependencies": {
@@ -4533,7 +4533,7 @@
         },
         "node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "license": "MIT",
@@ -4543,14 +4543,14 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/containerization-assist-mcp": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/containerization-assist-mcp/-/containerization-assist-mcp-1.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/containerization-assist-mcp/-/containerization-assist-mcp-1.4.1.tgz",
             "integrity": "sha512-ZRRdFTTlHkHyZE06r7QZV7/8vC+htZ7W83EXW0g3Zlv4jCVflryYEZU5oA0Jnam5K+kTeNfTIrJiOheF/LEC+w==",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
@@ -4586,7 +4586,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/@isaacs/cliui": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/cliui/-/cliui-9.0.0.tgz",
             "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -4595,7 +4595,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "license": "MIT",
             "engines": {
@@ -4604,7 +4604,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/brace-expansion": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "license": "MIT",
             "dependencies": {
@@ -4616,7 +4616,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/commander": {
             "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-14.0.3.tgz",
             "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "license": "MIT",
             "engines": {
@@ -4625,7 +4625,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/glob": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-11.1.0.tgz",
             "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "BlueOak-1.0.0",
@@ -4649,7 +4649,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/jackspeak": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jackspeak/-/jackspeak-4.2.3.tgz",
             "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -4664,7 +4664,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -4679,7 +4679,7 @@
         },
         "node_modules/containerization-assist-mcp/node_modules/xml2js": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xml2js/-/xml2js-0.6.2.tgz",
             "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "license": "MIT",
             "dependencies": {
@@ -4692,7 +4692,7 @@
         },
         "node_modules/content-disposition": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-disposition/-/content-disposition-1.1.0.tgz",
             "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
             "license": "MIT",
             "engines": {
@@ -4705,7 +4705,7 @@
         },
         "node_modules/content-type": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-type/-/content-type-2.0.0.tgz",
             "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
             "license": "MIT",
             "engines": {
@@ -4718,7 +4718,7 @@
         },
         "node_modules/cookie": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "license": "MIT",
             "engines": {
@@ -4727,7 +4727,7 @@
         },
         "node_modules/cookie-signature": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cookie-signature/-/cookie-signature-1.2.2.tgz",
             "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
             "license": "MIT",
             "engines": {
@@ -4736,7 +4736,7 @@
         },
         "node_modules/copy-webpack-plugin": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
             "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
             "dev": true,
             "license": "MIT",
@@ -4760,13 +4760,13 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "license": "MIT"
         },
         "node_modules/cors": {
             "version": "2.8.6",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cors/-/cors-2.8.6.tgz",
             "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
             "license": "MIT",
             "dependencies": {
@@ -4783,7 +4783,7 @@
         },
         "node_modules/cpu-features": {
             "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cpu-features/-/cpu-features-0.0.10.tgz",
             "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
             "hasInstallScript": true,
             "optional": true,
@@ -4797,7 +4797,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -4811,13 +4811,13 @@
         },
         "node_modules/cross-spawn/node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
         "node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -4832,7 +4832,7 @@
         },
         "node_modules/css-select": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/css-select/-/css-select-5.2.2.tgz",
             "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -4849,7 +4849,7 @@
         },
         "node_modules/css-what": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/css-what/-/css-what-6.2.2.tgz",
             "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -4862,7 +4862,7 @@
         },
         "node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
             "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
             "license": "MIT",
             "engines": {
@@ -4871,13 +4871,13 @@
         },
         "node_modules/dayjs": {
             "version": "1.11.21",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dayjs/-/dayjs-1.11.21.tgz",
             "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
             "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
@@ -4894,7 +4894,7 @@
         },
         "node_modules/decamelize": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decamelize/-/decamelize-4.0.0.tgz",
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true,
             "license": "MIT",
@@ -4907,7 +4907,7 @@
         },
         "node_modules/decompress": {
             "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress/-/decompress-4.2.1.tgz",
             "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
             "license": "MIT",
             "dependencies": {
@@ -4926,7 +4926,7 @@
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "license": "MIT",
@@ -4943,7 +4943,7 @@
         },
         "node_modules/decompress-tar": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress-tar/-/decompress-tar-4.1.1.tgz",
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "license": "MIT",
             "dependencies": {
@@ -4957,7 +4957,7 @@
         },
         "node_modules/decompress-tarbz2": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "license": "MIT",
             "dependencies": {
@@ -4973,7 +4973,7 @@
         },
         "node_modules/decompress-tarbz2/node_modules/file-type": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/file-type/-/file-type-6.2.0.tgz",
             "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
             "license": "MIT",
             "engines": {
@@ -4982,7 +4982,7 @@
         },
         "node_modules/decompress-targz": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress-targz/-/decompress-targz-4.1.1.tgz",
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "license": "MIT",
             "dependencies": {
@@ -4996,7 +4996,7 @@
         },
         "node_modules/decompress-unzip": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
             "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
             "license": "MIT",
             "dependencies": {
@@ -5011,7 +5011,7 @@
         },
         "node_modules/decompress-unzip/node_modules/file-type": {
             "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/file-type/-/file-type-3.9.0.tgz",
             "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
             "license": "MIT",
             "engines": {
@@ -5020,7 +5020,7 @@
         },
         "node_modules/decompress-unzip/node_modules/yauzl": {
             "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "license": "MIT",
             "dependencies": {
@@ -5030,7 +5030,7 @@
         },
         "node_modules/deep-extend": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
             "license": "MIT",
@@ -5041,14 +5041,14 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "license": "MIT",
             "engines": {
@@ -5057,7 +5057,7 @@
         },
         "node_modules/deepmerge-json": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/deepmerge-json/-/deepmerge-json-1.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/deepmerge-json/-/deepmerge-json-1.5.0.tgz",
             "integrity": "sha512-jZRrDmBKjmGcqMFEUJ14FjMJwm05Qaked+1vxaALRtF0UAl7lPU8OLWXFxvoeg3jbQM249VPFVn8g2znaQkEtA==",
             "dev": true,
             "license": "MIT",
@@ -5067,7 +5067,7 @@
         },
         "node_modules/default-browser": {
             "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/default-browser/-/default-browser-5.5.0.tgz",
             "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
             "license": "MIT",
             "dependencies": {
@@ -5083,7 +5083,7 @@
         },
         "node_modules/default-browser-id": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/default-browser-id/-/default-browser-id-5.0.1.tgz",
             "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
             "license": "MIT",
             "engines": {
@@ -5095,7 +5095,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "license": "MIT",
             "dependencies": {
@@ -5112,7 +5112,7 @@
         },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "license": "MIT",
             "engines": {
@@ -5124,7 +5124,7 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "license": "MIT",
             "engines": {
@@ -5133,7 +5133,7 @@
         },
         "node_modules/depd": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "license": "MIT",
             "engines": {
@@ -5142,7 +5142,7 @@
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
             "license": "Apache-2.0",
@@ -5153,7 +5153,7 @@
         },
         "node_modules/diff": {
             "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/diff/-/diff-8.0.4.tgz",
             "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -5163,19 +5163,19 @@
         },
         "node_modules/discontinuous-range": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
             "license": "MIT"
         },
         "node_modules/docker-file-parser": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/docker-file-parser/-/docker-file-parser-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/docker-file-parser/-/docker-file-parser-1.0.7.tgz",
             "integrity": "sha512-6+VnnhZpxwWvvKwjkRnuqlTtlBRJuM+3cCSXmZoYhyXcdgxx6l/3lwYpqmJ9qmhzgWVeATkpVsTua92BsObJjw==",
             "license": "MPL"
         },
         "node_modules/docker-modem": {
             "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/docker-modem/-/docker-modem-5.0.7.tgz",
             "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -5190,7 +5190,7 @@
         },
         "node_modules/dockerfilelint": {
             "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/dockerfilelint/-/dockerfilelint-1.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dockerfilelint/-/dockerfilelint-1.8.0.tgz",
             "integrity": "sha512-j0tipeP1kpTWfx1XV6QVrrJTtGiP/46+3NT5JuaqXUnYrNlusgvrSP4/ACkqQdglJfmeedIU7c2wztmxEV+JQA==",
             "license": "MIT",
             "dependencies": {
@@ -5206,7 +5206,7 @@
         },
         "node_modules/dockerfilelint/node_modules/ansi-regex": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-4.1.1.tgz",
             "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
             "license": "MIT",
             "engines": {
@@ -5215,7 +5215,7 @@
         },
         "node_modules/dockerfilelint/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "license": "MIT",
             "dependencies": {
@@ -5227,7 +5227,7 @@
         },
         "node_modules/dockerfilelint/node_modules/camelcase": {
             "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "license": "MIT",
             "engines": {
@@ -5236,7 +5236,7 @@
         },
         "node_modules/dockerfilelint/node_modules/chalk": {
             "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "license": "MIT",
             "dependencies": {
@@ -5250,7 +5250,7 @@
         },
         "node_modules/dockerfilelint/node_modules/color-convert": {
             "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "license": "MIT",
             "dependencies": {
@@ -5259,13 +5259,13 @@
         },
         "node_modules/dockerfilelint/node_modules/color-name": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "license": "MIT"
         },
         "node_modules/dockerfilelint/node_modules/decamelize": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
             "license": "MIT",
             "engines": {
@@ -5274,13 +5274,13 @@
         },
         "node_modules/dockerfilelint/node_modules/emoji-regex": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "license": "MIT"
         },
         "node_modules/dockerfilelint/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "license": "MIT",
             "engines": {
@@ -5289,7 +5289,7 @@
         },
         "node_modules/dockerfilelint/node_modules/find-up": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-3.0.0.tgz",
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "license": "MIT",
             "dependencies": {
@@ -5301,7 +5301,7 @@
         },
         "node_modules/dockerfilelint/node_modules/has-flag": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "license": "MIT",
             "engines": {
@@ -5310,7 +5310,7 @@
         },
         "node_modules/dockerfilelint/node_modules/is-fullwidth-code-point": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
             "license": "MIT",
             "engines": {
@@ -5319,7 +5319,7 @@
         },
         "node_modules/dockerfilelint/node_modules/locate-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-3.0.0.tgz",
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "license": "MIT",
             "dependencies": {
@@ -5332,7 +5332,7 @@
         },
         "node_modules/dockerfilelint/node_modules/p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "license": "MIT",
             "dependencies": {
@@ -5347,7 +5347,7 @@
         },
         "node_modules/dockerfilelint/node_modules/p-locate": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-3.0.0.tgz",
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "license": "MIT",
             "dependencies": {
@@ -5359,7 +5359,7 @@
         },
         "node_modules/dockerfilelint/node_modules/path-exists": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "license": "MIT",
             "engines": {
@@ -5368,7 +5368,7 @@
         },
         "node_modules/dockerfilelint/node_modules/string-width": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-3.1.0.tgz",
             "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
             "license": "MIT",
             "dependencies": {
@@ -5382,7 +5382,7 @@
         },
         "node_modules/dockerfilelint/node_modules/strip-ansi": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "license": "MIT",
             "dependencies": {
@@ -5394,7 +5394,7 @@
         },
         "node_modules/dockerfilelint/node_modules/supports-color": {
             "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "license": "MIT",
             "dependencies": {
@@ -5406,7 +5406,7 @@
         },
         "node_modules/dockerfilelint/node_modules/wrap-ansi": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
             "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
             "license": "MIT",
             "dependencies": {
@@ -5420,13 +5420,13 @@
         },
         "node_modules/dockerfilelint/node_modules/y18n": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/y18n/-/y18n-4.0.3.tgz",
             "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
             "license": "ISC"
         },
         "node_modules/dockerfilelint/node_modules/yargs": {
             "version": "13.3.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yargs/-/yargs-13.3.2.tgz",
             "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
             "license": "MIT",
             "dependencies": {
@@ -5444,7 +5444,7 @@
         },
         "node_modules/dockerfilelint/node_modules/yargs-parser": {
             "version": "13.1.2",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
             "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
             "license": "ISC",
             "dependencies": {
@@ -5454,7 +5454,7 @@
         },
         "node_modules/dockerfilelint/node_modules/yargs/node_modules/cliui": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cliui/-/cliui-5.0.0.tgz",
             "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
             "license": "ISC",
             "dependencies": {
@@ -5465,7 +5465,7 @@
         },
         "node_modules/dockerode": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dockerode/-/dockerode-5.0.1.tgz",
             "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -5482,7 +5482,7 @@
         },
         "node_modules/dockerode/node_modules/bl": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "license": "MIT",
             "dependencies": {
@@ -5493,13 +5493,13 @@
         },
         "node_modules/dockerode/node_modules/chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "license": "ISC"
         },
         "node_modules/dockerode/node_modules/protobufjs": {
             "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/protobufjs/-/protobufjs-7.6.4.tgz",
             "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -5522,7 +5522,7 @@
         },
         "node_modules/dockerode/node_modules/tar-fs": {
             "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-fs/-/tar-fs-2.1.4.tgz",
             "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
             "license": "MIT",
             "dependencies": {
@@ -5534,7 +5534,7 @@
         },
         "node_modules/dockerode/node_modules/tar-stream": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "license": "MIT",
             "dependencies": {
@@ -5550,7 +5550,7 @@
         },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "license": "MIT",
             "dependencies": {
@@ -5564,7 +5564,7 @@
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "funding": [
                 {
@@ -5576,7 +5576,7 @@
         },
         "node_modules/domhandler": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -5591,7 +5591,7 @@
         },
         "node_modules/domutils": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/domutils/-/domutils-3.2.2.tgz",
             "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -5605,7 +5605,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "license": "MIT",
             "dependencies": {
@@ -5619,14 +5619,14 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -5635,7 +5635,7 @@
         },
         "node_modules/editions": {
             "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/editions/-/editions-6.22.0.tgz",
             "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
             "dev": true,
             "license": "Artistic-2.0",
@@ -5652,26 +5652,26 @@
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.380",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
             "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/emojis-list": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emojis-list/-/emojis-list-3.0.0.tgz",
             "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true,
             "license": "MIT",
@@ -5681,7 +5681,7 @@
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "license": "MIT",
             "engines": {
@@ -5690,7 +5690,7 @@
         },
         "node_modules/encoding-sniffer": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
             "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
             "dev": true,
             "license": "MIT",
@@ -5704,7 +5704,7 @@
         },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/end-of-stream/-/end-of-stream-1.4.5.tgz",
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "license": "MIT",
             "dependencies": {
@@ -5713,7 +5713,7 @@
         },
         "node_modules/enhanced-resolve": {
             "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
             "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
             "dev": true,
             "license": "MIT",
@@ -5727,7 +5727,7 @@
         },
         "node_modules/entities": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "license": "BSD-2-Clause",
             "engines": {
@@ -5739,7 +5739,7 @@
         },
         "node_modules/envinfo": {
             "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/envinfo/-/envinfo-7.21.0.tgz",
             "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
             "dev": true,
             "license": "MIT",
@@ -5752,7 +5752,7 @@
         },
         "node_modules/environment": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/environment/-/environment-1.1.0.tgz",
             "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
             "dev": true,
             "license": "MIT",
@@ -5765,7 +5765,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "license": "MIT",
             "engines": {
@@ -5774,7 +5774,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "license": "MIT",
             "engines": {
@@ -5783,14 +5783,14 @@
         },
         "node_modules/es-module-lexer": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
             "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
             "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
@@ -5802,7 +5802,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "license": "MIT",
             "dependencies": {
@@ -5817,7 +5817,7 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "license": "MIT",
             "engines": {
@@ -5826,13 +5826,13 @@
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "devOptional": true,
             "license": "MIT",
@@ -5845,7 +5845,7 @@
         },
         "node_modules/eslint": {
             "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint/-/eslint-10.6.0.tgz",
             "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
             "devOptional": true,
             "license": "MIT",
@@ -5904,7 +5904,7 @@
         },
         "node_modules/eslint-scope": {
             "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "devOptional": true,
             "license": "BSD-2-Clause",
@@ -5923,7 +5923,7 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -5936,7 +5936,7 @@
         },
         "node_modules/eslint-webpack-plugin": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-webpack-plugin/-/eslint-webpack-plugin-6.0.0.tgz",
             "integrity": "sha512-x9m9cH0Rw0RNJB/utP9AMGzmuXg/yLP/FCHSVSfsyjQUyetXN4g1BaIqxkj1i3mVX48aOys0bsVt63LLfh6oYg==",
             "dev": true,
             "license": "MIT",
@@ -5960,7 +5960,7 @@
         },
         "node_modules/eslint/node_modules/ajv": {
             "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-6.15.0.tgz",
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "devOptional": true,
             "license": "MIT",
@@ -5977,7 +5977,7 @@
         },
         "node_modules/eslint/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "devOptional": true,
             "license": "MIT",
@@ -5987,7 +5987,7 @@
         },
         "node_modules/eslint/node_modules/brace-expansion": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "devOptional": true,
             "license": "MIT",
@@ -6000,7 +6000,7 @@
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "devOptional": true,
             "license": "Apache-2.0",
@@ -6013,7 +6013,7 @@
         },
         "node_modules/eslint/node_modules/espree": {
             "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "devOptional": true,
             "license": "BSD-2-Clause",
@@ -6031,14 +6031,14 @@
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "devOptional": true,
             "license": "BlueOak-1.0.0",
@@ -6054,7 +6054,7 @@
         },
         "node_modules/espree": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/espree/-/espree-10.4.0.tgz",
             "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -6072,7 +6072,7 @@
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
             "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
             "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
@@ -6085,7 +6085,7 @@
         },
         "node_modules/esquery": {
             "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "devOptional": true,
             "license": "BSD-3-Clause",
@@ -6098,7 +6098,7 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "devOptional": true,
             "license": "BSD-2-Clause",
@@ -6111,7 +6111,7 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "devOptional": true,
             "license": "BSD-2-Clause",
@@ -6121,7 +6121,7 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "devOptional": true,
             "license": "BSD-2-Clause",
@@ -6131,7 +6131,7 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "license": "MIT",
             "engines": {
@@ -6140,14 +6140,14 @@
         },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/events": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "license": "MIT",
             "engines": {
@@ -6156,7 +6156,7 @@
         },
         "node_modules/events-universal": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/events-universal/-/events-universal-1.0.1.tgz",
             "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -6165,7 +6165,7 @@
         },
         "node_modules/eventsource": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eventsource/-/eventsource-3.0.7.tgz",
             "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
             "license": "MIT",
             "dependencies": {
@@ -6177,7 +6177,7 @@
         },
         "node_modules/eventsource-parser": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
             "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
             "license": "MIT",
             "engines": {
@@ -6186,7 +6186,7 @@
         },
         "node_modules/expand-template": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true,
             "license": "(MIT OR WTFPL)",
@@ -6197,7 +6197,7 @@
         },
         "node_modules/express": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
             "dependencies": {
@@ -6240,7 +6240,7 @@
         },
         "node_modules/express-rate-limit": {
             "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
             "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
             "license": "MIT",
             "dependencies": {
@@ -6258,7 +6258,7 @@
         },
         "node_modules/express/node_modules/content-type": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "license": "MIT",
             "engines": {
@@ -6267,13 +6267,13 @@
         },
         "node_modules/extend": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
         "node_modules/fast-check": {
             "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-check/-/fast-check-4.8.0.tgz",
             "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
             "dev": true,
             "funding": [
@@ -6296,19 +6296,19 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
             "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
@@ -6325,7 +6325,7 @@
         },
         "node_modules/fast-glob/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "license": "ISC",
@@ -6338,21 +6338,21 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.2.tgz",
             "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
@@ -6368,7 +6368,7 @@
         },
         "node_modules/fast-xml-builder": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
             "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "funding": [
                 {
@@ -6384,7 +6384,7 @@
         },
         "node_modules/fast-xml-parser": {
             "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
             "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
             "funding": [
                 {
@@ -6407,7 +6407,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
@@ -6417,7 +6417,7 @@
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "license": "MIT",
             "dependencies": {
@@ -6426,7 +6426,7 @@
         },
         "node_modules/fdir": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
@@ -6444,7 +6444,7 @@
         },
         "node_modules/fetch-blob": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fetch-blob/-/fetch-blob-3.2.0.tgz",
             "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
             "funding": [
                 {
@@ -6467,7 +6467,7 @@
         },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "devOptional": true,
             "license": "MIT",
@@ -6480,7 +6480,7 @@
         },
         "node_modules/file-type": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/file-type/-/file-type-5.2.0.tgz",
             "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
             "license": "MIT",
             "engines": {
@@ -6489,7 +6489,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "license": "MIT",
@@ -6502,7 +6502,7 @@
         },
         "node_modules/finalhandler": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/finalhandler/-/finalhandler-2.1.1.tgz",
             "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "license": "MIT",
             "dependencies": {
@@ -6523,7 +6523,7 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "devOptional": true,
             "license": "MIT",
@@ -6540,7 +6540,7 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -6550,7 +6550,7 @@
         },
         "node_modules/flat-cache": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "devOptional": true,
             "license": "MIT",
@@ -6564,14 +6564,14 @@
         },
         "node_modules/flatted": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "devOptional": true,
             "license": "ISC"
         },
         "node_modules/for-each": {
             "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/for-each/-/for-each-0.3.5.tgz",
             "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "license": "MIT",
             "dependencies": {
@@ -6586,7 +6586,7 @@
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "license": "ISC",
             "dependencies": {
@@ -6602,7 +6602,7 @@
         },
         "node_modules/form-data": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/form-data/-/form-data-4.0.6.tgz",
             "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
@@ -6618,7 +6618,7 @@
         },
         "node_modules/form-data/node_modules/mime-db": {
             "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "license": "MIT",
             "engines": {
@@ -6627,7 +6627,7 @@
         },
         "node_modules/form-data/node_modules/mime-types": {
             "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "license": "MIT",
             "dependencies": {
@@ -6639,7 +6639,7 @@
         },
         "node_modules/formdata-polyfill": {
             "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
             "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
             "license": "MIT",
             "dependencies": {
@@ -6651,7 +6651,7 @@
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "license": "MIT",
             "engines": {
@@ -6660,7 +6660,7 @@
         },
         "node_modules/fresh": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fresh/-/fresh-2.0.0.tgz",
             "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
             "license": "MIT",
             "engines": {
@@ -6669,13 +6669,13 @@
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "license": "MIT"
         },
         "node_modules/fs-extra": {
             "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fs-extra/-/fs-extra-11.3.5.tgz",
             "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "dev": true,
             "license": "MIT",
@@ -6690,7 +6690,7 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "license": "MIT",
             "funding": {
@@ -6699,7 +6699,7 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "license": "ISC",
             "engines": {
@@ -6708,7 +6708,7 @@
         },
         "node_modules/get-east-asian-width": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
             "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
             "dev": true,
             "license": "MIT",
@@ -6721,7 +6721,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "license": "MIT",
             "dependencies": {
@@ -6745,7 +6745,7 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "license": "MIT",
             "dependencies": {
@@ -6758,7 +6758,7 @@
         },
         "node_modules/get-stdin": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-stdin/-/get-stdin-7.0.0.tgz",
             "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
             "dev": true,
             "license": "MIT",
@@ -6768,7 +6768,7 @@
         },
         "node_modules/get-stream": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-stream/-/get-stream-2.3.1.tgz",
             "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
             "license": "MIT",
             "dependencies": {
@@ -6781,7 +6781,7 @@
         },
         "node_modules/github-from-package": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true,
             "license": "MIT",
@@ -6789,7 +6789,7 @@
         },
         "node_modules/glob": {
             "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-13.0.6.tgz",
             "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -6807,7 +6807,7 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "devOptional": true,
             "license": "ISC",
@@ -6820,7 +6820,7 @@
         },
         "node_modules/glob/node_modules/balanced-match": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
@@ -6830,7 +6830,7 @@
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
@@ -6843,7 +6843,7 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -6859,7 +6859,7 @@
         },
         "node_modules/globals": {
             "version": "17.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/globals/-/globals-17.7.0.tgz",
             "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
             "dev": true,
             "license": "MIT",
@@ -6872,7 +6872,7 @@
         },
         "node_modules/globby": {
             "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/globby/-/globby-14.1.0.tgz",
             "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
             "dev": true,
             "license": "MIT",
@@ -6893,7 +6893,7 @@
         },
         "node_modules/globby/node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
@@ -6903,7 +6903,7 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "license": "MIT",
             "engines": {
@@ -6915,13 +6915,13 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
@@ -6931,7 +6931,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "license": "MIT",
             "dependencies": {
@@ -6943,7 +6943,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
             "engines": {
@@ -6955,7 +6955,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "license": "MIT",
             "dependencies": {
@@ -6970,7 +6970,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
@@ -6982,7 +6982,7 @@
         },
         "node_modules/he": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
             "license": "MIT",
@@ -6992,7 +6992,7 @@
         },
         "node_modules/hono": {
             "version": "4.12.27",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hono/-/hono-4.12.27.tgz",
             "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
             "license": "MIT",
             "engines": {
@@ -7001,7 +7001,7 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
             "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
             "license": "ISC",
@@ -7014,7 +7014,7 @@
         },
         "node_modules/hpagent": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hpagent/-/hpagent-1.2.0.tgz",
             "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
             "license": "MIT",
             "engines": {
@@ -7023,7 +7023,7 @@
         },
         "node_modules/html-to-text": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/html-to-text/-/html-to-text-9.0.5.tgz",
             "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
             "license": "MIT",
             "dependencies": {
@@ -7039,7 +7039,7 @@
         },
         "node_modules/html-to-text/node_modules/htmlparser2": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/htmlparser2/-/htmlparser2-8.0.2.tgz",
             "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -7058,7 +7058,7 @@
         },
         "node_modules/htmlparser2": {
             "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/htmlparser2/-/htmlparser2-10.1.0.tgz",
             "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
             "dev": true,
             "funding": [
@@ -7078,7 +7078,7 @@
         },
         "node_modules/htmlparser2/node_modules/entities": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/entities/-/entities-7.0.1.tgz",
             "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -7091,7 +7091,7 @@
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-errors/-/http-errors-2.0.1.tgz",
             "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
@@ -7111,7 +7111,7 @@
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
             "dependencies": {
@@ -7124,7 +7124,7 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
             "dependencies": {
@@ -7137,7 +7137,7 @@
         },
         "node_modules/husky": {
             "version": "9.1.7",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/husky/-/husky-9.1.7.tgz",
             "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
             "dev": true,
             "license": "MIT",
@@ -7153,7 +7153,7 @@
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
@@ -7166,7 +7166,7 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "funding": [
                 {
@@ -7186,7 +7186,7 @@
         },
         "node_modules/ignore": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "devOptional": true,
             "license": "MIT",
@@ -7196,14 +7196,14 @@
         },
         "node_modules/immediate": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/import-fresh/-/import-fresh-3.3.1.tgz",
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
@@ -7220,7 +7220,7 @@
         },
         "node_modules/import-local": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/import-local/-/import-local-3.2.0.tgz",
             "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
             "license": "MIT",
@@ -7240,7 +7240,7 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "devOptional": true,
             "license": "MIT",
@@ -7250,7 +7250,7 @@
         },
         "node_modules/index-to-position": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/index-to-position/-/index-to-position-1.2.0.tgz",
             "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
             "dev": true,
             "license": "MIT",
@@ -7263,13 +7263,13 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
         "node_modules/ini": {
             "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
             "license": "ISC",
@@ -7277,7 +7277,7 @@
         },
         "node_modules/interpret": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/interpret/-/interpret-3.1.1.tgz",
             "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true,
             "license": "MIT",
@@ -7287,7 +7287,7 @@
         },
         "node_modules/ip-address": {
             "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ip-address/-/ip-address-10.2.0.tgz",
             "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "license": "MIT",
             "engines": {
@@ -7296,7 +7296,7 @@
         },
         "node_modules/ip-regex": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ip-regex/-/ip-regex-4.3.0.tgz",
             "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
             "license": "MIT",
             "engines": {
@@ -7305,7 +7305,7 @@
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "license": "MIT",
             "engines": {
@@ -7314,7 +7314,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "license": "MIT",
             "engines": {
@@ -7326,7 +7326,7 @@
         },
         "node_modules/is-cidr": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-cidr/-/is-cidr-4.0.2.tgz",
             "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -7338,7 +7338,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.16.2.tgz",
             "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
@@ -7354,7 +7354,7 @@
         },
         "node_modules/is-docker": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "license": "MIT",
             "bin": {
@@ -7369,7 +7369,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "devOptional": true,
             "license": "MIT",
@@ -7379,7 +7379,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
             "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
             "dev": true,
             "license": "MIT",
@@ -7395,7 +7395,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "devOptional": true,
             "license": "MIT",
@@ -7408,7 +7408,7 @@
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "license": "MIT",
             "dependencies": {
@@ -7426,7 +7426,7 @@
         },
         "node_modules/is-interactive": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-interactive/-/is-interactive-2.0.0.tgz",
             "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
             "dev": true,
             "license": "MIT",
@@ -7439,13 +7439,13 @@
         },
         "node_modules/is-natural-number": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-natural-number/-/is-natural-number-4.0.1.tgz",
             "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
             "license": "MIT"
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "license": "MIT",
@@ -7455,7 +7455,7 @@
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "license": "MIT",
@@ -7465,7 +7465,7 @@
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
             "license": "MIT",
@@ -7475,7 +7475,7 @@
         },
         "node_modules/is-plain-object": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "license": "MIT",
             "engines": {
@@ -7484,13 +7484,13 @@
         },
         "node_modules/is-promise": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
             "license": "MIT",
             "engines": {
@@ -7499,7 +7499,7 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-typed-array/-/is-typed-array-1.1.15.tgz",
             "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "license": "MIT",
             "dependencies": {
@@ -7514,7 +7514,7 @@
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
             "license": "MIT",
@@ -7527,7 +7527,7 @@
         },
         "node_modules/is-unsafe": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-unsafe/-/is-unsafe-1.0.1.tgz",
             "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
             "funding": [
                 {
@@ -7539,7 +7539,7 @@
         },
         "node_modules/is-wsl": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-wsl/-/is-wsl-3.1.1.tgz",
             "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
             "license": "MIT",
             "dependencies": {
@@ -7554,13 +7554,13 @@
         },
         "node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-3.1.5.tgz",
             "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -7569,7 +7569,7 @@
         },
         "node_modules/isobject": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true,
             "license": "MIT",
@@ -7579,7 +7579,7 @@
         },
         "node_modules/isomorphic-ws": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
             "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
             "license": "MIT",
             "peerDependencies": {
@@ -7588,7 +7588,7 @@
         },
         "node_modules/istextorbinary": {
             "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/istextorbinary/-/istextorbinary-9.5.0.tgz",
             "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
             "dev": true,
             "license": "Artistic-2.0",
@@ -7606,7 +7606,7 @@
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -7622,7 +7622,7 @@
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
@@ -7637,7 +7637,7 @@
         },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
@@ -7653,7 +7653,7 @@
         },
         "node_modules/jose": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jose/-/jose-6.2.3.tgz",
             "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
             "license": "MIT",
             "funding": {
@@ -7662,14 +7662,14 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/js-yaml/-/js-yaml-4.3.0.tgz",
             "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
@@ -7691,7 +7691,7 @@
         },
         "node_modules/jsep": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
             "engines": {
@@ -7700,39 +7700,39 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
         },
         "node_modules/json-schema-typed": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
             "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
             "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/json-with-bigint": {
             "version": "3.5.8",
-            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
             "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
             "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
@@ -7745,14 +7745,14 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsonfile/-/jsonfile-6.2.1.tgz",
             "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "dev": true,
             "license": "MIT",
@@ -7765,7 +7765,7 @@
         },
         "node_modules/jsonpath-plus": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
             "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
             "license": "MIT",
             "dependencies": {
@@ -7783,7 +7783,7 @@
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
             "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "license": "MIT",
             "dependencies": {
@@ -7805,7 +7805,7 @@
         },
         "node_modules/jszip": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jszip/-/jszip-3.10.1.tgz",
             "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
             "dev": true,
             "license": "(MIT OR GPL-3.0-or-later)",
@@ -7818,14 +7818,14 @@
         },
         "node_modules/jszip/node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/jszip/node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "license": "MIT",
@@ -7841,14 +7841,14 @@
         },
         "node_modules/jszip/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/jszip/node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "license": "MIT",
@@ -7858,7 +7858,7 @@
         },
         "node_modules/jwa": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jwa/-/jwa-2.0.1.tgz",
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "license": "MIT",
             "dependencies": {
@@ -7869,7 +7869,7 @@
         },
         "node_modules/jws": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jws/-/jws-4.0.1.tgz",
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "license": "MIT",
             "dependencies": {
@@ -7879,7 +7879,7 @@
         },
         "node_modules/keytar": {
             "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/keytar/-/keytar-7.9.0.tgz",
             "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
             "dev": true,
             "hasInstallScript": true,
@@ -7892,7 +7892,7 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "devOptional": true,
             "license": "MIT",
@@ -7902,7 +7902,7 @@
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
             "license": "MIT",
@@ -7912,7 +7912,7 @@
         },
         "node_modules/kubernetes-models": {
             "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/kubernetes-models/-/kubernetes-models-4.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/kubernetes-models/-/kubernetes-models-4.5.1.tgz",
             "integrity": "sha512-M/dxDW9hLjVQkRJkMAZbYLLbIj5ZrItgL9ZLJhla2bURUHhQ1CoLAz0+2bcfvAVgu0KFwP9x0kjypYVdWYajXw==",
             "license": "MIT",
             "dependencies": {
@@ -7927,7 +7927,7 @@
         },
         "node_modules/leac": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/leac/-/leac-0.6.0.tgz",
             "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
             "license": "MIT",
             "funding": {
@@ -7936,7 +7936,7 @@
         },
         "node_modules/leven": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/leven/-/leven-3.1.0.tgz",
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true,
             "license": "MIT",
@@ -7946,7 +7946,7 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "devOptional": true,
             "license": "MIT",
@@ -7960,13 +7960,13 @@
         },
         "node_modules/libsodium": {
             "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/libsodium/-/libsodium-0.8.4.tgz",
             "integrity": "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==",
             "license": "ISC"
         },
         "node_modules/libsodium-wrappers": {
             "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
             "integrity": "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==",
             "license": "ISC",
             "dependencies": {
@@ -7975,7 +7975,7 @@
         },
         "node_modules/lie": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lie/-/lie-3.3.0.tgz",
             "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "license": "MIT",
@@ -7985,7 +7985,7 @@
         },
         "node_modules/linkify-it": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/linkify-it/-/linkify-it-5.0.1.tgz",
             "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
             "dev": true,
             "funding": [
@@ -8005,7 +8005,7 @@
         },
         "node_modules/lint-staged": {
             "version": "17.0.8",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lint-staged/-/lint-staged-17.0.8.tgz",
             "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
             "dev": true,
             "license": "MIT",
@@ -8030,7 +8030,7 @@
         },
         "node_modules/listr2": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/listr2/-/listr2-10.2.2.tgz",
             "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
             "dev": true,
             "license": "MIT",
@@ -8047,7 +8047,7 @@
         },
         "node_modules/listr2/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -8060,7 +8060,7 @@
         },
         "node_modules/listr2/node_modules/string-width": {
             "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-8.2.1.tgz",
             "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
             "dev": true,
             "license": "MIT",
@@ -8077,7 +8077,7 @@
         },
         "node_modules/listr2/node_modules/wrap-ansi": {
             "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
             "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
             "dev": true,
             "license": "MIT",
@@ -8095,7 +8095,7 @@
         },
         "node_modules/loader-runner": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/loader-runner/-/loader-runner-4.3.2.tgz",
             "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
             "license": "MIT",
@@ -8109,7 +8109,7 @@
         },
         "node_modules/loader-utils": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/loader-utils/-/loader-utils-2.0.4.tgz",
             "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dev": true,
             "license": "MIT",
@@ -8124,7 +8124,7 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "devOptional": true,
             "license": "MIT",
@@ -8140,68 +8140,68 @@
         },
         "node_modules/lodash": {
             "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "license": "MIT"
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
             "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
             "license": "MIT"
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
             "license": "MIT"
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
             "license": "MIT"
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
             "license": "MIT"
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "license": "MIT",
@@ -8218,7 +8218,7 @@
         },
         "node_modules/log-update": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/log-update/-/log-update-6.1.0.tgz",
             "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "dev": true,
             "license": "MIT",
@@ -8238,7 +8238,7 @@
         },
         "node_modules/log-update/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -8251,14 +8251,14 @@
         },
         "node_modules/log-update/node_modules/emoji-regex": {
             "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/log-update/node_modules/slice-ansi": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/slice-ansi/-/slice-ansi-7.1.2.tgz",
             "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
             "dev": true,
             "license": "MIT",
@@ -8275,7 +8275,7 @@
         },
         "node_modules/log-update/node_modules/string-width": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
@@ -8293,7 +8293,7 @@
         },
         "node_modules/log-update/node_modules/wrap-ansi": {
             "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
             "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "dev": true,
             "license": "MIT",
@@ -8311,13 +8311,13 @@
         },
         "node_modules/long": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
             "license": "ISC",
@@ -8330,7 +8330,7 @@
         },
         "node_modules/make-dir": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "license": "MIT",
             "dependencies": {
@@ -8342,7 +8342,7 @@
         },
         "node_modules/make-dir/node_modules/pify": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pify/-/pify-3.0.0.tgz",
             "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "license": "MIT",
             "engines": {
@@ -8351,7 +8351,7 @@
         },
         "node_modules/markdown-it": {
             "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/markdown-it/-/markdown-it-14.2.0.tgz",
             "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
             "dev": true,
             "funding": [
@@ -8379,7 +8379,7 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "license": "MIT",
             "engines": {
@@ -8388,14 +8388,14 @@
         },
         "node_modules/mdurl": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/media-typer": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/media-typer/-/media-typer-1.1.0.tgz",
             "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
             "license": "MIT",
             "engines": {
@@ -8404,7 +8404,7 @@
         },
         "node_modules/merge-descriptors": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
             "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
             "license": "MIT",
             "engines": {
@@ -8416,14 +8416,14 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
             "license": "MIT",
@@ -8433,7 +8433,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "license": "MIT",
@@ -8447,7 +8447,7 @@
         },
         "node_modules/micromatch/node_modules/picomatch": {
             "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
@@ -8460,7 +8460,7 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "license": "MIT",
@@ -8473,7 +8473,7 @@
         },
         "node_modules/mime-db": {
             "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "license": "MIT",
             "engines": {
@@ -8482,7 +8482,7 @@
         },
         "node_modules/mime-types": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-types/-/mime-types-3.0.2.tgz",
             "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
             "dependencies": {
@@ -8498,7 +8498,7 @@
         },
         "node_modules/mimic-function": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mimic-function/-/mimic-function-5.0.1.tgz",
             "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
             "dev": true,
             "license": "MIT",
@@ -8511,7 +8511,7 @@
         },
         "node_modules/mimic-response": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
             "license": "MIT",
@@ -8525,7 +8525,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
@@ -8538,7 +8538,7 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "license": "MIT",
@@ -8549,7 +8549,7 @@
         },
         "node_modules/minimizer-webpack-plugin": {
             "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
             "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
             "dev": true,
             "license": "MIT",
@@ -8610,7 +8610,7 @@
         },
         "node_modules/minipass": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -8619,7 +8619,7 @@
         },
         "node_modules/minizlib": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minizlib/-/minizlib-3.1.0.tgz",
             "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "license": "MIT",
             "dependencies": {
@@ -8631,13 +8631,13 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "license": "MIT"
         },
         "node_modules/mocha": {
             "version": "11.7.6",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mocha/-/mocha-11.7.6.tgz",
             "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
             "dev": true,
             "license": "MIT",
@@ -8674,7 +8674,7 @@
         },
         "node_modules/mocha/node_modules/brace-expansion": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-2.1.1.tgz",
             "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
@@ -8684,7 +8684,7 @@
         },
         "node_modules/mocha/node_modules/glob": {
             "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
@@ -8706,14 +8706,14 @@
         },
         "node_modules/mocha/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/mocha/node_modules/minimatch": {
             "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
@@ -8729,7 +8729,7 @@
         },
         "node_modules/mocha/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -8746,7 +8746,7 @@
         },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
@@ -8762,13 +8762,13 @@
         },
         "node_modules/moo": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/moo/-/moo-0.5.3.tgz",
             "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/move-file": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/move-file/-/move-file-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/move-file/-/move-file-4.1.0.tgz",
             "integrity": "sha512-YE06K9XLIvMlqSfoZTl32qvbZLPgL70Za41wS8pEhsSOhy71xz2fn8J07nuz/LEEtPSuUzLUFGAJSx499eKDSw==",
             "license": "MIT",
             "engines": {
@@ -8780,27 +8780,27 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/nan": {
             "version": "2.28.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/nan/-/nan-2.28.0.tgz",
             "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
             "license": "MIT",
             "optional": true
         },
         "node_modules/napi-build-utils": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "dev": true,
             "license": "MIT",
@@ -8808,14 +8808,14 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/nearley": {
             "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/nearley/-/nearley-2.20.1.tgz",
             "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
             "license": "MIT",
             "dependencies": {
@@ -8837,13 +8837,13 @@
         },
         "node_modules/nearley/node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
             "license": "MIT",
             "engines": {
@@ -8852,14 +8852,14 @@
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/node-abi": {
             "version": "3.92.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-abi/-/node-abi-3.92.0.tgz",
             "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
             "dev": true,
             "license": "MIT",
@@ -8873,7 +8873,7 @@
         },
         "node_modules/node-addon-api": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-addon-api/-/node-addon-api-4.3.0.tgz",
             "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true,
             "license": "MIT",
@@ -8881,7 +8881,7 @@
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-domexception/-/node-domexception-1.0.0.tgz",
             "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
             "deprecated": "Use your platform's native DOMException instead",
             "funding": [
@@ -8901,7 +8901,7 @@
         },
         "node_modules/node-fetch": {
             "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-fetch/-/node-fetch-3.3.2.tgz",
             "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "license": "MIT",
             "dependencies": {
@@ -8919,7 +8919,7 @@
         },
         "node_modules/node-html-markdown": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
             "integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
             "dev": true,
             "license": "MIT",
@@ -8932,7 +8932,7 @@
         },
         "node_modules/node-html-parser": {
             "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-html-parser/-/node-html-parser-6.1.13.tgz",
             "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
             "dev": true,
             "license": "MIT",
@@ -8943,7 +8943,7 @@
         },
         "node_modules/node-loader": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-loader/-/node-loader-2.1.0.tgz",
             "integrity": "sha512-OwjPkyh8+7jW8DMd/iq71uU1Sspufr/C2+c3t0p08J3CrM9ApZ4U53xuisNrDXOHyGi5OYHgtfmmh+aK9zJA6g==",
             "dev": true,
             "license": "MIT",
@@ -8963,7 +8963,7 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-releases/-/node-releases-2.0.50.tgz",
             "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
             "dev": true,
             "license": "MIT",
@@ -8973,7 +8973,7 @@
         },
         "node_modules/node-sarif-builder": {
             "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
             "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
             "dev": true,
             "license": "MIT",
@@ -8987,7 +8987,7 @@
         },
         "node_modules/normalize-package-data": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
             "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -9002,7 +9002,7 @@
         },
         "node_modules/normalize-package-data/node_modules/hosted-git-info": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
             "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
             "dev": true,
             "license": "ISC",
@@ -9015,14 +9015,14 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
             "license": "MIT",
@@ -9032,7 +9032,7 @@
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -9045,7 +9045,7 @@
         },
         "node_modules/number-is-nan": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
             "license": "MIT",
             "engines": {
@@ -9054,7 +9054,7 @@
         },
         "node_modules/oauth4webapi": {
             "version": "3.8.6",
-            "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
             "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
             "license": "MIT",
             "funding": {
@@ -9063,7 +9063,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "license": "MIT",
             "engines": {
@@ -9072,7 +9072,7 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
@@ -9084,7 +9084,7 @@
         },
         "node_modules/on-exit-leak-free": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
             "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
             "license": "MIT",
             "engines": {
@@ -9093,7 +9093,7 @@
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "license": "MIT",
             "dependencies": {
@@ -9105,7 +9105,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "license": "ISC",
             "dependencies": {
@@ -9114,7 +9114,7 @@
         },
         "node_modules/onetime": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/onetime/-/onetime-7.0.0.tgz",
             "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
             "license": "MIT",
@@ -9130,7 +9130,7 @@
         },
         "node_modules/open": {
             "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/open/-/open-10.2.0.tgz",
             "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "license": "MIT",
             "dependencies": {
@@ -9148,7 +9148,7 @@
         },
         "node_modules/openid-client": {
             "version": "6.8.4",
-            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/openid-client/-/openid-client-6.8.4.tgz",
             "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
             "license": "MIT",
             "dependencies": {
@@ -9161,7 +9161,7 @@
         },
         "node_modules/optionator": {
             "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "devOptional": true,
             "license": "MIT",
@@ -9179,7 +9179,7 @@
         },
         "node_modules/ora": {
             "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ora/-/ora-8.2.0.tgz",
             "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
             "dev": true,
             "license": "MIT",
@@ -9203,7 +9203,7 @@
         },
         "node_modules/ora/node_modules/chalk": {
             "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
@@ -9216,14 +9216,14 @@
         },
         "node_modules/ora/node_modules/emoji-regex": {
             "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ora/node_modules/is-unicode-supported": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
             "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "dev": true,
             "license": "MIT",
@@ -9236,7 +9236,7 @@
         },
         "node_modules/ora/node_modules/log-symbols": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/log-symbols/-/log-symbols-6.0.0.tgz",
             "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
             "dev": true,
             "license": "MIT",
@@ -9253,7 +9253,7 @@
         },
         "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
             "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
             "dev": true,
             "license": "MIT",
@@ -9266,7 +9266,7 @@
         },
         "node_modules/ora/node_modules/string-width": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
@@ -9284,7 +9284,7 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "devOptional": true,
             "license": "MIT",
@@ -9300,7 +9300,7 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "devOptional": true,
             "license": "MIT",
@@ -9316,7 +9316,7 @@
         },
         "node_modules/p-map": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-map/-/p-map-7.0.4.tgz",
             "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
             "dev": true,
             "license": "MIT",
@@ -9329,7 +9329,7 @@
         },
         "node_modules/p-try": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "license": "MIT",
             "engines": {
@@ -9338,20 +9338,20 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true,
             "license": "(MIT AND Zlib)"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
@@ -9364,7 +9364,7 @@
         },
         "node_modules/parse-json": {
             "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parse-json/-/parse-json-8.3.0.tgz",
             "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
             "dev": true,
             "license": "MIT",
@@ -9382,7 +9382,7 @@
         },
         "node_modules/parse-semver": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parse-semver/-/parse-semver-1.1.1.tgz",
             "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
             "dev": true,
             "license": "MIT",
@@ -9392,7 +9392,7 @@
         },
         "node_modules/parse-semver/node_modules/semver": {
             "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
@@ -9402,7 +9402,7 @@
         },
         "node_modules/parse5": {
             "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parse5/-/parse5-7.3.0.tgz",
             "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "dev": true,
             "license": "MIT",
@@ -9415,7 +9415,7 @@
         },
         "node_modules/parse5-htmlparser2-tree-adapter": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
             "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
             "dev": true,
             "license": "MIT",
@@ -9429,7 +9429,7 @@
         },
         "node_modules/parse5-parser-stream": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
             "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
             "dev": true,
             "license": "MIT",
@@ -9442,7 +9442,7 @@
         },
         "node_modules/parse5/node_modules/entities": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/entities/-/entities-6.0.1.tgz",
             "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -9455,7 +9455,7 @@
         },
         "node_modules/parseley": {
             "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parseley/-/parseley-0.12.1.tgz",
             "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
             "license": "MIT",
             "dependencies": {
@@ -9468,7 +9468,7 @@
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "license": "MIT",
             "engines": {
@@ -9477,7 +9477,7 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "devOptional": true,
             "license": "MIT",
@@ -9487,7 +9487,7 @@
         },
         "node_modules/path-expression-matcher": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
             "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
             "funding": [
                 {
@@ -9502,7 +9502,7 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
@@ -9511,14 +9511,14 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/path-scurry": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-scurry/-/path-scurry-2.0.2.tgz",
             "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -9534,7 +9534,7 @@
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-11.5.1.tgz",
             "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -9543,7 +9543,7 @@
         },
         "node_modules/path-to-regexp": {
             "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
             "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
             "license": "MIT",
             "funding": {
@@ -9553,7 +9553,7 @@
         },
         "node_modules/path-type": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-type/-/path-type-6.0.0.tgz",
             "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
             "dev": true,
             "license": "MIT",
@@ -9566,7 +9566,7 @@
         },
         "node_modules/peberminta": {
             "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/peberminta/-/peberminta-0.9.0.tgz",
             "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
             "license": "MIT",
             "funding": {
@@ -9575,20 +9575,20 @@
         },
         "node_modules/pend": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
@@ -9601,7 +9601,7 @@
         },
         "node_modules/pify": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "license": "MIT",
             "engines": {
@@ -9610,7 +9610,7 @@
         },
         "node_modules/pinkie": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pinkie/-/pinkie-2.0.4.tgz",
             "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
             "license": "MIT",
             "engines": {
@@ -9619,7 +9619,7 @@
         },
         "node_modules/pinkie-promise": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
             "license": "MIT",
             "dependencies": {
@@ -9631,7 +9631,7 @@
         },
         "node_modules/pino": {
             "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pino/-/pino-9.14.0.tgz",
             "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
             "license": "MIT",
             "dependencies": {
@@ -9653,7 +9653,7 @@
         },
         "node_modules/pino-abstract-transport": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
             "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
             "license": "MIT",
             "dependencies": {
@@ -9662,13 +9662,13 @@
         },
         "node_modules/pino-std-serializers": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
             "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
             "license": "MIT"
         },
         "node_modules/pkce-challenge": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
             "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
             "license": "MIT",
             "engines": {
@@ -9677,7 +9677,7 @@
         },
         "node_modules/pkg-dir": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
             "license": "MIT",
@@ -9690,7 +9690,7 @@
         },
         "node_modules/pkg-dir/node_modules/find-up": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "license": "MIT",
@@ -9704,7 +9704,7 @@
         },
         "node_modules/pkg-dir/node_modules/locate-path": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
             "license": "MIT",
@@ -9717,7 +9717,7 @@
         },
         "node_modules/pkg-dir/node_modules/p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "license": "MIT",
@@ -9733,7 +9733,7 @@
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "license": "MIT",
@@ -9746,7 +9746,7 @@
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pluralize/-/pluralize-8.0.0.tgz",
             "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
             "dev": true,
             "license": "MIT",
@@ -9756,7 +9756,7 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
             "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "license": "MIT",
             "engines": {
@@ -9765,7 +9765,7 @@
         },
         "node_modules/prebuild-install": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/prebuild-install/-/prebuild-install-7.1.3.tgz",
             "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
             "dev": true,
@@ -9794,7 +9794,7 @@
         },
         "node_modules/prebuild-install/node_modules/bl": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "dev": true,
             "license": "MIT",
@@ -9807,7 +9807,7 @@
         },
         "node_modules/prebuild-install/node_modules/chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true,
             "license": "ISC",
@@ -9815,7 +9815,7 @@
         },
         "node_modules/prebuild-install/node_modules/tar-fs": {
             "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-fs/-/tar-fs-2.1.4.tgz",
             "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
             "dev": true,
             "license": "MIT",
@@ -9829,7 +9829,7 @@
         },
         "node_modules/prebuild-install/node_modules/tar-stream": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "dev": true,
             "license": "MIT",
@@ -9847,7 +9847,7 @@
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "devOptional": true,
             "license": "MIT",
@@ -9857,7 +9857,7 @@
         },
         "node_modules/prettier": {
             "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/prettier/-/prettier-3.9.4.tgz",
             "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
             "dev": true,
             "license": "MIT",
@@ -9873,13 +9873,13 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
         "node_modules/process-warning": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/process-warning/-/process-warning-5.0.0.tgz",
             "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
             "funding": [
                 {
@@ -9895,7 +9895,7 @@
         },
         "node_modules/protobufjs": {
             "version": "8.6.5",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/protobufjs/-/protobufjs-8.6.5.tgz",
             "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -9907,7 +9907,7 @@
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
             "license": "MIT",
             "dependencies": {
@@ -9920,7 +9920,7 @@
         },
         "node_modules/pseudo-localization": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
             "integrity": "sha512-ISYMOKY8+f+PmiXMFw2y6KLY74LBrv/8ml/VjjoVEV2k+MS+OJZz7ydciK5ntJwxPrKQPTU1+oXq9Mx2b0zEzg==",
             "dev": true,
             "license": "MIT",
@@ -9936,7 +9936,7 @@
         },
         "node_modules/pseudo-localization/node_modules/typescript": {
             "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "license": "Apache-2.0",
@@ -9950,7 +9950,7 @@
         },
         "node_modules/pump": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pump/-/pump-3.0.4.tgz",
             "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "license": "MIT",
             "dependencies": {
@@ -9960,7 +9960,7 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "license": "MIT",
             "engines": {
@@ -9969,7 +9969,7 @@
         },
         "node_modules/punycode.js": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/punycode.js/-/punycode.js-2.3.1.tgz",
             "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "dev": true,
             "license": "MIT",
@@ -9979,7 +9979,7 @@
         },
         "node_modules/pure-rand": {
             "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pure-rand/-/pure-rand-8.4.1.tgz",
             "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
             "dev": true,
             "funding": [
@@ -9996,7 +9996,7 @@
         },
         "node_modules/qs": {
             "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/qs/-/qs-6.15.3.tgz",
             "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -10012,7 +10012,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
@@ -10033,19 +10033,19 @@
         },
         "node_modules/quick-format-unescaped": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
             "license": "MIT"
         },
         "node_modules/railroad-diagrams": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
             "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
             "license": "CC0-1.0"
         },
         "node_modules/randexp": {
             "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/randexp/-/randexp-0.4.6.tgz",
             "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
             "license": "MIT",
             "dependencies": {
@@ -10058,7 +10058,7 @@
         },
         "node_modules/range-parser": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/range-parser/-/range-parser-1.3.0.tgz",
             "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "license": "MIT",
             "engines": {
@@ -10071,7 +10071,7 @@
         },
         "node_modules/raw-body": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/raw-body/-/raw-body-3.0.2.tgz",
             "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "license": "MIT",
             "dependencies": {
@@ -10086,7 +10086,7 @@
         },
         "node_modules/raw-body/node_modules/iconv-lite": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
             "dependencies": {
@@ -10102,7 +10102,7 @@
         },
         "node_modules/rc": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -10119,7 +10119,7 @@
         },
         "node_modules/rc-config-loader": {
             "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
             "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
             "dev": true,
             "license": "MIT",
@@ -10132,7 +10132,7 @@
         },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
             "license": "MIT",
@@ -10143,7 +10143,7 @@
         },
         "node_modules/re2-wasm": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/re2-wasm/-/re2-wasm-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/re2-wasm/-/re2-wasm-1.0.2.tgz",
             "integrity": "sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA==",
             "license": "Apache-2.0",
             "optional": true,
@@ -10153,7 +10153,7 @@
         },
         "node_modules/read": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/read/-/read-1.0.7.tgz",
             "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
             "license": "ISC",
@@ -10166,7 +10166,7 @@
         },
         "node_modules/read-pkg": {
             "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/read-pkg/-/read-pkg-9.0.1.tgz",
             "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
             "dev": true,
             "license": "MIT",
@@ -10186,7 +10186,7 @@
         },
         "node_modules/read-pkg/node_modules/unicorn-magic": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
             "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
             "dev": true,
             "license": "MIT",
@@ -10199,7 +10199,7 @@
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "license": "MIT",
             "dependencies": {
@@ -10213,7 +10213,7 @@
         },
         "node_modules/readdirp": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readdirp/-/readdirp-4.1.2.tgz",
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
@@ -10227,7 +10227,7 @@
         },
         "node_modules/real-require": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/real-require/-/real-require-0.2.0.tgz",
             "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
             "license": "MIT",
             "engines": {
@@ -10236,7 +10236,7 @@
         },
         "node_modules/rechoir": {
             "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rechoir/-/rechoir-0.8.0.tgz",
             "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "license": "MIT",
@@ -10249,7 +10249,7 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "license": "MIT",
             "engines": {
@@ -10258,7 +10258,7 @@
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "license": "MIT",
             "engines": {
@@ -10267,13 +10267,13 @@
         },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "license": "ISC"
         },
         "node_modules/resolve": {
             "version": "1.22.12",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-1.22.12.tgz",
             "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
@@ -10295,7 +10295,7 @@
         },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
             "license": "MIT",
@@ -10308,7 +10308,7 @@
         },
         "node_modules/resolve-cwd/node_modules/resolve-from": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
             "license": "MIT",
@@ -10318,7 +10318,7 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
@@ -10328,7 +10328,7 @@
         },
         "node_modules/restore-cursor": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/restore-cursor/-/restore-cursor-5.1.0.tgz",
             "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
             "license": "MIT",
@@ -10345,7 +10345,7 @@
         },
         "node_modules/ret": {
             "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "license": "MIT",
             "engines": {
@@ -10354,7 +10354,7 @@
         },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
@@ -10365,20 +10365,20 @@
         },
         "node_modules/rfc4648": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rfc4648/-/rfc4648-1.5.4.tgz",
             "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
             "license": "MIT"
         },
         "node_modules/rfdc": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/router": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/router/-/router-2.2.0.tgz",
             "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
             "license": "MIT",
             "dependencies": {
@@ -10394,7 +10394,7 @@
         },
         "node_modules/run-applescript": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/run-applescript/-/run-applescript-7.1.0.tgz",
             "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "license": "MIT",
             "engines": {
@@ -10406,7 +10406,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
@@ -10430,7 +10430,7 @@
         },
         "node_modules/rxjs": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -10439,7 +10439,7 @@
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "funding": [
                 {
@@ -10459,7 +10459,7 @@
         },
         "node_modules/safe-stable-stringify": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
             "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
             "license": "MIT",
             "engines": {
@@ -10468,13 +10468,13 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
         "node_modules/sax": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sax/-/sax-1.6.0.tgz",
             "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -10483,7 +10483,7 @@
         },
         "node_modules/schema-utils": {
             "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/schema-utils/-/schema-utils-4.3.3.tgz",
             "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dev": true,
             "license": "MIT",
@@ -10503,7 +10503,7 @@
         },
         "node_modules/schemes": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/schemes/-/schemes-1.4.0.tgz",
             "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
             "license": "MIT",
             "dependencies": {
@@ -10512,7 +10512,7 @@
         },
         "node_modules/secretlint": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/secretlint/-/secretlint-10.2.2.tgz",
             "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
             "dev": true,
             "license": "MIT",
@@ -10534,7 +10534,7 @@
         },
         "node_modules/seek-bzip": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/seek-bzip/-/seek-bzip-1.0.6.tgz",
             "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
             "license": "MIT",
             "dependencies": {
@@ -10547,13 +10547,13 @@
         },
         "node_modules/seek-bzip/node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
         },
         "node_modules/selderee": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/selderee/-/selderee-0.11.0.tgz",
             "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
             "license": "MIT",
             "dependencies": {
@@ -10565,7 +10565,7 @@
         },
         "node_modules/semver": {
             "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.8.5.tgz",
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
@@ -10577,7 +10577,7 @@
         },
         "node_modules/send": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/send/-/send-1.2.1.tgz",
             "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "license": "MIT",
             "dependencies": {
@@ -10603,7 +10603,7 @@
         },
         "node_modules/serialize-javascript": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
             "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -10613,7 +10613,7 @@
         },
         "node_modules/serve-static": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/serve-static/-/serve-static-2.2.1.tgz",
             "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "license": "MIT",
             "dependencies": {
@@ -10632,13 +10632,13 @@
         },
         "node_modules/set-blocking": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
             "license": "ISC"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "license": "MIT",
             "dependencies": {
@@ -10655,20 +10655,20 @@
         },
         "node_modules/setimmediate": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
             "license": "ISC"
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
             "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
             "license": "MIT",
@@ -10681,7 +10681,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -10693,7 +10693,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -10702,7 +10702,7 @@
         },
         "node_modules/side-channel": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel/-/side-channel-1.1.1.tgz",
             "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
@@ -10721,7 +10721,7 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-list/-/side-channel-list-1.0.1.tgz",
             "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
@@ -10737,7 +10737,7 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
             "dependencies": {
@@ -10755,7 +10755,7 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
             "dependencies": {
@@ -10774,7 +10774,7 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
             "engines": {
@@ -10786,7 +10786,7 @@
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true,
             "funding": [
@@ -10808,7 +10808,7 @@
         },
         "node_modules/simple-get": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/simple-get/-/simple-get-4.0.1.tgz",
             "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "funding": [
@@ -10835,7 +10835,7 @@
         },
         "node_modules/sinon": {
             "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sinon/-/sinon-22.0.0.tgz",
             "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -10852,7 +10852,7 @@
         },
         "node_modules/sinon/node_modules/diff": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/diff/-/diff-9.0.0.tgz",
             "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -10862,7 +10862,7 @@
         },
         "node_modules/slash": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/slash/-/slash-5.1.0.tgz",
             "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "dev": true,
             "license": "MIT",
@@ -10875,7 +10875,7 @@
         },
         "node_modules/slice-ansi": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/slice-ansi/-/slice-ansi-8.0.0.tgz",
             "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
             "dev": true,
             "license": "MIT",
@@ -10892,7 +10892,7 @@
         },
         "node_modules/slice-ansi/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -10905,7 +10905,7 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
             "engines": {
@@ -10915,7 +10915,7 @@
         },
         "node_modules/smtp-address-parser": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/smtp-address-parser/-/smtp-address-parser-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/smtp-address-parser/-/smtp-address-parser-1.1.0.tgz",
             "integrity": "sha512-Gz11jbNU0plrReU9Sj7fmshSBxxJ9ShdD2q4ktHIHo/rpTH6lFyQoYHYKINPJtPe8aHFnsbtW46Ls0tCCBsIZg==",
             "license": "MIT",
             "dependencies": {
@@ -10927,7 +10927,7 @@
         },
         "node_modules/socks": {
             "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/socks/-/socks-2.8.9.tgz",
             "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
             "license": "MIT",
             "dependencies": {
@@ -10941,7 +10941,7 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "license": "MIT",
             "dependencies": {
@@ -10955,7 +10955,7 @@
         },
         "node_modules/sonic-boom": {
             "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sonic-boom/-/sonic-boom-4.2.1.tgz",
             "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
             "license": "MIT",
             "dependencies": {
@@ -10964,7 +10964,7 @@
         },
         "node_modules/source-map": {
             "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map/-/source-map-0.7.6.tgz",
             "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -10974,7 +10974,7 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
@@ -10985,7 +10985,7 @@
         },
         "node_modules/source-map-support/node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -10995,7 +10995,7 @@
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdx-correct/-/spdx-correct-3.2.0.tgz",
             "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
             "license": "Apache-2.0",
@@ -11006,14 +11006,14 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
             "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
             "dev": true,
             "license": "CC-BY-3.0"
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
             "license": "MIT",
@@ -11024,20 +11024,20 @@
         },
         "node_modules/spdx-license-ids": {
             "version": "3.0.23",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
             "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/split-ca": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/split-ca/-/split-ca-1.0.1.tgz",
             "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
             "license": "ISC"
         },
         "node_modules/split2": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/split2/-/split2-4.2.0.tgz",
             "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
             "license": "ISC",
             "engines": {
@@ -11046,13 +11046,13 @@
         },
         "node_modules/sprintf-js": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/ssh2": {
             "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ssh2/-/ssh2-1.17.0.tgz",
             "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
             "hasInstallScript": true,
             "dependencies": {
@@ -11069,7 +11069,7 @@
         },
         "node_modules/statuses": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
@@ -11078,7 +11078,7 @@
         },
         "node_modules/stdin-discarder": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
             "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
             "dev": true,
             "license": "MIT",
@@ -11091,7 +11091,7 @@
         },
         "node_modules/stream-buffers": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/stream-buffers/-/stream-buffers-3.0.3.tgz",
             "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
             "license": "Unlicense",
             "engines": {
@@ -11100,7 +11100,7 @@
         },
         "node_modules/streamx": {
             "version": "2.28.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/streamx/-/streamx-2.28.0.tgz",
             "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
             "license": "MIT",
             "dependencies": {
@@ -11111,7 +11111,7 @@
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "license": "MIT",
             "dependencies": {
@@ -11120,7 +11120,7 @@
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-argv/-/string-argv-0.3.2.tgz",
             "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
             "dev": true,
             "license": "MIT",
@@ -11130,7 +11130,7 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "dependencies": {
@@ -11145,7 +11145,7 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
@@ -11160,7 +11160,7 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -11170,7 +11170,7 @@
         },
         "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
@@ -11180,7 +11180,7 @@
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -11193,7 +11193,7 @@
         },
         "node_modules/string-width/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "license": "MIT",
             "engines": {
@@ -11202,7 +11202,7 @@
         },
         "node_modules/string-width/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "license": "MIT",
             "engines": {
@@ -11211,7 +11211,7 @@
         },
         "node_modules/string-width/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
@@ -11223,7 +11223,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-7.2.0.tgz",
             "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
             "license": "MIT",
@@ -11240,7 +11240,7 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -11253,7 +11253,7 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -11263,7 +11263,7 @@
         },
         "node_modules/strip-dirs": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-dirs/-/strip-dirs-2.1.0.tgz",
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "license": "MIT",
             "dependencies": {
@@ -11272,7 +11272,7 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
@@ -11285,7 +11285,7 @@
         },
         "node_modules/strnum": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strnum/-/strnum-2.4.1.tgz",
             "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
@@ -11300,7 +11300,7 @@
         },
         "node_modules/structured-source": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/structured-source/-/structured-source-4.0.0.tgz",
             "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -11310,7 +11310,7 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
@@ -11323,7 +11323,7 @@
         },
         "node_modules/supports-hyperlinks": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
             "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
             "dev": true,
             "license": "MIT",
@@ -11340,7 +11340,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
             "license": "MIT",
@@ -11353,7 +11353,7 @@
         },
         "node_modules/table": {
             "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/table/-/table-6.9.0.tgz",
             "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -11370,7 +11370,7 @@
         },
         "node_modules/table/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -11380,7 +11380,7 @@
         },
         "node_modules/table/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
@@ -11390,7 +11390,7 @@
         },
         "node_modules/table/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
             "license": "MIT",
@@ -11408,7 +11408,7 @@
         },
         "node_modules/table/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -11421,7 +11421,7 @@
         },
         "node_modules/tapable": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tapable/-/tapable-2.3.3.tgz",
             "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "license": "MIT",
@@ -11435,7 +11435,7 @@
         },
         "node_modules/tar": {
             "version": "7.5.17",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar/-/tar-7.5.17.tgz",
             "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -11451,7 +11451,7 @@
         },
         "node_modules/tar-fs": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-fs/-/tar-fs-3.1.2.tgz",
             "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
             "license": "MIT",
             "dependencies": {
@@ -11465,7 +11465,7 @@
         },
         "node_modules/tar-fs/node_modules/tar-stream": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-stream/-/tar-stream-3.2.0.tgz",
             "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
             "license": "MIT",
             "dependencies": {
@@ -11477,7 +11477,7 @@
         },
         "node_modules/tar-stream": {
             "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "license": "MIT",
             "dependencies": {
@@ -11495,13 +11495,13 @@
         },
         "node_modules/tar-stream/node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "license": "MIT"
         },
         "node_modules/tar-stream/node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "license": "MIT",
             "dependencies": {
@@ -11516,13 +11516,13 @@
         },
         "node_modules/tar-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
         "node_modules/tar-stream/node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "license": "MIT",
             "dependencies": {
@@ -11531,7 +11531,7 @@
         },
         "node_modules/tar/node_modules/yallist": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yallist/-/yallist-5.0.0.tgz",
             "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -11540,7 +11540,7 @@
         },
         "node_modules/tas-client": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tas-client/-/tas-client-0.3.2.tgz",
             "integrity": "sha512-Hr0k7swJSyI7fsgqWf28GoME3lDXysTV1pJW/OBCrokhkqd3dTL+79SLKRGaYNHNaHii5N7VLRlZZc/up6xdAA==",
             "license": "MIT",
             "engines": {
@@ -11549,7 +11549,7 @@
         },
         "node_modules/teex": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/teex/-/teex-1.0.1.tgz",
             "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
             "license": "MIT",
             "dependencies": {
@@ -11558,7 +11558,7 @@
         },
         "node_modules/terminal-link": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/terminal-link/-/terminal-link-4.0.0.tgz",
             "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
             "dev": true,
             "license": "MIT",
@@ -11575,7 +11575,7 @@
         },
         "node_modules/terser": {
             "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/terser/-/terser-5.48.0.tgz",
             "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -11594,14 +11594,14 @@
         },
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/text-decoder": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/text-decoder/-/text-decoder-1.2.7.tgz",
             "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -11610,14 +11610,14 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/textextensions": {
             "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/textextensions/-/textextensions-6.11.0.tgz",
             "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
             "dev": true,
             "license": "Artistic-2.0",
@@ -11633,7 +11633,7 @@
         },
         "node_modules/thread-stream": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/thread-stream/-/thread-stream-3.2.0.tgz",
             "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
             "license": "MIT",
             "dependencies": {
@@ -11642,13 +11642,13 @@
         },
         "node_modules/through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "license": "MIT"
         },
         "node_modules/tinyexec": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tinyexec/-/tinyexec-1.2.4.tgz",
             "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
             "license": "MIT",
@@ -11658,7 +11658,7 @@
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tinyglobby/-/tinyglobby-0.2.17.tgz",
             "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
@@ -11675,7 +11675,7 @@
         },
         "node_modules/tmp": {
             "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tmp/-/tmp-0.2.7.tgz",
             "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "license": "MIT",
             "engines": {
@@ -11684,7 +11684,7 @@
         },
         "node_modules/to-buffer": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/to-buffer/-/to-buffer-1.2.2.tgz",
             "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
             "license": "MIT",
             "dependencies": {
@@ -11698,7 +11698,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "license": "MIT",
@@ -11711,7 +11711,7 @@
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "license": "MIT",
             "engines": {
@@ -11720,13 +11720,13 @@
         },
         "node_modules/tr46": {
             "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT"
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tree-kill/-/tree-kill-1.2.2.tgz",
             "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "license": "MIT",
             "bin": {
@@ -11735,7 +11735,7 @@
         },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
             "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
@@ -11748,7 +11748,7 @@
         },
         "node_modules/ts-loader": {
             "version": "9.6.2",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ts-loader/-/ts-loader-9.6.2.tgz",
             "integrity": "sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==",
             "dev": true,
             "license": "MIT",
@@ -11773,13 +11773,13 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
             "license": "MIT",
@@ -11789,7 +11789,7 @@
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
             "license": "Apache-2.0",
@@ -11803,13 +11803,13 @@
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
             "license": "Unlicense"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "devOptional": true,
             "license": "MIT",
@@ -11822,7 +11822,7 @@
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true,
             "license": "MIT",
@@ -11832,7 +11832,7 @@
         },
         "node_modules/type-fest": {
             "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
@@ -11845,7 +11845,7 @@
         },
         "node_modules/type-is": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-is/-/type-is-2.1.0.tgz",
             "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "license": "MIT",
             "dependencies": {
@@ -11863,7 +11863,7 @@
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "license": "MIT",
             "dependencies": {
@@ -11877,7 +11877,7 @@
         },
         "node_modules/typed-rest-client": {
             "version": "1.8.11",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
             "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
             "dev": true,
             "license": "MIT",
@@ -11889,7 +11889,7 @@
         },
         "node_modules/typescript": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
@@ -11903,14 +11903,14 @@
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/unbzip2-stream": {
             "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
             "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
             "license": "MIT",
             "dependencies": {
@@ -11920,14 +11920,14 @@
         },
         "node_modules/underscore": {
             "version": "1.13.8",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/undici/-/undici-7.28.0.tgz",
             "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true,
             "license": "MIT",
@@ -11937,13 +11937,13 @@
         },
         "node_modules/undici-types": {
             "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/undici-types/-/undici-types-8.3.0.tgz",
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "license": "MIT"
         },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
             "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
             "dev": true,
             "license": "MIT",
@@ -11956,13 +11956,13 @@
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
             "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
             "license": "ISC"
         },
         "node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
@@ -11972,7 +11972,7 @@
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "license": "MIT",
             "engines": {
@@ -11981,7 +11981,7 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
             "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
@@ -12012,7 +12012,7 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -12021,20 +12021,20 @@
         },
         "node_modules/url-join": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/url-join/-/url-join-4.0.1.tgz",
             "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/uuid/-/uuid-14.0.1.tgz",
             "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -12047,7 +12047,7 @@
         },
         "node_modules/validate-dockerfile": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/validate-dockerfile/-/validate-dockerfile-1.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/validate-dockerfile/-/validate-dockerfile-1.8.1.tgz",
             "integrity": "sha512-lV4O0V9RqYgV6gLl0YtLsJSNySee5eCV8Qm43dykErJVM0+OQYfwv+CU+Sq8TSTu1dKBdusoe7TP3qaKVQWlIg==",
             "license": "MIT",
             "dependencies": {
@@ -12059,13 +12059,13 @@
         },
         "node_modules/validate-dockerfile/node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "license": "Apache-2.0",
@@ -12076,7 +12076,7 @@
         },
         "node_modules/vary": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "license": "MIT",
             "engines": {
@@ -12085,7 +12085,7 @@
         },
         "node_modules/version-range": {
             "version": "4.15.0",
-            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/version-range/-/version-range-4.15.0.tgz",
             "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
             "dev": true,
             "license": "Artistic-2.0",
@@ -12098,7 +12098,7 @@
         },
         "node_modules/vscode-kubernetes-tools-api": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.3.0.tgz",
             "integrity": "sha512-5+4OdwrRinoTsE8i6s8pPY+BbGh5U7DNAA/3pn5wlOhvQpivaBMdi89bRKfdAffPjt/bvHodje4BFm5GSNjFxQ==",
             "license": "MIT",
             "engines": {
@@ -12107,7 +12107,7 @@
         },
         "node_modules/vscode-tas-client": {
             "version": "0.1.86",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.86.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/vscode-tas-client/-/vscode-tas-client-0.1.86.tgz",
             "integrity": "sha512-4P3zjGXTKXknbWOd6EDnD3lWZuc/aFrW8Ixzk0B8gQDBq2BXuKg0NwsZiFeAzBohAxCcsRA4gQipH57Bxf6XXg==",
             "license": "MIT",
             "dependencies": {
@@ -12119,7 +12119,7 @@
         },
         "node_modules/watchpack": {
             "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/watchpack/-/watchpack-2.5.2.tgz",
             "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
             "dev": true,
             "license": "MIT",
@@ -12132,7 +12132,7 @@
         },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
             "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
             "license": "MIT",
             "engines": {
@@ -12141,20 +12141,20 @@
         },
         "node_modules/web-tree-sitter": {
             "version": "0.20.8",
-            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
             "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
             "version": "5.108.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack/-/webpack-5.108.1.tgz",
             "integrity": "sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==",
             "dev": true,
             "license": "MIT",
@@ -12200,7 +12200,7 @@
         },
         "node_modules/webpack-cli": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-cli/-/webpack-cli-7.1.0.tgz",
             "integrity": "sha512-pSJ5p5PkXRD88sfCq5Wo+coc42QykwRu5Md0DyESj0rT6PPPA2wTNabpHPKgqH8EMkfTDo3IWx3iiNXMu8XDBQ==",
             "dev": true,
             "license": "MIT",
@@ -12252,7 +12252,7 @@
         },
         "node_modules/webpack-cli/node_modules/commander": {
             "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-14.0.3.tgz",
             "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "dev": true,
             "license": "MIT",
@@ -12262,7 +12262,7 @@
         },
         "node_modules/webpack-merge": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-merge/-/webpack-merge-6.0.1.tgz",
             "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
             "dev": true,
             "license": "MIT",
@@ -12277,7 +12277,7 @@
         },
         "node_modules/webpack-sources": {
             "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-sources/-/webpack-sources-3.5.0.tgz",
             "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
             "dev": true,
             "license": "MIT",
@@ -12287,7 +12287,7 @@
         },
         "node_modules/webpack/node_modules/eslint-scope": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -12301,7 +12301,7 @@
         },
         "node_modules/webpack/node_modules/estraverse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
@@ -12311,7 +12311,7 @@
         },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "dev": true,
@@ -12325,7 +12325,7 @@
         },
         "node_modules/whatwg-mimetype": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
             "dev": true,
             "license": "MIT",
@@ -12335,7 +12335,7 @@
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "license": "MIT",
             "dependencies": {
@@ -12345,7 +12345,7 @@
         },
         "node_modules/which": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-5.0.0.tgz",
             "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
             "license": "ISC",
             "dependencies": {
@@ -12360,13 +12360,13 @@
         },
         "node_modules/which-module": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-module/-/which-module-2.0.1.tgz",
             "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
             "license": "ISC"
         },
         "node_modules/which-typed-array": {
             "version": "1.1.22",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-typed-array/-/which-typed-array-1.1.22.tgz",
             "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
             "license": "MIT",
             "dependencies": {
@@ -12387,14 +12387,14 @@
         },
         "node_modules/wildcard": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wildcard/-/wildcard-2.0.1.tgz",
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "devOptional": true,
             "license": "MIT",
@@ -12404,14 +12404,14 @@
         },
         "node_modules/workerpool": {
             "version": "9.3.4",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/workerpool/-/workerpool-9.3.4.tgz",
             "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
             "license": "MIT",
             "dependencies": {
@@ -12425,7 +12425,7 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
@@ -12443,7 +12443,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -12453,7 +12453,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -12466,7 +12466,7 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
             "license": "MIT",
             "engines": {
@@ -12475,7 +12475,7 @@
         },
         "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
             "license": "MIT",
             "dependencies": {
@@ -12487,7 +12487,7 @@
         },
         "node_modules/wrap-ansi/node_modules/string-width": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
             "license": "MIT",
             "dependencies": {
@@ -12501,7 +12501,7 @@
         },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "license": "MIT",
             "dependencies": {
@@ -12513,13 +12513,13 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
         "node_modules/ws": {
             "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ws/-/ws-8.21.0.tgz",
             "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
@@ -12540,7 +12540,7 @@
         },
         "node_modules/wsl-utils": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wsl-utils/-/wsl-utils-0.1.0.tgz",
             "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
             "license": "MIT",
             "dependencies": {
@@ -12555,7 +12555,7 @@
         },
         "node_modules/xml-naming": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xml-naming/-/xml-naming-0.1.0.tgz",
             "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
             "funding": [
                 {
@@ -12570,7 +12570,7 @@
         },
         "node_modules/xml2js": {
             "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xml2js/-/xml2js-0.5.0.tgz",
             "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "dev": true,
             "license": "MIT",
@@ -12584,7 +12584,7 @@
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "license": "MIT",
             "engines": {
@@ -12593,7 +12593,7 @@
         },
         "node_modules/xtend": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "license": "MIT",
             "engines": {
@@ -12602,7 +12602,7 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "license": "ISC",
             "engines": {
@@ -12611,14 +12611,14 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "bin": {
@@ -12633,7 +12633,7 @@
         },
         "node_modules/yargs": {
             "version": "17.7.3",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yargs/-/yargs-17.7.3.tgz",
             "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
             "license": "MIT",
             "dependencies": {
@@ -12651,7 +12651,7 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "license": "ISC",
             "engines": {
@@ -12660,7 +12660,7 @@
         },
         "node_modules/yargs-unparser": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
             "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
             "license": "MIT",
@@ -12676,7 +12676,7 @@
         },
         "node_modules/yargs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "license": "MIT",
             "engines": {
@@ -12685,7 +12685,7 @@
         },
         "node_modules/yargs/node_modules/cliui": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "license": "ISC",
             "dependencies": {
@@ -12699,7 +12699,7 @@
         },
         "node_modules/yargs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
@@ -12711,7 +12711,7 @@
         },
         "node_modules/yargs/node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "license": "MIT",
             "dependencies": {
@@ -12728,7 +12728,7 @@
         },
         "node_modules/yauzl": {
             "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yauzl/-/yauzl-3.4.0.tgz",
             "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
             "dev": true,
             "license": "MIT",
@@ -12741,7 +12741,7 @@
         },
         "node_modules/yazl": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yazl/-/yazl-2.5.1.tgz",
             "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "license": "MIT",
@@ -12751,7 +12751,7 @@
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "devOptional": true,
             "license": "MIT",
@@ -12764,7 +12764,7 @@
         },
         "node_modules/zod": {
             "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
             "funding": {
@@ -12773,7 +12773,7 @@
         },
         "node_modules/zod-to-json-schema": {
             "version": "3.25.2",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "license": "ISC",
             "peerDependencies": {

--- a/webview-ui/.npmrc
+++ b/webview-ui/.npmrc
@@ -1,0 +1,1 @@
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/webview-ui/.npmrc
+++ b/webview-ui/.npmrc
@@ -1,1 +1,2 @@
 registry=https://packagefeedproxy.microsoft.io/npm/
+always-auth=true

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -36,7 +36,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
@@ -51,7 +51,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
@@ -61,7 +61,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
@@ -92,7 +92,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
@@ -109,7 +109,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
@@ -126,7 +126,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
@@ -136,7 +136,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
@@ -150,7 +150,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
@@ -168,7 +168,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
@@ -178,7 +178,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
@@ -188,7 +188,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
@@ -198,7 +198,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
@@ -212,7 +212,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
@@ -228,7 +228,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
@@ -243,7 +243,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
@@ -262,7 +262,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
@@ -276,7 +276,7 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "optional": true,
@@ -287,7 +287,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "optional": true,
@@ -297,7 +297,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "optional": true,
@@ -307,7 +307,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "dependencies": {
@@ -325,7 +325,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "engines": {
@@ -334,7 +334,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "dependencies": {
@@ -348,7 +348,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "engines": {
@@ -357,7 +357,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
@@ -370,7 +370,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "dependencies": {
@@ -385,7 +385,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
       "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "dependencies": {
@@ -397,7 +397,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "dependencies": {
@@ -409,7 +409,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "engines": {
@@ -418,7 +418,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "dependencies": {
@@ -431,7 +431,7 @@
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
       "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw==",
       "engines": {
         "node": ">=6"
@@ -439,7 +439,7 @@
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
       "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -450,7 +450,7 @@
     },
     "node_modules/@fortawesome/free-regular-svg-icons": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.0.tgz",
       "integrity": "sha512-4675NiHzJJs0dLStFpp5G1JNfMYxqFSxZ2iCaiMfHptjlc8McLG9oqcd5pFEiPiqfiV2YG25cJ9EYWIEhUvp+A==",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -461,7 +461,7 @@
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
       "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -472,7 +472,7 @@
     },
     "node_modules/@fortawesome/react-fontawesome": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
       "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
       "engines": {
         "node": ">=20"
@@ -484,7 +484,7 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -494,7 +494,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -508,7 +508,7 @@
     },
     "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -522,7 +522,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "engines": {
@@ -535,7 +535,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -549,7 +549,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "dev": true,
       "dependencies": {
@@ -559,7 +559,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "dependencies": {
@@ -569,7 +569,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
@@ -578,13 +578,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dev": true,
       "dependencies": {
@@ -594,7 +594,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "optional": true,
@@ -612,7 +612,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "funding": {
@@ -621,7 +621,7 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
@@ -637,7 +637,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
@@ -653,7 +653,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
@@ -669,7 +669,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
@@ -685,7 +685,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
@@ -701,7 +701,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
@@ -717,7 +717,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
@@ -733,7 +733,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
@@ -749,7 +749,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
@@ -765,7 +765,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
@@ -781,7 +781,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
@@ -797,7 +797,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
@@ -813,7 +813,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
@@ -831,7 +831,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
@@ -847,7 +847,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
@@ -863,13 +863,13 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
       "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
       "dev": true,
       "dependencies": {
@@ -882,7 +882,7 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "optional": true,
@@ -892,7 +892,7 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/debug/-/debug-4.1.9.tgz",
       "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "dependencies": {
         "@types/ms": "*"
@@ -900,7 +900,7 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/eslint/-/eslint-8.56.12.tgz",
       "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
       "dev": true,
       "license": "MIT",
@@ -911,20 +911,20 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/hast/-/hast-3.0.1.tgz",
       "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
       "dependencies": {
         "@types/unist": "*"
@@ -932,13 +932,13 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mdast/-/mdast-4.0.1.tgz",
       "integrity": "sha512-IlKct1rUTJ1T81d8OHzyop15kGv9A/ff7Gz7IJgrk6jDb4Udw77pCJ+vq8oxZf4Ghpm+616+i1s/LNg/Vh7d+g==",
       "dependencies": {
         "@types/unist": "*"
@@ -946,12 +946,12 @@
     },
     "node_modules/@types/ms": {
       "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/ms/-/ms-0.7.32.tgz",
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -959,7 +959,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "peerDependencies": {
@@ -968,18 +968,18 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "node_modules/@types/vscode-webview": {
       "version": "1.57.5",
-      "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
       "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
       "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "dependencies": {
@@ -1007,7 +1007,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "engines": {
@@ -1016,7 +1016,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/parser/-/parser-8.63.0.tgz",
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "dependencies": {
@@ -1040,7 +1040,7 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
       "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "dependencies": {
@@ -1061,7 +1061,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
       "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "dependencies": {
@@ -1078,7 +1078,7 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
       "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "engines": {
@@ -1094,7 +1094,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
       "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "dependencies": {
@@ -1118,7 +1118,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/types/-/types-8.63.0.tgz",
       "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "engines": {
@@ -1131,7 +1131,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
       "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "dependencies": {
@@ -1158,7 +1158,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "engines": {
@@ -1167,7 +1167,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "dependencies": {
@@ -1179,7 +1179,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "dependencies": {
@@ -1194,7 +1194,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "bin": {
@@ -1206,7 +1206,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/utils/-/utils-8.63.0.tgz",
       "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "dependencies": {
@@ -1229,7 +1229,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
       "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "dependencies": {
@@ -1246,7 +1246,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "engines": {
@@ -1258,12 +1258,12 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
       "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "dependencies": {
@@ -1288,12 +1288,12 @@
     },
     "node_modules/@vscode/codicons": {
       "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/codicons/-/codicons-0.0.45.tgz",
       "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw=="
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
@@ -1306,7 +1306,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -1316,7 +1316,7 @@
     },
     "node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
@@ -1333,7 +1333,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
@@ -1350,7 +1350,7 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array-includes/-/array-includes-3.1.8.tgz",
       "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
       "dev": true,
       "license": "MIT",
@@ -1371,7 +1371,7 @@
     },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
@@ -1392,7 +1392,7 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
       "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
@@ -1411,7 +1411,7 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
       "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
@@ -1430,7 +1430,7 @@
     },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
@@ -1447,7 +1447,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
@@ -1469,7 +1469,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
@@ -1485,7 +1485,7 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "funding": {
         "type": "github",
@@ -1494,13 +1494,13 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
       "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1513,7 +1513,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
@@ -1524,7 +1524,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/browserslist/-/browserslist-4.28.4.tgz",
       "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
@@ -1558,7 +1558,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
@@ -1577,7 +1577,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -1591,7 +1591,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
@@ -1608,7 +1608,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
       "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
@@ -1629,7 +1629,7 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
       "funding": {
         "type": "github",
@@ -1638,7 +1638,7 @@
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "dependencies": {
@@ -1653,7 +1653,7 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "funding": {
         "type": "github",
@@ -1662,20 +1662,20 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1690,12 +1690,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
@@ -1713,7 +1713,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
@@ -1731,7 +1731,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
@@ -1749,7 +1749,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1765,7 +1765,7 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -1777,13 +1777,13 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -1801,7 +1801,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
@@ -1819,7 +1819,7 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "engines": {
         "node": ">=6"
@@ -1827,7 +1827,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "engines": {
@@ -1836,7 +1836,7 @@
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -1848,7 +1848,7 @@
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1861,7 +1861,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -1876,14 +1876,14 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.380",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
       "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
@@ -1894,7 +1894,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-abstract/-/es-abstract-1.23.9.tgz",
       "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
       "license": "MIT",
@@ -1960,7 +1960,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -1970,7 +1970,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -1980,7 +1980,7 @@
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
       "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "license": "MIT",
@@ -2008,7 +2008,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
@@ -2021,7 +2021,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
@@ -2037,7 +2037,7 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
       "license": "MIT",
@@ -2047,7 +2047,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
@@ -2065,7 +2065,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -2075,7 +2075,7 @@
     },
     "node_modules/eslint": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint/-/eslint-10.6.0.tgz",
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "dependencies": {
@@ -2130,7 +2130,7 @@
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
@@ -2163,7 +2163,7 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
@@ -2183,7 +2183,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2202,7 +2202,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
@@ -2214,7 +2214,7 @@
     },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -2224,7 +2224,7 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
@@ -2237,7 +2237,7 @@
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "engines": {
@@ -2249,7 +2249,7 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2262,7 +2262,7 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
@@ -2274,7 +2274,7 @@
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2290,7 +2290,7 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2308,7 +2308,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2321,7 +2321,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2334,7 +2334,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2347,7 +2347,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
@@ -2356,13 +2356,13 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "engines": {
@@ -2371,32 +2371,32 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -2409,7 +2409,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
@@ -2425,7 +2425,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -2439,13 +2439,13 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "license": "MIT",
@@ -2455,7 +2455,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2469,7 +2469,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
@@ -2479,7 +2479,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
@@ -2500,7 +2500,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
@@ -2510,7 +2510,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
@@ -2520,7 +2520,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
@@ -2545,7 +2545,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -2559,7 +2559,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
@@ -2577,7 +2577,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -2594,7 +2594,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -2607,13 +2607,13 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
@@ -2626,7 +2626,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -2639,7 +2639,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
@@ -2655,7 +2655,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -2668,7 +2668,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -2684,7 +2684,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
@@ -2697,7 +2697,7 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
       "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2716,7 +2716,7 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2728,7 +2728,7 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
       "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2752,7 +2752,7 @@
     },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz",
       "integrity": "sha512-wSlp23N45CMjDg/BPW8zvhEi3R+8eRE1qFbjEyAUzMCzu2l1Wzwakq+Tlia9nkCtEl5mDxa7nKHsvYJ6Gfn21A==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2772,7 +2772,7 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
       "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2790,7 +2790,7 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2802,7 +2802,7 @@
     },
     "node_modules/hastscript": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hastscript/-/hastscript-8.0.0.tgz",
       "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2818,14 +2818,14 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
       "license": "MIT",
@@ -2835,7 +2835,7 @@
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
       "integrity": "sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==",
       "funding": {
         "type": "opencollective",
@@ -2844,7 +2844,7 @@
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "funding": {
         "type": "github",
@@ -2853,7 +2853,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -2863,7 +2863,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
@@ -2872,12 +2872,12 @@
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
@@ -2892,7 +2892,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
@@ -2910,7 +2910,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-async-function/-/is-async-function-2.1.0.tgz",
       "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "dev": true,
       "license": "MIT",
@@ -2929,7 +2929,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
@@ -2945,7 +2945,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
       "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "dev": true,
       "license": "MIT",
@@ -2962,7 +2962,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
@@ -2975,7 +2975,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
@@ -2991,7 +2991,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
@@ -3009,7 +3009,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
@@ -3026,7 +3026,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
@@ -3035,7 +3035,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
@@ -3051,7 +3051,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
@@ -3070,7 +3070,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
@@ -3082,7 +3082,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
@@ -3095,7 +3095,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
@@ -3112,7 +3112,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "engines": {
         "node": ">=12"
@@ -3123,7 +3123,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
@@ -3142,7 +3142,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
@@ -3155,7 +3155,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
@@ -3171,7 +3171,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
@@ -3188,7 +3188,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
@@ -3206,7 +3206,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
@@ -3222,7 +3222,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
@@ -3235,7 +3235,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakref/-/is-weakref-1.1.0.tgz",
       "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "dev": true,
       "license": "MIT",
@@ -3251,7 +3251,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
@@ -3268,21 +3268,21 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
@@ -3300,13 +3300,13 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
@@ -3319,27 +3319,27 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -3352,7 +3352,7 @@
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
@@ -3368,7 +3368,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -3378,7 +3378,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "dependencies": {
@@ -3391,7 +3391,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "dependencies": {
@@ -3420,7 +3420,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -3440,7 +3440,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -3460,7 +3460,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -3480,7 +3480,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -3500,7 +3500,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -3520,7 +3520,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -3540,7 +3540,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -3560,7 +3560,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -3580,7 +3580,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -3600,7 +3600,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -3620,7 +3620,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -3640,7 +3640,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
@@ -3655,7 +3655,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "dependencies": {
@@ -3667,7 +3667,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -3677,7 +3677,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -3687,7 +3687,7 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
       "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3710,7 +3710,7 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3730,7 +3730,7 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -3742,7 +3742,7 @@
     },
     "node_modules/micromark": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark/-/micromark-4.0.0.tgz",
       "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
       "funding": [
         {
@@ -3776,7 +3776,7 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
       "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
       "funding": [
         {
@@ -3809,7 +3809,7 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
       "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
       "funding": [
         {
@@ -3829,7 +3829,7 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
       "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
       "funding": [
         {
@@ -3850,7 +3850,7 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
       "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
       "funding": [
         {
@@ -3869,7 +3869,7 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
       "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
       "funding": [
         {
@@ -3890,7 +3890,7 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
       "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
       "funding": [
         {
@@ -3911,7 +3911,7 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
       "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
       "funding": [
         {
@@ -3930,7 +3930,7 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
       "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
       "funding": [
         {
@@ -3948,7 +3948,7 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
       "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
       "funding": [
         {
@@ -3968,7 +3968,7 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
       "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
       "funding": [
         {
@@ -3987,7 +3987,7 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.0.tgz",
       "integrity": "sha512-pIgcsGxpHEtTG/rPJRz/HOLSqp5VTuIIjXlPI+6JSDlK2oljApusG6KzpS8AF0ENUMCHlC/IBb5B9xdFiVlm5Q==",
       "funding": [
         {
@@ -4005,7 +4005,7 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
       "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
       "funding": [
         {
@@ -4026,7 +4026,7 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
       "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
       "funding": [
         {
@@ -4041,7 +4041,7 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
       "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
       "funding": [
         {
@@ -4056,7 +4056,7 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
       "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
       "funding": [
         {
@@ -4074,7 +4074,7 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
       "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
       "funding": [
         {
@@ -4092,7 +4092,7 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
       "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
       "funding": [
         {
@@ -4112,7 +4112,7 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
       "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
       "funding": [
         {
@@ -4133,7 +4133,7 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
       "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
       "funding": [
         {
@@ -4148,7 +4148,7 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
       "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
       "funding": [
         {
@@ -4163,7 +4163,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
@@ -4175,13 +4175,13 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
@@ -4199,13 +4199,13 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
@@ -4215,7 +4215,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/npm-run-path/-/npm-run-path-6.0.0.tgz",
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
@@ -4232,7 +4232,7 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
@@ -4245,7 +4245,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "engines": {
@@ -4254,7 +4254,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "license": "MIT",
@@ -4267,7 +4267,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
@@ -4277,7 +4277,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
@@ -4298,7 +4298,7 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.entries/-/object.entries-1.1.9.tgz",
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
@@ -4314,7 +4314,7 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "license": "MIT",
@@ -4333,7 +4333,7 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.values/-/object.values-1.2.1.tgz",
       "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
@@ -4352,7 +4352,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -4370,7 +4370,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
@@ -4388,7 +4388,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
@@ -4403,7 +4403,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
@@ -4418,7 +4418,7 @@
     },
     "node_modules/parse5": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
@@ -4429,7 +4429,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
@@ -4438,7 +4438,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -4448,20 +4448,20 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
@@ -4473,7 +4473,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true,
       "license": "MIT",
@@ -4483,7 +4483,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
@@ -4511,7 +4511,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "engines": {
@@ -4520,7 +4520,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "dependencies": {
@@ -4531,7 +4531,7 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dev": true,
       "dependencies": {
@@ -4542,7 +4542,7 @@
     },
     "node_modules/property-information": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/property-information/-/property-information-6.3.0.tgz",
       "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==",
       "funding": {
         "type": "github",
@@ -4551,7 +4551,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -4561,7 +4561,7 @@
     },
     "node_modules/react": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "engines": {
         "node": ">=0.10.0"
@@ -4569,7 +4569,7 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -4580,13 +4580,13 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-markdown/-/react-markdown-10.1.0.tgz",
       "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
       "dependencies": {
@@ -4613,7 +4613,7 @@
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "engines": {
@@ -4626,7 +4626,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
@@ -4649,7 +4649,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
@@ -4670,7 +4670,7 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4684,7 +4684,7 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4699,7 +4699,7 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/remark-rehype/-/remark-rehype-11.0.0.tgz",
       "integrity": "sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4715,7 +4715,7 @@
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-2.0.0-next.5.tgz",
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
@@ -4733,7 +4733,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "engines": {
@@ -4742,7 +4742,7 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "dependencies": {
@@ -4775,7 +4775,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
@@ -4795,7 +4795,7 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
@@ -4812,7 +4812,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
@@ -4830,12 +4830,12 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
@@ -4844,7 +4844,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
@@ -4862,7 +4862,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "license": "MIT",
@@ -4878,7 +4878,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
@@ -4893,7 +4893,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -4906,7 +4906,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -4916,7 +4916,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
@@ -4936,7 +4936,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
@@ -4953,7 +4953,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -4972,7 +4972,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -4992,13 +4992,13 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "engines": {
@@ -5007,7 +5007,7 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
       "funding": {
         "type": "github",
@@ -5016,7 +5016,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
@@ -5044,7 +5044,7 @@
     },
     "node_modules/string.prototype.repeat": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
@@ -5055,7 +5055,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
@@ -5077,7 +5077,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
@@ -5096,7 +5096,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
@@ -5114,7 +5114,7 @@
     },
     "node_modules/style-to-object": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/style-to-object/-/style-to-object-0.4.2.tgz",
       "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
       "dependencies": {
         "inline-style-parser": "0.1.1"
@@ -5122,7 +5122,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
@@ -5135,14 +5135,14 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "dependencies": {
@@ -5158,7 +5158,7 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "engines": {
@@ -5175,7 +5175,7 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "engines": {
@@ -5187,7 +5187,7 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
       "funding": {
         "type": "github",
@@ -5196,7 +5196,7 @@
     },
     "node_modules/trough": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/trough/-/trough-2.1.0.tgz",
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
       "funding": {
         "type": "github",
@@ -5205,7 +5205,7 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "engines": {
@@ -5217,14 +5217,14 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "dependencies": {
@@ -5236,7 +5236,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
@@ -5251,7 +5251,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
@@ -5271,7 +5271,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
@@ -5293,7 +5293,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
@@ -5314,7 +5314,7 @@
     },
     "node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5328,7 +5328,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
@@ -5347,7 +5347,7 @@
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
@@ -5360,7 +5360,7 @@
     },
     "node_modules/unified": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unified/-/unified-11.0.3.tgz",
       "integrity": "sha512-jlCV402P+YDcFcB2VcN/n8JasOddqIiaxv118wNBoZXEhOn+lYG7BR4Bfg2BwxvlK58dwbuH2w7GX2esAjL6Mg==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5378,7 +5378,7 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5390,7 +5390,7 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5402,7 +5402,7 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5414,7 +5414,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5428,7 +5428,7 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
       "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5441,7 +5441,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -5472,7 +5472,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5482,7 +5482,7 @@
     },
     "node_modules/vfile": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile/-/vfile-6.0.1.tgz",
       "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5496,7 +5496,7 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile-location/-/vfile-location-5.0.2.tgz",
       "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5509,7 +5509,7 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile-message/-/vfile-message-4.0.2.tgz",
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5522,7 +5522,7 @@
     },
     "node_modules/vite": {
       "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite/-/vite-8.1.3.tgz",
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "dependencies": {
@@ -5599,7 +5599,7 @@
     },
     "node_modules/vite-plugin-checker": {
       "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
       "integrity": "sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==",
       "dev": true,
       "dependencies": {
@@ -5654,7 +5654,7 @@
     },
     "node_modules/vite-plugin-checker/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "engines": {
@@ -5666,7 +5666,7 @@
     },
     "node_modules/vite-plugin-eslint": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
       "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
       "dev": true,
       "dependencies": {
@@ -5681,7 +5681,7 @@
     },
     "node_modules/vite-plugin-eslint/node_modules/rollup": {
       "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "bin": {
@@ -5696,7 +5696,7 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "engines": {
@@ -5708,7 +5708,7 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "funding": {
         "type": "github",
@@ -5717,7 +5717,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -5733,7 +5733,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
@@ -5753,7 +5753,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
@@ -5781,7 +5781,7 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
@@ -5800,7 +5800,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-typed-array/-/which-typed-array-1.1.18.tgz",
       "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dev": true,
       "license": "MIT",
@@ -5821,7 +5821,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -5831,14 +5831,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "engines": {
@@ -5850,7 +5850,7 @@
     },
     "node_modules/zod": {
       "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
@@ -5860,7 +5860,7 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",
@@ -5873,7 +5873,7 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "funding": {
         "type": "github",
@@ -5884,7 +5884,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "requires": {
@@ -5895,13 +5895,13 @@
     },
     "@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true
     },
     "@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "requires": {
@@ -5924,7 +5924,7 @@
     },
     "@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "requires": {
@@ -5937,7 +5937,7 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "requires": {
@@ -5950,13 +5950,13 @@
     },
     "@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true
     },
     "@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "requires": {
@@ -5966,7 +5966,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "requires": {
@@ -5977,25 +5977,25 @@
     },
     "@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true
     },
     "@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "requires": {
@@ -6005,7 +6005,7 @@
     },
     "@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "requires": {
@@ -6014,7 +6014,7 @@
     },
     "@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "requires": {
@@ -6025,7 +6025,7 @@
     },
     "@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "requires": {
@@ -6040,7 +6040,7 @@
     },
     "@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "requires": {
@@ -6050,7 +6050,7 @@
     },
     "@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "optional": true,
@@ -6061,7 +6061,7 @@
     },
     "@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "optional": true,
@@ -6071,7 +6071,7 @@
     },
     "@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "optional": true,
@@ -6081,7 +6081,7 @@
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "requires": {
@@ -6090,13 +6090,13 @@
     },
     "@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true
     },
     "@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "requires": {
@@ -6107,13 +6107,13 @@
       "dependencies": {
         "balanced-match": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
           "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
           "dev": true
         },
         "brace-expansion": {
           "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
           "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
@@ -6122,7 +6122,7 @@
         },
         "minimatch": {
           "version": "10.2.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "dev": true,
           "requires": {
@@ -6133,7 +6133,7 @@
     },
     "@eslint/config-helpers": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
       "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "requires": {
@@ -6142,7 +6142,7 @@
     },
     "@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "requires": {
@@ -6151,13 +6151,13 @@
     },
     "@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true
     },
     "@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "requires": {
@@ -6167,12 +6167,12 @@
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
       "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw=="
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
       "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -6180,7 +6180,7 @@
     },
     "@fortawesome/free-regular-svg-icons": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.0.tgz",
       "integrity": "sha512-4675NiHzJJs0dLStFpp5G1JNfMYxqFSxZ2iCaiMfHptjlc8McLG9oqcd5pFEiPiqfiV2YG25cJ9EYWIEhUvp+A==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -6188,7 +6188,7 @@
     },
     "@fortawesome/free-solid-svg-icons": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
       "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
@@ -6196,19 +6196,19 @@
     },
     "@fortawesome/react-fontawesome": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
       "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
       "requires": {}
     },
     "@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true
     },
     "@humanfs/node": {
       "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "requires": {
@@ -6218,7 +6218,7 @@
       "dependencies": {
         "@humanwhocodes/retry": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/retry/-/retry-0.3.1.tgz",
           "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
           "dev": true
         }
@@ -6226,19 +6226,19 @@
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/retry": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "dev": true,
       "requires": {
@@ -6248,7 +6248,7 @@
     },
     "@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "requires": {
@@ -6258,19 +6258,19 @@
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dev": true,
       "requires": {
@@ -6280,7 +6280,7 @@
     },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "optional": true,
@@ -6290,97 +6290,97 @@
     },
     "@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true
     },
     "@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "dev": true,
       "optional": true,
@@ -6392,27 +6392,27 @@
     },
     "@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "dev": true,
       "optional": true
     },
     "@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "dev": true,
       "optional": true
     },
     "@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
       "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
       "dev": true,
       "requires": {
@@ -6422,7 +6422,7 @@
     },
     "@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "optional": true,
@@ -6432,7 +6432,7 @@
     },
     "@types/debug": {
       "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/debug/-/debug-4.1.9.tgz",
       "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "requires": {
         "@types/ms": "*"
@@ -6440,7 +6440,7 @@
     },
     "@types/eslint": {
       "version": "8.56.12",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/eslint/-/eslint-8.56.12.tgz",
       "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
       "dev": true,
       "requires": {
@@ -6450,19 +6450,19 @@
     },
     "@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true
     },
     "@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
     "@types/hast": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/hast/-/hast-3.0.1.tgz",
       "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
       "requires": {
         "@types/unist": "*"
@@ -6470,13 +6470,13 @@
     },
     "@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "@types/mdast": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mdast/-/mdast-4.0.1.tgz",
       "integrity": "sha512-IlKct1rUTJ1T81d8OHzyop15kGv9A/ff7Gz7IJgrk6jDb4Udw77pCJ+vq8oxZf4Ghpm+616+i1s/LNg/Vh7d+g==",
       "requires": {
         "@types/unist": "*"
@@ -6484,12 +6484,12 @@
     },
     "@types/ms": {
       "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/ms/-/ms-0.7.32.tgz",
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "@types/react": {
       "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "requires": {
         "csstype": "^3.2.2"
@@ -6497,25 +6497,25 @@
     },
     "@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "requires": {}
     },
     "@types/unist": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "@types/vscode-webview": {
       "version": "1.57.5",
-      "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
       "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
       "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "requires": {
@@ -6531,7 +6531,7 @@
       "dependencies": {
         "ignore": {
           "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-7.0.5.tgz",
           "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
           "dev": true
         }
@@ -6539,7 +6539,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/parser/-/parser-8.63.0.tgz",
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "requires": {
@@ -6552,7 +6552,7 @@
     },
     "@typescript-eslint/project-service": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
       "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "requires": {
@@ -6563,7 +6563,7 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
       "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "requires": {
@@ -6573,14 +6573,14 @@
     },
     "@typescript-eslint/tsconfig-utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
       "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "requires": {}
     },
     "@typescript-eslint/type-utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
       "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "requires": {
@@ -6593,13 +6593,13 @@
     },
     "@typescript-eslint/types": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/types/-/types-8.63.0.tgz",
       "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
       "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "requires": {
@@ -6616,13 +6616,13 @@
       "dependencies": {
         "balanced-match": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
           "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
           "dev": true
         },
         "brace-expansion": {
           "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
           "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
           "dev": true,
           "requires": {
@@ -6631,7 +6631,7 @@
         },
         "minimatch": {
           "version": "10.2.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "dev": true,
           "requires": {
@@ -6640,7 +6640,7 @@
         },
         "semver": {
           "version": "7.8.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.8.5.tgz",
           "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         }
@@ -6648,7 +6648,7 @@
     },
     "@typescript-eslint/utils": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/utils/-/utils-8.63.0.tgz",
       "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "requires": {
@@ -6660,7 +6660,7 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
       "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "requires": {
@@ -6670,7 +6670,7 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
           "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
           "dev": true
         }
@@ -6678,12 +6678,12 @@
     },
     "@ungap/structured-clone": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@vitejs/plugin-react": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
       "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "requires": {
@@ -6692,25 +6692,25 @@
     },
     "@vscode/codicons": {
       "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@vscode/codicons/-/codicons-0.0.45.tgz",
       "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw=="
     },
     "acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
     "ajv": {
       "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "requires": {
@@ -6722,7 +6722,7 @@
     },
     "array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "requires": {
@@ -6732,7 +6732,7 @@
     },
     "array-includes": {
       "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array-includes/-/array-includes-3.1.8.tgz",
       "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
       "dev": true,
       "requires": {
@@ -6746,7 +6746,7 @@
     },
     "array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "requires": {
@@ -6760,7 +6760,7 @@
     },
     "array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
       "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "requires": {
@@ -6772,7 +6772,7 @@
     },
     "array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
       "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "requires": {
@@ -6784,7 +6784,7 @@
     },
     "array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "requires": {
@@ -6797,7 +6797,7 @@
     },
     "arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "requires": {
@@ -6812,7 +6812,7 @@
     },
     "available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "requires": {
@@ -6821,24 +6821,24 @@
     },
     "bail": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "baseline-browser-mapping": {
       "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
       "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "requires": {
@@ -6848,7 +6848,7 @@
     },
     "browserslist": {
       "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/browserslist/-/browserslist-4.28.4.tgz",
       "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "requires": {
@@ -6861,7 +6861,7 @@
     },
     "call-bind": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "requires": {
@@ -6873,7 +6873,7 @@
     },
     "call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "requires": {
@@ -6883,7 +6883,7 @@
     },
     "call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "requires": {
@@ -6893,18 +6893,18 @@
     },
     "caniuse-lite": {
       "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
       "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true
     },
     "character-entities": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
     },
     "chokidar": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "requires": {
@@ -6913,24 +6913,24 @@
     },
     "comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
@@ -6941,12 +6941,12 @@
     },
     "csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "requires": {
@@ -6957,7 +6957,7 @@
     },
     "data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "requires": {
@@ -6968,7 +6968,7 @@
     },
     "data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "requires": {
@@ -6979,7 +6979,7 @@
     },
     "debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
         "ms": "^2.1.3"
@@ -6987,7 +6987,7 @@
     },
     "decode-named-character-reference": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
       "requires": {
         "character-entities": "^2.0.0"
@@ -6995,13 +6995,13 @@
     },
     "deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "requires": {
@@ -7012,7 +7012,7 @@
     },
     "define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "requires": {
@@ -7023,18 +7023,18 @@
     },
     "dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true
     },
     "devlop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "requires": {
         "dequal": "^2.0.0"
@@ -7042,7 +7042,7 @@
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
@@ -7051,7 +7051,7 @@
     },
     "dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "requires": {
@@ -7062,18 +7062,18 @@
     },
     "electron-to-chromium": {
       "version": "1.5.380",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
       "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
       "dev": true
     },
     "entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "es-abstract": {
       "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-abstract/-/es-abstract-1.23.9.tgz",
       "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
       "requires": {
@@ -7132,19 +7132,19 @@
     },
     "es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true
     },
     "es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
     },
     "es-iterator-helpers": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
       "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "requires": {
@@ -7168,7 +7168,7 @@
     },
     "es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "requires": {
@@ -7177,7 +7177,7 @@
     },
     "es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "requires": {
@@ -7189,7 +7189,7 @@
     },
     "es-shim-unscopables": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
       "requires": {
@@ -7198,7 +7198,7 @@
     },
     "es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "requires": {
@@ -7209,13 +7209,13 @@
     },
     "escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
     "eslint": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint/-/eslint-10.6.0.tgz",
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "requires": {
@@ -7253,13 +7253,13 @@
       "dependencies": {
         "balanced-match": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-4.0.4.tgz",
           "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
           "dev": true
         },
         "brace-expansion": {
           "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
           "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
@@ -7268,19 +7268,19 @@
         },
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
         "eslint-visitor-keys": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
           "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
           "dev": true
         },
         "glob-parent": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
@@ -7289,7 +7289,7 @@
         },
         "minimatch": {
           "version": "10.2.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.2.4.tgz",
           "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
           "dev": true,
           "requires": {
@@ -7300,7 +7300,7 @@
     },
     "eslint-plugin-react": {
       "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "requires": {
@@ -7326,7 +7326,7 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "requires": {
@@ -7339,7 +7339,7 @@
     },
     "eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "requires": {
@@ -7351,13 +7351,13 @@
     },
     "eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true
     },
     "espree": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "requires": {
@@ -7368,7 +7368,7 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
           "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
           "dev": true
         }
@@ -7376,7 +7376,7 @@
     },
     "esquery": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "requires": {
@@ -7385,7 +7385,7 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
@@ -7394,48 +7394,48 @@
     },
     "estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
     "estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "requires": {
@@ -7444,7 +7444,7 @@
     },
     "find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "requires": {
@@ -7454,7 +7454,7 @@
     },
     "flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "requires": {
@@ -7464,13 +7464,13 @@
     },
     "flatted": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "for-each": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
@@ -7479,20 +7479,20 @@
     },
     "fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
     "function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "requires": {
@@ -7506,19 +7506,19 @@
     },
     "functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "requires": {
@@ -7536,7 +7536,7 @@
     },
     "get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "requires": {
@@ -7546,7 +7546,7 @@
     },
     "get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "requires": {
@@ -7557,7 +7557,7 @@
     },
     "globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "requires": {
@@ -7567,25 +7567,25 @@
     },
     "gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true
     },
     "graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "requires": {
@@ -7594,7 +7594,7 @@
     },
     "has-proto": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "requires": {
@@ -7603,13 +7603,13 @@
     },
     "has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "requires": {
@@ -7618,7 +7618,7 @@
     },
     "hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "requires": {
@@ -7627,7 +7627,7 @@
     },
     "hast-util-from-parse5": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
       "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -7642,7 +7642,7 @@
     },
     "hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "requires": {
         "@types/hast": "^3.0.0"
@@ -7650,7 +7650,7 @@
     },
     "hast-util-raw": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
       "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -7670,7 +7670,7 @@
     },
     "hast-util-to-jsx-runtime": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz",
       "integrity": "sha512-wSlp23N45CMjDg/BPW8zvhEi3R+8eRE1qFbjEyAUzMCzu2l1Wzwakq+Tlia9nkCtEl5mDxa7nKHsvYJ6Gfn21A==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -7686,7 +7686,7 @@
     },
     "hast-util-to-parse5": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
       "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -7700,7 +7700,7 @@
     },
     "hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "requires": {
         "@types/hast": "^3.0.0"
@@ -7708,7 +7708,7 @@
     },
     "hastscript": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hastscript/-/hastscript-8.0.0.tgz",
       "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -7720,13 +7720,13 @@
     },
     "hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "dev": true
     },
     "hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
       "requires": {
@@ -7735,34 +7735,34 @@
     },
     "html-url-attributes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
       "integrity": "sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow=="
     },
     "html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
     "ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inline-style-parser": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "requires": {
@@ -7773,7 +7773,7 @@
     },
     "is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "requires": {
@@ -7784,7 +7784,7 @@
     },
     "is-async-function": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-async-function/-/is-async-function-2.1.0.tgz",
       "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "dev": true,
       "requires": {
@@ -7796,7 +7796,7 @@
     },
     "is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "requires": {
@@ -7805,7 +7805,7 @@
     },
     "is-boolean-object": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
       "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "dev": true,
       "requires": {
@@ -7815,13 +7815,13 @@
     },
     "is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true
     },
     "is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "requires": {
@@ -7830,7 +7830,7 @@
     },
     "is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "requires": {
@@ -7841,7 +7841,7 @@
     },
     "is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "requires": {
@@ -7851,13 +7851,13 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "requires": {
@@ -7866,7 +7866,7 @@
     },
     "is-generator-function": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "requires": {
@@ -7878,7 +7878,7 @@
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
@@ -7887,13 +7887,13 @@
     },
     "is-map": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true
     },
     "is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "requires": {
@@ -7903,12 +7903,12 @@
     },
     "is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
     },
     "is-regex": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "requires": {
@@ -7920,13 +7920,13 @@
     },
     "is-set": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "requires": {
@@ -7935,7 +7935,7 @@
     },
     "is-string": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "requires": {
@@ -7945,7 +7945,7 @@
     },
     "is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "requires": {
@@ -7956,7 +7956,7 @@
     },
     "is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "requires": {
@@ -7965,13 +7965,13 @@
     },
     "is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true
     },
     "is-weakref": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakref/-/is-weakref-1.1.0.tgz",
       "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "dev": true,
       "requires": {
@@ -7980,7 +7980,7 @@
     },
     "is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "requires": {
@@ -7990,19 +7990,19 @@
     },
     "isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "iterator.prototype": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "requires": {
@@ -8016,43 +8016,43 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true
     },
     "json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsx-ast-utils": {
       "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "requires": {
@@ -8064,7 +8064,7 @@
     },
     "keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "requires": {
@@ -8073,7 +8073,7 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
@@ -8083,7 +8083,7 @@
     },
     "lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "requires": {
@@ -8103,84 +8103,84 @@
     },
     "lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "dev": true,
       "optional": true
     },
     "lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "dev": true,
       "optional": true
     },
     "locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "requires": {
@@ -8189,7 +8189,7 @@
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
@@ -8198,7 +8198,7 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
@@ -8207,13 +8207,13 @@
     },
     "math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true
     },
     "mdast-util-from-markdown": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
       "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
       "requires": {
         "@types/mdast": "^4.0.0",
@@ -8232,7 +8232,7 @@
     },
     "mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -8248,7 +8248,7 @@
     },
     "mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "requires": {
         "@types/mdast": "^4.0.0"
@@ -8256,7 +8256,7 @@
     },
     "micromark": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark/-/micromark-4.0.0.tgz",
       "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
       "requires": {
         "@types/debug": "^4.0.0",
@@ -8280,7 +8280,7 @@
     },
     "micromark-core-commonmark": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
       "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
       "requires": {
         "decode-named-character-reference": "^1.0.0",
@@ -8303,7 +8303,7 @@
     },
     "micromark-factory-destination": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
       "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
       "requires": {
         "micromark-util-character": "^2.0.0",
@@ -8313,7 +8313,7 @@
     },
     "micromark-factory-label": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
       "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
       "requires": {
         "devlop": "^1.0.0",
@@ -8324,7 +8324,7 @@
     },
     "micromark-factory-space": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
       "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
       "requires": {
         "micromark-util-character": "^2.0.0",
@@ -8333,7 +8333,7 @@
     },
     "micromark-factory-title": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
       "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
       "requires": {
         "micromark-factory-space": "^2.0.0",
@@ -8344,7 +8344,7 @@
     },
     "micromark-factory-whitespace": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
       "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
       "requires": {
         "micromark-factory-space": "^2.0.0",
@@ -8355,7 +8355,7 @@
     },
     "micromark-util-character": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
       "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
       "requires": {
         "micromark-util-symbol": "^2.0.0",
@@ -8364,7 +8364,7 @@
     },
     "micromark-util-chunked": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
       "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
       "requires": {
         "micromark-util-symbol": "^2.0.0"
@@ -8372,7 +8372,7 @@
     },
     "micromark-util-classify-character": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
       "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
       "requires": {
         "micromark-util-character": "^2.0.0",
@@ -8382,7 +8382,7 @@
     },
     "micromark-util-combine-extensions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
       "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
       "requires": {
         "micromark-util-chunked": "^2.0.0",
@@ -8391,7 +8391,7 @@
     },
     "micromark-util-decode-numeric-character-reference": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.0.tgz",
       "integrity": "sha512-pIgcsGxpHEtTG/rPJRz/HOLSqp5VTuIIjXlPI+6JSDlK2oljApusG6KzpS8AF0ENUMCHlC/IBb5B9xdFiVlm5Q==",
       "requires": {
         "micromark-util-symbol": "^2.0.0"
@@ -8399,7 +8399,7 @@
     },
     "micromark-util-decode-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
       "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
       "requires": {
         "decode-named-character-reference": "^1.0.0",
@@ -8410,17 +8410,17 @@
     },
     "micromark-util-encode": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
       "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
     },
     "micromark-util-html-tag-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
       "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
     },
     "micromark-util-normalize-identifier": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
       "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
       "requires": {
         "micromark-util-symbol": "^2.0.0"
@@ -8428,7 +8428,7 @@
     },
     "micromark-util-resolve-all": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
       "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
       "requires": {
         "micromark-util-types": "^2.0.0"
@@ -8436,7 +8436,7 @@
     },
     "micromark-util-sanitize-uri": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
       "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
       "requires": {
         "micromark-util-character": "^2.0.0",
@@ -8446,7 +8446,7 @@
     },
     "micromark-util-subtokenize": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
       "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
       "requires": {
         "devlop": "^1.0.0",
@@ -8457,17 +8457,17 @@
     },
     "micromark-util-symbol": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
       "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
     },
     "micromark-util-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
       "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
     },
     "minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
@@ -8476,30 +8476,30 @@
     },
     "ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
       "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node-releases": {
       "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true
     },
     "npm-run-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/npm-run-path/-/npm-run-path-6.0.0.tgz",
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "requires": {
@@ -8509,7 +8509,7 @@
       "dependencies": {
         "path-key": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-4.0.0.tgz",
           "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
           "dev": true
         }
@@ -8517,25 +8517,25 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-inspect": {
       "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "requires": {
@@ -8549,7 +8549,7 @@
     },
     "object.entries": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.entries/-/object.entries-1.1.9.tgz",
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "requires": {
@@ -8561,7 +8561,7 @@
     },
     "object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "requires": {
@@ -8573,7 +8573,7 @@
     },
     "object.values": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/object.values/-/object.values-1.2.1.tgz",
       "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "requires": {
@@ -8585,7 +8585,7 @@
     },
     "optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "requires": {
@@ -8599,7 +8599,7 @@
     },
     "own-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "requires": {
@@ -8610,7 +8610,7 @@
     },
     "p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
@@ -8619,7 +8619,7 @@
     },
     "p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "requires": {
@@ -8628,7 +8628,7 @@
     },
     "parse5": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
@@ -8636,43 +8636,43 @@
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "possible-typed-array-names": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true
     },
     "postcss": {
       "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "requires": {
@@ -8683,13 +8683,13 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "prop-types": {
       "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "requires": {
@@ -8700,7 +8700,7 @@
     },
     "proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dev": true,
       "requires": {
@@ -8711,23 +8711,23 @@
     },
     "property-information": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/property-information/-/property-information-6.3.0.tgz",
       "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg=="
     },
     "punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
     "react": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="
     },
     "react-dom": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "requires": {
         "scheduler": "^0.27.0"
@@ -8735,13 +8735,13 @@
     },
     "react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
     "react-markdown": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/react-markdown/-/react-markdown-10.1.0.tgz",
       "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -8759,13 +8759,13 @@
     },
     "readdirp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true
     },
     "reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "requires": {
@@ -8781,7 +8781,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "requires": {
@@ -8795,7 +8795,7 @@
     },
     "rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -8805,7 +8805,7 @@
     },
     "remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "requires": {
         "@types/mdast": "^4.0.0",
@@ -8816,7 +8816,7 @@
     },
     "remark-rehype": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/remark-rehype/-/remark-rehype-11.0.0.tgz",
       "integrity": "sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==",
       "requires": {
         "@types/hast": "^3.0.0",
@@ -8828,7 +8828,7 @@
     },
     "resolve": {
       "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-2.0.0-next.5.tgz",
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "requires": {
@@ -8839,13 +8839,13 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true
     },
     "rolldown": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "requires": {
@@ -8870,7 +8870,7 @@
     },
     "safe-array-concat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "requires": {
@@ -8883,7 +8883,7 @@
     },
     "safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "requires": {
@@ -8893,7 +8893,7 @@
     },
     "safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "requires": {
@@ -8904,18 +8904,18 @@
     },
     "scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "requires": {
@@ -8929,7 +8929,7 @@
     },
     "set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "requires": {
@@ -8941,7 +8941,7 @@
     },
     "set-proto": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "requires": {
@@ -8952,7 +8952,7 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
@@ -8961,13 +8961,13 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "requires": {
@@ -8980,7 +8980,7 @@
     },
     "side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "requires": {
@@ -8990,7 +8990,7 @@
     },
     "side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "requires": {
@@ -9002,7 +9002,7 @@
     },
     "side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "requires": {
@@ -9015,24 +9015,24 @@
     },
     "signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
     "space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
     },
     "string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "requires": {
@@ -9053,7 +9053,7 @@
     },
     "string.prototype.repeat": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "requires": {
@@ -9063,7 +9063,7 @@
     },
     "string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "requires": {
@@ -9078,7 +9078,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "requires": {
@@ -9090,7 +9090,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "requires": {
@@ -9101,7 +9101,7 @@
     },
     "style-to-object": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/style-to-object/-/style-to-object-0.4.2.tgz",
       "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
       "requires": {
         "inline-style-parser": "0.1.1"
@@ -9109,19 +9109,19 @@
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
     "tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true
     },
     "tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "requires": {
@@ -9131,14 +9131,14 @@
       "dependencies": {
         "fdir": {
           "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
           "dev": true,
           "requires": {}
         },
         "picomatch": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
           "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         }
@@ -9146,31 +9146,31 @@
     },
     "trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
     "trough": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/trough/-/trough-2.1.0.tgz",
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
     },
     "ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "requires": {}
     },
     "tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
@@ -9179,7 +9179,7 @@
     },
     "typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "requires": {
@@ -9190,7 +9190,7 @@
     },
     "typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "requires": {
@@ -9203,7 +9203,7 @@
     },
     "typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "requires": {
@@ -9218,7 +9218,7 @@
     },
     "typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "requires": {
@@ -9232,13 +9232,13 @@
     },
     "typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "requires": {
@@ -9250,13 +9250,13 @@
     },
     "unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true
     },
     "unified": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unified/-/unified-11.0.3.tgz",
       "integrity": "sha512-jlCV402P+YDcFcB2VcN/n8JasOddqIiaxv118wNBoZXEhOn+lYG7BR4Bfg2BwxvlK58dwbuH2w7GX2esAjL6Mg==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9270,7 +9270,7 @@
     },
     "unist-util-is": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "requires": {
         "@types/unist": "^3.0.0"
@@ -9278,7 +9278,7 @@
     },
     "unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "requires": {
         "@types/unist": "^3.0.0"
@@ -9286,7 +9286,7 @@
     },
     "unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "requires": {
         "@types/unist": "^3.0.0"
@@ -9294,7 +9294,7 @@
     },
     "unist-util-visit": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9304,7 +9304,7 @@
     },
     "unist-util-visit-parents": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
       "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9313,7 +9313,7 @@
     },
     "update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "requires": {
@@ -9323,7 +9323,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
@@ -9332,7 +9332,7 @@
     },
     "vfile": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile/-/vfile-6.0.1.tgz",
       "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9342,7 +9342,7 @@
     },
     "vfile-location": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile-location/-/vfile-location-5.0.2.tgz",
       "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9351,7 +9351,7 @@
     },
     "vfile-message": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vfile-message/-/vfile-message-4.0.2.tgz",
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
       "requires": {
         "@types/unist": "^3.0.0",
@@ -9360,7 +9360,7 @@
     },
     "vite": {
       "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite/-/vite-8.1.3.tgz",
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "requires": {
@@ -9374,7 +9374,7 @@
       "dependencies": {
         "picomatch": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
           "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         }
@@ -9382,7 +9382,7 @@
     },
     "vite-plugin-checker": {
       "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
       "integrity": "sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==",
       "dev": true,
       "requires": {
@@ -9397,7 +9397,7 @@
       "dependencies": {
         "picomatch": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.4.tgz",
           "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         }
@@ -9405,7 +9405,7 @@
     },
     "vite-plugin-eslint": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
       "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
       "dev": true,
       "requires": {
@@ -9416,7 +9416,7 @@
       "dependencies": {
         "rollup": {
           "version": "2.80.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+          "resolved": "https://packagefeedproxy.microsoft.io/npm/rollup/-/rollup-2.80.0.tgz",
           "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
           "dev": true,
           "requires": {
@@ -9427,12 +9427,12 @@
     },
     "web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
@@ -9441,7 +9441,7 @@
     },
     "which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "requires": {
@@ -9454,7 +9454,7 @@
     },
     "which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "requires": {
@@ -9475,7 +9475,7 @@
     },
     "which-collection": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "requires": {
@@ -9487,7 +9487,7 @@
     },
     "which-typed-array": {
       "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/which-typed-array/-/which-typed-array-1.1.18.tgz",
       "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dev": true,
       "requires": {
@@ -9501,38 +9501,38 @@
     },
     "word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     },
     "zod": {
       "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true
     },
     "zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "requires": {}
     },
     "zwitch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }


### PR DESCRIPTION
Adds an `.npmrc` that pins the npm registry to `https://packagefeedproxy.microsoft.io/npm/`.

Microsoft-managed devices are being updated with a policy that blocks direct access to `registry.npmjs.org`, `registry.yarnpkg.com`, and `registry.npmmirror.com`. Package installs must go through the CFS-protected proxy. This change ensures contributors on Microsoft-managed devices can run `npm install` without additional local configuration.