### PR TITLE
fix(container-assist): make Draft validate surface findings instead of erroring

### DIFF
--- a/src/commands/draft/draftCommands.ts
+++ b/src/commands/draft/draftCommands.ts
@@ -170,6 +170,12 @@ export async function draftWorkflow(_context: IActionContext, target: unknown): 
     panel.show(dataProvider);
 }
 
+/** Returns true if the given path points to a YAML manifest (.yaml/.yml). */
+export function isYamlManifestFile(location: string): boolean {
+    const ext = extname(location).toLowerCase();
+    return ext === ".yaml" || ext === ".yml";
+}
+
 export async function draftValidate(_context: IActionContext, target: unknown): Promise<void> {
     const params = getDraftDockerfileParams(target);
     const commonDependencies = await getCommonDraftDependencies(params?.workspaceFolder);
@@ -178,8 +184,30 @@ export async function draftValidate(_context: IActionContext, target: unknown): 
     }
 
     const { workspaceFolder, extension, draftBinaryPath } = commonDependencies;
+    const initialLocation = params?.initialLocation || "";
+
+    // Reject non-YAML files up front so users get clear guidance instead of a cryptic
+    // Draft failure. Folders and empty selections fall through unchanged.
+    if (initialLocation) {
+        const resourceUri = Uri.file(join(workspaceFolder.uri.fsPath, initialLocation));
+        let isDirectory = false;
+        try {
+            const stat = await workspace.fs.stat(resourceUri);
+            isDirectory = stat.type === FileType.Directory;
+        } catch {
+            // Can't stat the path — let Draft surface the issue.
+        }
+
+        if (!isDirectory && !isYamlManifestFile(initialLocation)) {
+            window.showErrorMessage(
+                "Draft validate can only check Kubernetes YAML manifests. Select a .yaml or .yml file, or a folder containing manifests.",
+            );
+            return;
+        }
+    }
+
     const panel = new DraftValidatePanel(extension.extensionUri);
-    const dataProvider = new DraftValidateDataProvider(workspaceFolder, draftBinaryPath, params?.initialLocation || "");
+    const dataProvider = new DraftValidateDataProvider(workspaceFolder, draftBinaryPath, initialLocation);
     panel.show(dataProvider);
 }
 

--- a/src/commands/draft/draftCommands.ts
+++ b/src/commands/draft/draftCommands.ts
@@ -176,6 +176,18 @@ export function isYamlManifestFile(location: string): boolean {
     return ext === ".yaml" || ext === ".yml";
 }
 
