### PR TITLE
fix: use .usageOperations

### DIFF
--- a/src/commands/utils/clusterPreflight.ts
+++ b/src/commands/utils/clusterPreflight.ts
@@ -210,7 +210,7 @@ export async function checkAutomaticSkuQuota(
 ): Promise<Errorable<AutomaticSkuQuota>> {
     try {
         const client = getComputeManagementClient(sessionProvider, subscriptionId);
-        const usages = client.usage.list(location);
+        const usages = client.usageOperations.list(location);
         const candidateFamilies = new Set(AKS_AUTOMATIC_CANDIDATE_FAMILIES);
         let cores: VCpuQuota | null = null;
         const families: FamilyQuota[] = [];

--- a/src/panels/KaitoModelsPanel.ts
+++ b/src/panels/KaitoModelsPanel.ts
@@ -265,7 +265,7 @@ export class KaitoModelsPanelDataProvider implements PanelDataProvider<"kaitoMod
                         this.resourceGroupName,
                         this.clusterName,
                     );
-                    const quotas = computeClient.usage.list(cluster.location);
+                    const quotas = computeClient.usageOperations.list(cluster.location);
                     const foundQuota = await this.findMatchingQuota(quotas, gpuFamily);
                     if (!foundQuota || !this.isQuotaSufficient(foundQuota, requiredCPUs)) {
                         this.promptForQuotaIncrease();


### PR DESCRIPTION
@azure/arm-compute renamed the usage operations group to usageOperations. Two call sites landed after the SDK bump without updating, breaking tsc on main. Rename only, runtime behavior is unchanged.