### PR TITLE
kickstart: prefer open-capacity regions + base cost estimate

### DIFF
--- a/src/commands/utils/clusterPreflight.ts
+++ b/src/commands/utils/clusterPreflight.ts
@@ -111,12 +111,28 @@ export interface SkuZoneAvailability {
     regionZones: string[];
     usableZones: string[];
     sufficient: boolean;
+    /**
+     * True when this SKU is blocked by a `NotAvailableForSubscription` restriction (the family isn't
+     * enabled for the subscription in this region/zone) rather than a transient capacity/zone
+     * shortfall. Distinguishes "request SKU enablement" from "pick another region".
+     */
+    notAvailableForSubscription: boolean;
 }
 
 export interface AutomaticSkuZones {
     requiredZoneCount: number;
     offered: SkuZoneAvailability[];
-    restrictedZones: string[];
+    /**
+     * The largest number of usable availability zones any single offered SKU provides. This is the
+     * value that actually gates AKS Automatic (it needs one SKU with enough zones), unlike a union
+     * of restricted zones across SKUs, which overstates the restriction.
+     */
+    bestUsableZoneCount: number;
+    /**
+     * True when every offered SKU is blocked specifically by `NotAvailableForSubscription`, i.e. the
+     * region has the SKUs but they aren't enabled for this subscription. Drives a clearer message.
+     */
+    blockedForSubscription: boolean;
     sufficient: boolean;
 }
 