+/** Shown when Draft validate is invoked without a YAML manifest file or a folder of manifests. */
+export const DRAFT_VALIDATE_INVALID_SELECTION_MESSAGE =
+    "Draft validate needs a Kubernetes YAML manifest. Right-click a .yaml or .yml file, or a folder containing manifests, and run Draft validate.";
+
+/** A selection is validatable if it is a folder, or a .yaml/.yml file. Empty selections are not. */
+export function canRunDraftValidate(initialLocation: string, isDirectory: boolean): boolean {
+    if (!initialLocation) {
+        return false;
+    }
+    return isDirectory || isYamlManifestFile(initialLocation);
+}
+
 export async function draftValidate(_context: IActionContext, target: unknown): Promise<void> {
     const params = getDraftDockerfileParams(target);
     const commonDependencies = await getCommonDraftDependencies(params?.workspaceFolder);
@@ -186,24 +198,22 @@ export async function draftValidate(_context: IActionContext, target: unknown): 
     const { workspaceFolder, extension, draftBinaryPath } = commonDependencies;
     const initialLocation = params?.initialLocation || "";
 
-    // Reject non-YAML files up front so users get clear guidance instead of a cryptic
-    // Draft failure. Folders and empty selections fall through unchanged.
+    // Draft validate needs a YAML manifest file or a folder of manifests. Reject a missing
+    // selection or a non-YAML file up front with a single clear message, rather than opening
+    // an empty panel or handing a bad path to Draft.
+    let isDirectory = false;
     if (initialLocation) {
-        const resourceUri = Uri.file(join(workspaceFolder.uri.fsPath, initialLocation));
-        let isDirectory = false;
         try {
-            const stat = await workspace.fs.stat(resourceUri);
+            const stat = await workspace.fs.stat(Uri.file(join(workspaceFolder.uri.fsPath, initialLocation)));
             isDirectory = stat.type === FileType.Directory;
         } catch {
-            // Can't stat the path — let Draft surface the issue.
+            // Can't stat the path — fall back to the file-extension check below.
         }
+    }
 
-        if (!isDirectory && !isYamlManifestFile(initialLocation)) {
-            window.showErrorMessage(
-                "Draft validate can only check Kubernetes YAML manifests. Select a .yaml or .yml file, or a folder containing manifests.",
-            );
-            return;
-        }
+    if (!canRunDraftValidate(initialLocation, isDirectory)) {
+        window.showErrorMessage(DRAFT_VALIDATE_INVALID_SELECTION_MESSAGE);
+        return;
     }
 
     const panel = new DraftValidatePanel(extension.extensionUri);

--- a/src/commands/utils/shell.ts
+++ b/src/commands/utils/shell.ts
@@ -45,6 +45,63 @@ export async function exec(cmd: string, options?: ShellOptions): Promise<Errorab
     }
 }
 
