### PR TITLE
chore: update Dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       typescript-eslint:
         patterns:
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/webview-ui"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       typescript-eslint:
         patterns:
@@ -19,4 +19,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## Description

Updates Dependabot configuration to run monthly instead of weekly for all package ecosystems. One of the key reason is the vetting cadence which will have impact for internal releases so reducing the more aggressive dependabot will help in them.

What will happen when we really need change, we will add them manually for those critical issues. Thanks.

## Changes

- Changed `schedule.interval` from `weekly` to `monthly` for:
  - npm packages in root directory
  - npm packages in `/webview-ui`
  - GitHub Actions

## Motivation

Weekly dependency updates were creating too frequent PRs. Monthly updates provide a better balance between staying up-to-date with dependencies and reducing maintenance overhead.

Note: Dependabot does not support biweekly/fortnightly intervals. The available options are `daily`, `weekly`, and `monthly`.

## Impact

- Dependabot will now create update PRs once per month instead of once per week
- Reduces the volume of automated dependency PRs
- Dependencies will still be kept reasonably up-to-date with monthly checks