@@ -268,7 +284,6 @@ export async function checkAutomaticSkuZones(
 
         const skus = client.resourceSkus.list({ filter: `location eq '${location}'` });
         const offered: SkuZoneAvailability[] = [];
-        const restrictedZones = new Set<string>();
 
         for await (const sku of skus) {
             if (sku.resourceType !== "virtualMachines" || !sku.name) {
@@ -285,12 +300,18 @@ export async function checkAutomaticSkuZones(
             const regionZones = sortZones(locationInfo?.zones ?? []);
 
             // A "Location" restriction blocks the SKU across the whole region for this subscription;
-            // a "Zone" restriction blocks specific zones. Subtract both from the offered zones.
+            // a "Zone" restriction blocks specific zones. Subtract both from the offered zones. Track
+            // whether the blocking reason is subscription enablement (NotAvailableForSubscription) vs
+            // a capacity/region shortfall, so we can give the right guidance.
             let locationBlocked = false;
+            let notAvailableForSubscription = false;
             const blockedZones = new Set<string>();
             for (const restriction of sku.restrictions ?? []) {
                 if (!restrictionAppliesToLocation(restriction, normalizedLocation)) {
                     continue;
+                }
+                if (restriction.reasonCode === "NotAvailableForSubscription") {
+                    notAvailableForSubscription = true;
                 }
                 if (restriction.type === "Location") {
                     locationBlocked = true;
@@ -302,26 +323,29 @@ export async function checkAutomaticSkuZones(
             }
 
             const usableZones = locationBlocked ? [] : regionZones.filter((zone) => !blockedZones.has(zone));
-            for (const zone of regionZones) {
-                if (locationBlocked || blockedZones.has(zone)) {
-                    restrictedZones.add(zone);
-                }
-            }
 
             offered.push({
                 name: canonicalName,
                 regionZones,
                 usableZones,
                 sufficient: usableZones.length >= requiredZoneCount,
+                // Only meaningful when the SKU is actually short of usable zones.
+                notAvailableForSubscription: notAvailableForSubscription && usableZones.length < requiredZoneCount,
             });
         }
+
+        const bestUsableZoneCount = offered.reduce((max, sku) => Math.max(max, sku.usableZones.length), 0);
+        const shortfallSkus = offered.filter((sku) => !sku.sufficient);
+        const blockedForSubscription =
+            shortfallSkus.length > 0 && shortfallSkus.every((sku) => sku.notAvailableForSubscription);
 
         return {
             succeeded: true,
             result: {
                 requiredZoneCount,
                 offered,
-                restrictedZones: sortZones([...restrictedZones]),
+                bestUsableZoneCount,
+                blockedForSubscription,
                 sufficient: offered.some((sku) => sku.sufficient),
             },
         };

--- a/src/commands/utils/kickstartCostEstimate.ts
+++ b/src/commands/utils/kickstartCostEstimate.ts
@@ -1,26 +1,15 @@
 import * as l10n from "@vscode/l10n";
 import { CostEstimate, CostEstimateLineItem } from "../../webview-contract/webviewDefinitions/kickstartCluster";
-import { REQUIRED_VCPUS_FOR_AUTOMATIC, normalizeLocation } from "./clusterPreflight";
+import { normalizeLocation } from "./clusterPreflight";
 import { Errorable, failed } from "./errorable";
 import { RetailPriceItem, fetchRetailPrices } from "./retailPrices";
 
 const HOURS_PER_MONTH = 730;
 const DAYS_PER_MONTH = 365 / 12;
-const BASELINE_VCPUS = REQUIRED_VCPUS_FOR_AUTOMATIC;
-const REPRESENTATIVE_NODE_SKU = "Standard_D4s_v5";
-const REPRESENTATIVE_NODE_VCPUS = 4;
 const CURRENCY_CODE = "USD";
 
 function controlPlaneFilter(region: string): string {
     return `serviceName eq 'Azure Kubernetes Service' and armRegionName eq '${region}' and skuName eq 'Automatic' and meterName eq 'Automatic Hosted Control Plane'`;
-}
-
-function nodeSurchargeFilter(region: string): string {
-    return `serviceName eq 'Azure Kubernetes Service' and armRegionName eq '${region}' and meterName eq 'Automatic General Purpose'`;
-}
-
-function nodeComputeFilter(region: string): string {
-    return `serviceName eq 'Virtual Machines' and armRegionName eq '${region}' and armSkuName eq '${REPRESENTATIVE_NODE_SKU}' and priceType eq 'Consumption'`;
 }
 
 function acrFilter(): string {
@@ -29,14 +18,6 @@ function acrFilter(): string {
 
 function firstPriced(items: RetailPriceItem[]): RetailPriceItem | undefined {
     return items.find((item) => item.retailPrice > 0);
-}
-
-function isStandardLinuxOnDemand(item: RetailPriceItem): boolean {
-    if (item.type !== "Consumption") return false;
-    if ((item.productName ?? "").includes("Windows")) return false;
-    if ((item.skuName ?? "").includes("Spot")) return false;
-    if ((item.skuName ?? "").includes("Low Priority")) return false;
-    return true;
 }
 
 function formatRate(value: number): string {
@@ -48,10 +29,6 @@ export async function estimateClusterMonthlyCost(location: string): Promise<Erro
 
     const controlPlaneResult = await fetchRetailPrices(controlPlaneFilter(region));
     if (failed(controlPlaneResult)) return controlPlaneResult;
-    const nodeComputeResult = await fetchRetailPrices(nodeComputeFilter(region));
-    if (failed(nodeComputeResult)) return nodeComputeResult;
-    const nodeSurchargeResult = await fetchRetailPrices(nodeSurchargeFilter(region));
-    if (failed(nodeSurchargeResult)) return nodeSurchargeResult;
     const acrResult = await fetchRetailPrices(acrFilter());
     if (failed(acrResult)) return acrResult;
 
@@ -71,41 +48,6 @@ export async function estimateClusterMonthlyCost(location: string): Promise<Erro
         isApproximate: false,
     });
 
-    const nodeCompute = nodeComputeResult.result.find((item) => item.retailPrice > 0 && isStandardLinuxOnDemand(item));
-    if (!nodeCompute) {
-        return {
-            succeeded: false,
-            error: l10n.t("Couldn't find {0} compute pricing for {1}.", REPRESENTATIVE_NODE_SKU, location),
-        };
-    }
-    const nodeCount = BASELINE_VCPUS / REPRESENTATIVE_NODE_VCPUS;
-    items.push({
-        label: l10n.t("Node compute (estimated)"),
-        monthlyCost: nodeCompute.retailPrice * nodeCount * HOURS_PER_MONTH,
-        detail: l10n.t(
-            "Assumes {0} × {1} at {2}/hour to cover a {3}-vCPU baseline.",
-            nodeCount,
-            REPRESENTATIVE_NODE_SKU,
-            formatRate(nodeCompute.retailPrice),
-            BASELINE_VCPUS,
-        ),
-        isApproximate: true,
-    });
-
-    const nodeSurcharge = firstPriced(nodeSurchargeResult.result);
-    if (nodeSurcharge) {
-        items.push({
-            label: l10n.t("AKS Automatic node management"),
-            monthlyCost: nodeSurcharge.retailPrice * BASELINE_VCPUS * HOURS_PER_MONTH,
-            detail: l10n.t(
-                "Automatic management premium at {0}/vCPU-hour across {1} vCPUs.",
-                formatRate(nodeSurcharge.retailPrice),
-                BASELINE_VCPUS,
-            ),
-            isApproximate: true,
-        });
-    }
-
     const acr = firstPriced(acrResult.result);
     if (!acr) {
         return {
@@ -123,8 +65,7 @@ export async function estimateClusterMonthlyCost(location: string): Promise<Erro
     const monthlyTotal = items.reduce((sum, item) => sum + item.monthlyCost, 0);
     const disclaimers = [
         l10n.t(
-            "AKS Automatic auto-selects node sizes for your workload. Node compute is estimated from a representative {0} configuration and will vary with actual usage and autoscaling.",
-            REPRESENTATIVE_NODE_SKU,
+            "Base cost covers the AKS Automatic control plane and container registry only. Node compute is auto-provisioned by AKS Automatic based on your workload and is not included.",
         ),
         l10n.t("Figures are retail pay-as-you-go rates and exclude taxes, discounts, reservations, and savings plans."),
         l10n.t("Storage, networking, load balancers, and data egress are not included."),
@@ -136,7 +77,7 @@ export async function estimateClusterMonthlyCost(location: string): Promise<Erro
             location,
             currencyCode: CURRENCY_CODE,
             monthlyTotal,
-            isApproximate: true,
+            isApproximate: false,
             items,
             disclaimers,
         },

--- a/src/panels/kickstartAzureBackend.ts
+++ b/src/panels/kickstartAzureBackend.ts
@@ -116,6 +116,66 @@ const HIGH_RISK_REGIONS = new Set(REGION_CAPACITY_RISK.high);
 
 const MAX_SUGGESTED_REGIONS = 3;
 
+// Regions are probed in priority order through a fixed worker window rather than all at once, so a
+// large PREFERRED_REGION_ORDER can't flood ARM with quota+zones calls (each region = 2 calls) and
+// trigger throttling. Tuned as a balance between scan latency and ARM pressure.
+const SCAN_CONCURRENCY = 5;
+
+/**
+ * Runs `worker` over `items` in order with at most `concurrency` in flight, stopping early once
+ * `shouldStop(results)` returns true. Because callers pass a priority-ordered list, this scans just
+ * enough of the head to satisfy demand instead of the whole list. Results preserve input order for
+ * the items that were actually processed. Cancellation is honored between scheduling decisions.
+ */
+async function scanWithConcurrencyUntil<TIn, TOut>(
+    items: TIn[],
+    concurrency: number,
+    worker: (item: TIn, index: number) => Promise<TOut>,
+    shouldStop: (results: TOut[]) => boolean,
+    token: CancellationToken,
+): Promise<TOut[]> {
+    const results: TOut[] = [];
+    const indexed = new Map<number, TOut>();
+    let nextIndex = 0;
+    let stopped = false;
+    const inFlight = new Set<Promise<void>>();
+
+    const collect = () => {
+        // Drain completed results in input order so early-exit decisions see a stable prefix.
+        for (let i = 0; indexed.has(i); i++) {
+            results.push(indexed.get(i)!);
+            indexed.delete(i);
+        }
+    };
+
+    while (!stopped && (nextIndex < items.length || inFlight.size > 0)) {
+        while (!stopped && inFlight.size < concurrency && nextIndex < items.length) {
+            token.throwIfCancelled();
+            const index = nextIndex++;
+            const task = worker(items[index], index).then((out) => {
+                indexed.set(index, out);
+            });
+            const tracked = task.finally(() => inFlight.delete(tracked));
+            inFlight.add(tracked);
+        }
+
+        if (inFlight.size > 0) {
+            await Promise.race(inFlight);
+        }
+        collect();
+        token.throwIfCancelled();
+
+        if (shouldStop(results)) {
+            stopped = true;
+        }
+    }
+
+    // Let any still-running probes settle so their reported activity entries finish cleanly.
+    await Promise.allSettled(inFlight);
+    collect();
+    return results;
+}
+
 function compareRegionsByCapacityRisk(a: string, b: string): number {
     const rank = (region: string): number => {
         const preferred = PREFERRED_REGION_ORDER.indexOf(region);
@@ -324,8 +384,13 @@ export async function runSubscriptionScan(
     }
 
     const capacityStage = reporter.stage("quota", l10n.t("Regional capacity"), { collapsible: true });
-    const scannedResults = await Promise.all(
-        PREFERRED_REGION_ORDER.map((location) =>
+    // Probe regions in priority order with bounded concurrency, stopping once we have enough
+    // recommendable regions. PREFERRED_REGION_ORDER is risk-ranked (best first), so the early-exit
+    // still yields the same top suggestions while avoiding a flood of ARM calls across all regions.
+    const scannedResults = await scanWithConcurrencyUntil(
+        PREFERRED_REGION_ORDER,
+        SCAN_CONCURRENCY,
+        (location) =>
             capacityStage
                 .run(
                     l10n.t("Checking capacity in {0}", location),
@@ -356,7 +421,9 @@ export async function runSubscriptionScan(
                     (r) => r.entryDetail,
                 )
                 .then((r) => r.regionResult),
-        ),
+        // Stop once enough regions have cleared to fill the suggestion slots.
+        (results) => results.filter((r) => r.status === "succeeded").length >= MAX_SUGGESTED_REGIONS,
+        token,
     );
     token.throwIfCancelled();
 

--- a/src/panels/kickstartAzureBackend.ts
+++ b/src/panels/kickstartAzureBackend.ts
@@ -1007,7 +1007,7 @@ function summarizeZones(
         };
     }
 
-    const { offered, restrictedZones, requiredZoneCount, sufficient } = zones.result;
+    const { offered, bestUsableZoneCount, blockedForSubscription, requiredZoneCount, sufficient } = zones.result;
     if (sufficient) {
         return {
             status: "succeeded",
@@ -1031,26 +1031,29 @@ function summarizeZones(
         };
     }
 
-    if (restrictedZones.length > 0) {
+    // The SKUs exist in the region but aren't enabled for this subscription (NotAvailableForSubscription).
+    // That's an enablement/allocation issue, not a regional capacity gap, so guide toward requesting access.
+    if (blockedForSubscription) {
         return {
             status: "failed",
             detail: l10n.t(
-                "Your subscription is restricted from availability zone(s) {0} in {1}, leaving fewer than the {2} zones AKS Automatic requires. Choose another region or request zone access for this subscription.",
-                restrictedZones.join(", "),
+                "The VM sizes AKS Automatic needs aren't enabled for your subscription in {0} (they offer only {1} of the {2} required availability zones). Request access to these VM sizes for your subscription, or choose another region.",
                 location,
+                bestUsableZoneCount,
                 requiredZoneCount,
             ),
-            entryDetail: l10n.t("zone(s) {0} restricted", restrictedZones.join(", ")),
+            entryDetail: l10n.t("VM sizes not enabled for subscription"),
         };
     }
 
     return {
         status: "failed",
         detail: l10n.t(
-            "{0} doesn't support the {1} availability zones AKS Automatic requires for its VM sizes.",
-            location,
+            "The VM sizes AKS Automatic needs offer only {0} of the {1} availability zones it requires in {2}. Choose another region.",
+            bestUsableZoneCount,
             requiredZoneCount,
+            location,
         ),
-        entryDetail: l10n.t("fewer than {0} zones", requiredZoneCount),
+        entryDetail: l10n.t("{0} of {1} zones available", bestUsableZoneCount, requiredZoneCount),
     };
 }

--- a/src/panels/kickstartAzureBackend.ts
+++ b/src/panels/kickstartAzureBackend.ts
@@ -59,10 +59,56 @@ import {
 } from "../webview-contract/webviewDefinitions/kickstartShared";
 import { ActivityReporter, ActivitySink, CancellationToken } from "./kickstartActivity";
 
+// Region capacity-risk tiers for AKS Automatic system-pool availability. Ordering drives which
+// region we recommend first: `low` regions have ample open pool capacity, `medium` have shrinking
+// headroom, and `high` are capacity-constrained (system pools supportable well below entitlement)
+// and are deprioritised. Membership only — no raw capacity numbers are encoded, since those drift.
 const REGION_CAPACITY_RISK = {
-    low: ["eastus2", "westus3", "southcentralus", "canadacentral", "swedencentral", "japaneast"],
-    medium: ["centralus", "westus2"],
-    high: ["eastus", "westeurope", "southeastasia"],
+    low: [
+        "newzealandnorth",
+        "japanwest",
+        "canadacentral",
+        "swedencentral",
+        "eastasia",
+        "centralindia",
+        "australiacentral",
+        "eastus2",
+        "polandcentral",
+        "ukwest",
+        "westcentralus",
+        "koreacentral",
+        "switzerlandnorth",
+        "italynorth",
+    ],
+    medium: [
+        "southindia",
+        "southeastasia",
+        "australiaeast",
+        "northcentralus",
+        "norwayeast",
+        "francecentral",
+        "centralus",
+        "southcentralus",
+        "japaneast",
+        "canadaeast",
+        "brazilsouth",
+        "westus2",
+        "westus3",
+    ],
+    high: [
+        "eastus",
+        "westeurope",
+        "northeurope",
+        "koreasouth",
+        "germanywestcentral",
+        "westus",
+        "uksouth",
+        "eastus3",
+        "southcentralus2",
+        "southeastus",
+        "southwestus",
+        "qatarcentral",
+    ],
 };
 
 const PREFERRED_REGION_ORDER = [...REGION_CAPACITY_RISK.low, ...REGION_CAPACITY_RISK.medium];

--- a/webview-ui/src/KickstartCluster/ClusterInput.tsx
+++ b/webview-ui/src/KickstartCluster/ClusterInput.tsx
@@ -535,7 +535,7 @@ export function ClusterInput(props: ClusterInputProps) {
         if (!matchesRegion) {
             return (
                 <div className={styles.costPanel}>
-                    <span className={styles.costHeader}>{l10n.t("Estimated monthly cost")}</span>
+                    <span className={styles.costHeader}>{l10n.t("Base cost estimate (excludes workloads)")}</span>
                     <span className={styles.costLoading}>{l10n.t("Estimating costs for {0}…", currentLocation)}</span>
                 </div>
             );
@@ -544,7 +544,7 @@ export function ClusterInput(props: ClusterInputProps) {
         if (result.error || !result.estimate) {
             return (
                 <div className={styles.costPanel}>
-                    <span className={styles.costHeader}>{l10n.t("Estimated monthly cost")}</span>
+                    <span className={styles.costHeader}>{l10n.t("Base cost estimate (excludes workloads)")}</span>
                     <span className={styles.costError}>
                         <FontAwesomeIcon className={styles.checkWarning} icon={faExclamationTriangle} />
                         {result.error ?? l10n.t("Couldn't estimate the monthly cost for this region.")}
@@ -557,7 +557,7 @@ export function ClusterInput(props: ClusterInputProps) {
         return (
             <div className={styles.costPanel}>
                 <div className={styles.costHeaderRow}>
-                    <span className={styles.costHeader}>{l10n.t("Estimated monthly cost")}</span>
+                    <span className={styles.costHeader}>{l10n.t("Base cost estimate (excludes workloads)")}</span>
                     <span className={styles.costTotal}>
                         {formatCurrency(estimate.monthlyTotal, estimate.currencyCode)}
                         {estimate.isApproximate ? "*" : ""}

--- a/webview-ui/src/KickstartCluster/ClusterInput.tsx
+++ b/webview-ui/src/KickstartCluster/ClusterInput.tsx
@@ -547,7 +547,7 @@ export function ClusterInput(props: ClusterInputProps) {
                     <span className={styles.costHeader}>{l10n.t("Base cost estimate (excludes workloads)")}</span>
                     <span className={styles.costError}>
                         <FontAwesomeIcon className={styles.checkWarning} icon={faExclamationTriangle} />
-                        {result.error ?? l10n.t("Couldn't estimate the monthly cost for this region.")}
+                        {result.error ?? l10n.t("Couldn't estimate the base cost for this region.")}
                     </span>
                 </div>
             );


### PR DESCRIPTION
splits the region-pref + cost-estimate changes out of the kickstart ui cleanup pr (#2326) so they can land independently.

## region prefs
- refreshed the region capacity-risk tiers (low/medium/high) from latest aks automatic system-pool availability so region recommendation + the region picker prefer regions with open pool capacity and sink constrained ones
- tier membership only, no raw capacity numbers encoded (they drift)

## region scan rate-limiting
- addresses feedback that the expanded preferred set (~29 regions) would flood arm: the old code did `Promise.all` over every preferred region, firing quota+zones calls for all of them at once
- now scans in priority order through a bounded worker window (5 regions at a time) and early-exits once enough recommendable regions are found
- since the list is risk-ranked, the top suggestions are unchanged but the common case makes far fewer arm calls; worst case (nothing clears) still scans all but capped at 5-in-flight
- cancellation honored between waves

## cost estimate
- dropped the node-derived line items (node compute + automatic node management surcharge) — they scale with workload and were misleading
- keeps just the flat aks automatic control plane fee + acr basic
- renamed the panel to `base cost estimate (excludes workloads)` and reworked disclaimers

## notes
- extension + webview typecheck clean
- not yet runtime-tested in vscode