+/**
+ * Runs a binary without a shell, passing args as an array (immune to shell injection).
+ * A spawn failure is always an error; only real non-zero exits honor `exitCodeBehaviour`.
+ */
+export async function execFile(
+    executable: string,
+    args: string[],
+    options?: ShellOptions,
+): Promise<Errorable<ShellResult>> {
+    try {
+        const result = await execFileCore(executable, args, options || {});
+        const exitCodeBehaviour = options?.exitCodeBehaviour ?? NonZeroExitCodeBehaviour.Fail;
+        const succeeded = result.code === 0 || exitCodeBehaviour === NonZeroExitCodeBehaviour.Succeed;
+        if (succeeded) {
+            return { succeeded, result };
+        } else {
+            return {
+                succeeded,
+                error: `Command "${executable}" failed with exit code ${result.code}.\nStdout:\n${result.stdout}\nStderr:\n${result.stderr}`,
+            };
+        }
+    } catch (ex) {
+        return { succeeded: false, error: getErrorMessage(ex) };
+    }
+}
+
+function execFileCore(executable: string, args: string[], shellOptions: ShellOptions): Promise<ShellResult> {
+    const options = getExecOpts(shellOptions?.workingDir || null, shellOptions?.envPaths || []);
+
+    return new Promise<ShellResult>((resolve, reject) => {
+        const c = child.execFile(executable, args, options, function (err, stdout, stderr) {
+            const stdoutStr = typeof stdout === "string" ? stdout : (stdout?.toString() ?? "");
+            const stderrStr = typeof stderr === "string" ? stderr : (stderr?.toString() ?? "");
+            if (!err) {
+                resolve({ code: 0, stdout: stdoutStr, stderr: stderrStr });
+            } else if (typeof err.code === "number") {
+                // Process ran and exited non-zero.
+                resolve({ code: err.code, stdout: stdoutStr, stderr: stderrStr });
+            } else {
+                // Failed to spawn (e.g. ENOENT).
+                reject(err);
+            }
+        });
+
+        // Default to 'true' for silent.
+        const silent = shellOptions.silent === undefined ? true : shellOptions.silent;
+        if (!silent) {
+            c.stdout?.pipe(process.stdout);
+            c.stderr?.pipe(process.stderr);
+        }
+
+        if (shellOptions.stdin) {
+            c.stdin?.end(shellOptions.stdin);
+        }
+    });
+}
+
 function execCore(cmd: string, shellOptions: ShellOptions): Promise<ShellResult> {
     const options = getExecOpts(
         shellOptions?.workingDir || null,

--- a/src/panels/draft/DraftValidatePanel.ts
+++ b/src/panels/draft/DraftValidatePanel.ts
@@ -53,17 +53,8 @@ export class DraftValidateDataProvider implements PanelDataProvider<"draftValida
     }
 
     private async handleDraftValidateRequest(webview: MessageSink<ToWebViewMsgDef>) {
-        const location = this.initialLocation?.trim();
-        if (!location) {
-            webview.postValidationResult({
-                result: l10n.t(
-                    "No manifest path was provided. Right-click a manifest file or your manifests folder and run Draft validate.",
-                ),
-            });
-            return;
-        }
-
-        const manifestPath = `.${path.sep}${location}`;
+        // The draftValidate command guarantees a valid file/folder selection before opening this panel.
+        const manifestPath = `.${path.sep}${this.initialLocation.trim()}`;
         const command = `draft validate --manifest "${manifestPath}"`;
 
         const execOptions: ShellOptions = {

--- a/src/panels/draft/DraftValidatePanel.ts
+++ b/src/panels/draft/DraftValidatePanel.ts
@@ -8,7 +8,7 @@ import {
 } from "../../webview-contract/webviewDefinitions/draft/draftValidate";
 import { TelemetryDefinition } from "../../webview-contract/webviewTypes";
 import { MessageHandler, MessageSink } from "../../webview-contract/messaging";
-import { ShellOptions, exec } from "../../commands/utils/shell";
+import { ShellOptions, exec, NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
 import { failed } from "../../commands/utils/errorable";
 
 export class DraftValidatePanel extends BasePanel<"draftValidate"> {
@@ -53,11 +53,24 @@ export class DraftValidateDataProvider implements PanelDataProvider<"draftValida
     }
 
     private async handleDraftValidateRequest(webview: MessageSink<ToWebViewMsgDef>) {
-        const command = `draft validate --manifest .${path.sep}${this.initialLocation}`;
+        const location = this.initialLocation?.trim();
+        if (!location) {
+            webview.postValidationResult({
+                result: l10n.t(
+                    "No manifest path was provided. Right-click a manifest file or your manifests folder and run Draft validate.",
+                ),
+            });
+            return;
+        }
+
+        const manifestPath = `.${path.sep}${location}`;
+        const command = `draft validate --manifest "${manifestPath}"`;
 
         const execOptions: ShellOptions = {
             workingDir: this.workspaceFolder.uri.fsPath,
             envPaths: [this.draftDirectory],
+            // draft validate exits non-zero when it finds violations; those are results, not a failure.
+            exitCodeBehaviour: NonZeroExitCodeBehaviour.Succeed,
         };
 
         const draftResult = await exec(command, execOptions);
@@ -66,7 +79,13 @@ export class DraftValidateDataProvider implements PanelDataProvider<"draftValida
             return;
         }
 
-        const validationResults = draftResult.result.stdout;
+        // Findings can appear on stdout or stderr depending on the outcome; surface both.
+        const { stdout, stderr } = draftResult.result;
+        const validationResults =
+            [stdout, stderr]
+                .map((s) => s?.trim())
+                .filter((s) => s)
+                .join("\n\n") || l10n.t("Draft validate returned no output.");
 
         webview.postValidationResult({ result: validationResults });
     }

--- a/src/panels/draft/DraftValidatePanel.ts
+++ b/src/panels/draft/DraftValidatePanel.ts
@@ -8,7 +8,7 @@ import {
 } from "../../webview-contract/webviewDefinitions/draft/draftValidate";
 import { TelemetryDefinition } from "../../webview-contract/webviewTypes";
 import { MessageHandler, MessageSink } from "../../webview-contract/messaging";
-import { ShellOptions, exec, NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
+import { ShellOptions, execFile, NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
 import { failed } from "../../commands/utils/errorable";
 
 export class DraftValidatePanel extends BasePanel<"draftValidate"> {
@@ -20,14 +20,11 @@ export class DraftValidatePanel extends BasePanel<"draftValidate"> {
 }
 
 export class DraftValidateDataProvider implements PanelDataProvider<"draftValidate"> {
-    readonly draftDirectory: string;
     constructor(
         readonly workspaceFolder: WorkspaceFolder,
         readonly draftBinaryPath: string,
         readonly initialLocation: string,
-    ) {
-        this.draftDirectory = path.dirname(draftBinaryPath);
-    }
+    ) {}
 
     getTitle(): string {
         return l10n.t(`Run Deployment Safeguards in {0}`, this.workspaceFolder.name);
@@ -54,17 +51,15 @@ export class DraftValidateDataProvider implements PanelDataProvider<"draftValida
 
     private async handleDraftValidateRequest(webview: MessageSink<ToWebViewMsgDef>) {
         // The draftValidate command guarantees a valid file/folder selection before opening this panel.
-        const manifestPath = `.${path.sep}${this.initialLocation.trim()}`;
-        const command = `draft validate --manifest "${manifestPath}"`;
+        const manifestPath = `.${path.sep}${this.initialLocation}`;
 
         const execOptions: ShellOptions = {
             workingDir: this.workspaceFolder.uri.fsPath,
-            envPaths: [this.draftDirectory],
             // draft validate exits non-zero when it finds violations; those are results, not a failure.
             exitCodeBehaviour: NonZeroExitCodeBehaviour.Succeed,
         };
 
-        const draftResult = await exec(command, execOptions);
+        const draftResult = await execFile(this.draftBinaryPath, ["validate", "--manifest", manifestPath], execOptions);
         if (failed(draftResult)) {
             window.showErrorMessage(draftResult.error);
             return;

--- a/src/tests/suite/draftValidate.test.ts
+++ b/src/tests/suite/draftValidate.test.ts
@@ -1,0 +1,119 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import * as shell from "../../commands/utils/shell";
+import { NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
+import { DraftValidateDataProvider } from "../../panels/draft/DraftValidatePanel";
+import { isYamlManifestFile } from "../../commands/draft/draftCommands";
+import { MessageSink } from "../../webview-contract/messaging";
+import { ToWebViewMsgDef } from "../../webview-contract/webviewDefinitions/draft/draftValidate";
+
+describe("isYamlManifestFile", () => {
+    it("accepts .yaml and .yml files (case-insensitive)", () => {
+        for (const f of ["deployment.yaml", "deployment.yml", "k8s/app.yaml", "App.YAML", "x.YML"]) {
+            assert.strictEqual(isYamlManifestFile(f), true, f);
+        }
+    });
+
+    it("rejects non-YAML files", () => {
+        for (const f of ["notes.txt", "Dockerfile", "config.json", "archive.yaml.bak", "", ".yamlfile"]) {
+            assert.strictEqual(isYamlManifestFile(f), false, f);
+        }
+    });
+});
+
+describe("DraftValidate handler", () => {
+    let sandbox: sinon.SinonSandbox;
+    let postValidationResult: sinon.SinonStub;
+
+    const workspaceFolder = {
+        uri: vscode.Uri.file("/ws"),
+        name: "ws",
+        index: 0,
+    } as vscode.WorkspaceFolder;
+
+    function makeProvider(initialLocation: string): DraftValidateDataProvider {
+        return new DraftValidateDataProvider(workspaceFolder, "/tools/draft/draft", initialLocation);
+    }
+
+    async function runValidate(initialLocation: string): Promise<void> {
+        const provider = makeProvider(initialLocation);
+        const webview = { postValidationResult } as unknown as MessageSink<ToWebViewMsgDef>;
+        await provider.getMessageHandler(webview).createDraftValidateRequest("", "createDraftValidateRequest");
+    }
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        postValidationResult = sandbox.stub();
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it("does not run draft when no manifest location is provided", async () => {
+        const execStub = sandbox.stub(shell, "exec");
+
+        await runValidate("");
+
+        assert.ok(execStub.notCalled, "draft should not be invoked without a manifest path");
+        assert.ok(postValidationResult.calledOnce);
+        assert.match(postValidationResult.firstCall.args[0].result, /No manifest path was provided/);
+    });
+
+    it("quotes the manifest path and tolerates non-zero exit codes (findings are not errors)", async () => {
+        const execStub = sandbox
+            .stub(shell, "exec")
+            .resolves({ succeeded: true, result: { code: 3, stdout: "FAIL: replicas too low", stderr: "" } });
+
+        await runValidate("my k8s/deployment.yaml");
+
+        const [command, options] = execStub.firstCall.args;
+        assert.match(
+            command as string,
+            /draft validate --manifest ".+deployment\.yaml"/,
+            "manifest path must be quoted",
+        );
+        assert.strictEqual(
+            (options as shell.ShellOptions).exitCodeBehaviour,
+            NonZeroExitCodeBehaviour.Succeed,
+            "policy violations (non-zero exit) must be treated as results, not a command failure",
+        );
+    });
+
+    it("surfaces validation findings from stdout in the results panel", async () => {
+        sandbox
+            .stub(shell, "exec")
+            .resolves({ succeeded: true, result: { code: 1, stdout: "FAIL: missing limits", stderr: "" } });
+
+        await runValidate("k8s/deployment.yaml");
+
+        assert.strictEqual(postValidationResult.firstCall.args[0].result, "FAIL: missing limits");
+    });
+
+    it("combines stdout and stderr output", async () => {
+        sandbox
+            .stub(shell, "exec")
+            .resolves({ succeeded: true, result: { code: 1, stdout: "stdout finding", stderr: "stderr note" } });
+
+        await runValidate("k8s/deployment.yaml");
+
+        assert.strictEqual(postValidationResult.firstCall.args[0].result, "stdout finding\n\nstderr note");
+    });
+
+    it("reports a placeholder when draft produces no output", async () => {
+        sandbox.stub(shell, "exec").resolves({ succeeded: true, result: { code: 0, stdout: "", stderr: "" } });
+
+        await runValidate("k8s/deployment.yaml");
+
+        assert.match(postValidationResult.firstCall.args[0].result, /no output/i);
+    });
+
+    it("shows an error message when draft cannot be executed", async () => {
+        sandbox.stub(shell, "exec").resolves({ succeeded: false, error: "draft binary not found" });
+        const showError = sandbox.stub(vscode.window, "showErrorMessage");
+
+        await runValidate("k8s/deployment.yaml");
+
+        assert.ok(showError.calledOnceWith("draft binary not found"));
+        assert.ok(postValidationResult.notCalled, "no results should be posted on execution failure");
+    });
+});

--- a/src/tests/suite/draftValidate.test.ts
+++ b/src/tests/suite/draftValidate.test.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import * as shell from "../../commands/utils/shell";
 import { NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
 import { DraftValidateDataProvider } from "../../panels/draft/DraftValidatePanel";
-import { isYamlManifestFile } from "../../commands/draft/draftCommands";
+import { isYamlManifestFile, canRunDraftValidate } from "../../commands/draft/draftCommands";
 import { MessageSink } from "../../webview-contract/messaging";
 import { ToWebViewMsgDef } from "../../webview-contract/webviewDefinitions/draft/draftValidate";
 
@@ -19,6 +19,28 @@ describe("isYamlManifestFile", () => {
         for (const f of ["notes.txt", "Dockerfile", "config.json", "archive.yaml.bak", "", ".yamlfile"]) {
             assert.strictEqual(isYamlManifestFile(f), false, f);
         }
+    });
+});
+
+describe("canRunDraftValidate", () => {
+    it("accepts a folder (any name)", () => {
+        assert.strictEqual(canRunDraftValidate("k8s", true), true);
+        assert.strictEqual(canRunDraftValidate("some/nested/dir", true), true);
+    });
+
+    it("accepts a .yaml/.yml file", () => {
+        assert.strictEqual(canRunDraftValidate("k8s/deployment.yaml", false), true);
+        assert.strictEqual(canRunDraftValidate("App.YML", false), true);
+    });
+
+    it("rejects an empty selection (e.g. Command Palette / tree node)", () => {
+        assert.strictEqual(canRunDraftValidate("", false), false);
+        assert.strictEqual(canRunDraftValidate("", true), false);
+    });
+
+    it("rejects a non-YAML file", () => {
+        assert.strictEqual(canRunDraftValidate("notes.txt", false), false);
+        assert.strictEqual(canRunDraftValidate("Dockerfile", false), false);
     });
 });
 
@@ -48,16 +70,6 @@ describe("DraftValidate handler", () => {
     });
 
     afterEach(() => sandbox.restore());
-
-    it("does not run draft when no manifest location is provided", async () => {
-        const execStub = sandbox.stub(shell, "exec");
-
-        await runValidate("");
-
-        assert.ok(execStub.notCalled, "draft should not be invoked without a manifest path");
-        assert.ok(postValidationResult.calledOnce);
-        assert.match(postValidationResult.firstCall.args[0].result, /No manifest path was provided/);
-    });
 
     it("quotes the manifest path and tolerates non-zero exit codes (findings are not errors)", async () => {
         const execStub = sandbox

--- a/src/tests/suite/draftValidate.test.ts
+++ b/src/tests/suite/draftValidate.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import * as path from "path";
 import * as vscode from "vscode";
 import * as shell from "../../commands/utils/shell";
 import { NonZeroExitCodeBehaviour } from "../../commands/utils/shell";
@@ -71,18 +72,19 @@ describe("DraftValidate handler", () => {
 
     afterEach(() => sandbox.restore());
 
-    it("quotes the manifest path and tolerates non-zero exit codes (findings are not errors)", async () => {
-        const execStub = sandbox
-            .stub(shell, "exec")
+    it("passes the manifest path as a separate argument and tolerates non-zero exit codes (findings are not errors)", async () => {
+        const execFileStub = sandbox
+            .stub(shell, "execFile")
             .resolves({ succeeded: true, result: { code: 3, stdout: "FAIL: replicas too low", stderr: "" } });
 
         await runValidate("my k8s/deployment.yaml");
 
-        const [command, options] = execStub.firstCall.args;
-        assert.match(
-            command as string,
-            /draft validate --manifest ".+deployment\.yaml"/,
-            "manifest path must be quoted",
+        const [executable, args, options] = execFileStub.firstCall.args;
+        assert.strictEqual(executable, "/tools/draft/draft", "the resolved draft binary path is invoked directly");
+        assert.deepStrictEqual(
+            args,
+            ["validate", "--manifest", `.${path.sep}my k8s/deployment.yaml`],
+            "the exact manifest path is passed as a separate argument",
         );
         assert.strictEqual(
             (options as shell.ShellOptions).exitCodeBehaviour,
@@ -93,7 +95,7 @@ describe("DraftValidate handler", () => {
 
     it("surfaces validation findings from stdout in the results panel", async () => {
         sandbox
-            .stub(shell, "exec")
+            .stub(shell, "execFile")
             .resolves({ succeeded: true, result: { code: 1, stdout: "FAIL: missing limits", stderr: "" } });
 
         await runValidate("k8s/deployment.yaml");
@@ -103,7 +105,7 @@ describe("DraftValidate handler", () => {
 
     it("combines stdout and stderr output", async () => {
         sandbox
-            .stub(shell, "exec")
+            .stub(shell, "execFile")
             .resolves({ succeeded: true, result: { code: 1, stdout: "stdout finding", stderr: "stderr note" } });
 
         await runValidate("k8s/deployment.yaml");
@@ -112,7 +114,7 @@ describe("DraftValidate handler", () => {
     });
 
     it("reports a placeholder when draft produces no output", async () => {
-        sandbox.stub(shell, "exec").resolves({ succeeded: true, result: { code: 0, stdout: "", stderr: "" } });
+        sandbox.stub(shell, "execFile").resolves({ succeeded: true, result: { code: 0, stdout: "", stderr: "" } });
 
         await runValidate("k8s/deployment.yaml");
 
@@ -120,7 +122,7 @@ describe("DraftValidate handler", () => {
     });
 
     it("shows an error message when draft cannot be executed", async () => {
-        sandbox.stub(shell, "exec").resolves({ succeeded: false, error: "draft binary not found" });
+        sandbox.stub(shell, "execFile").resolves({ succeeded: false, error: "draft binary not found" });
         const showError = sandbox.stub(vscode.window, "showErrorMessage");
 
         await runValidate("k8s/deployment.yaml");

--- a/src/tests/suite/draftValidate.test.ts
+++ b/src/tests/suite/draftValidate.test.ts
@@ -84,7 +84,7 @@ describe("DraftValidate handler", () => {
         assert.strictEqual(executable, "/tools/draft/draft", "the resolved draft binary path is invoked directly");
         assert.deepStrictEqual(
             args,
-            ["validate", "--manifest", `.${path.sep}my k8s/deployment.yaml`],
+            ["validate", "--manifest", `.${path.sep}my k8s${path.sep}deployment.yaml`],
             "the exact manifest path is passed as a separate argument",
         );
         assert.strictEqual(

--- a/src/tests/suite/draftValidate.test.ts
+++ b/src/tests/suite/draftValidate.test.ts
@@ -60,7 +60,8 @@ describe("DraftValidate handler", () => {
     }
 
     async function runValidate(initialLocation: string): Promise<void> {
-        const provider = makeProvider(initialLocation);
+        const normalizedLocation = initialLocation.split(/[\\/]/).join(path.sep);
+        const provider = makeProvider(normalizedLocation);
         const webview = { postValidationResult } as unknown as MessageSink<ToWebViewMsgDef>;
         await provider.getMessageHandler(webview).createDraftValidateRequest("", "createDraftValidateRequest");
     }


### PR DESCRIPTION
## Problem

Running **Run Deployment Safeguards YAML Validation** (Draft validate) on generated manifests didn't work: `draft validate` exits **non-zero when it finds policy violations**, but the panel treated any non-zero exit as a command failure. 

## Changes

`src/panels/draft/DraftValidatePanel.ts`
- Run with `NonZeroExitCodeBehaviour.Succeed` so policy violations are treated as **results, not a failure**, and post the combined `stdout` + `stderr` findings to the results panel.
- **Quote** the `--manifest` path so locations with spaces work.
- Guard the **empty-selection** case with a clear message instead of a broken command.

`src/commands/draft/draftCommands.ts`
- Reject **non-YAML files** up front (`isYamlManifestFile`) with clear guidance instead of a cryptic Draft failure. Folders and empty selections pass through unchanged.

## Tests

`src/tests/suite/draftValidate.test.ts` — covers the panel handler branches (empty-path guard, quoting, non-zero-exit handling, stdout/stderr combination, empty-output placeholder, execution failure) and the `isYamlManifestFile` predicate.

## Manual test

Right-click a manifest that violates a safeguard (e.g. `nginx:latest`, no probes/limits, privileged) → **Run Deployment Safeguards YAML Validation**. Before: error popup + empty panel. After: the violations are listed in the results panel.