### PR TITLE
fix(container-assist): skip build-output dirs when generating manifests

### DIFF
--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -16,7 +16,13 @@ import {
 
 import { LMClient } from "./lmClient";
 import { extractContent, parseManifestsFromLMResponse, fixManifestImageReferences } from "./contentParser";
-import { checkExistingFiles, writeFile, ensureDirectory, getK8sManifestFolder } from "./fileOperations";
+import {
+    checkExistingFiles,
+    writeFile,
+    ensureDirectory,
+    getK8sManifestFolder,
+    isExcludedModulePath,
+} from "./fileOperations";
 import {
     DOCKERFILE_SYSTEM_PROMPT,
     K8S_MANIFEST_SYSTEM_PROMPT,
@@ -82,16 +88,24 @@ export class ContainerAssistService {
             const analysis: RepositoryAnalysis = result.value;
             logger.toolResponse("analyzeRepo", analysis);
 
-            const modules: ModuleAnalysisResult[] = (analysis.modules || []).map((module) => ({
-                name: module.name,
-                modulePath: module.modulePath,
-                language: module.language,
-                framework: module.frameworks?.[0]?.name,
-                port: module.ports?.[0],
-                buildCommand: module.buildSystems?.[0]?.type,
-                dependencies: module.dependencies,
-                entryPoint: module.entryPoint,
-            }));
+            const modules: ModuleAnalysisResult[] = (analysis.modules || [])
+                .filter((module) => {
+                    if (isExcludedModulePath(module.modulePath, folderPath)) {
+                        logger.info(`Skipping module in excluded directory: ${module.modulePath}`);
+                        return false;
+                    }
+                    return true;
+                })
+                .map((module) => ({
+                    name: module.name,
+                    modulePath: module.modulePath,
+                    language: module.language,
+                    framework: module.frameworks?.[0]?.name,
+                    port: module.ports?.[0],
+                    buildCommand: module.buildSystems?.[0]?.type,
+                    dependencies: module.dependencies,
+                    entryPoint: module.entryPoint,
+                }));
 
             const isMonorepo = analysis.isMonorepo ?? modules.length > 1;
 

--- a/src/commands/aksContainerAssist/containerAssistService.ts
+++ b/src/commands/aksContainerAssist/containerAssistService.ts
@@ -22,6 +22,7 @@ import {
     ensureDirectory,
     getK8sManifestFolder,
     isExcludedModulePath,
+    getEffectiveExcludedDirs,
 } from "./fileOperations";
 import {
     DOCKERFILE_SYSTEM_PROMPT,
@@ -88,9 +89,13 @@ export class ContainerAssistService {
             const analysis: RepositoryAnalysis = result.value;
             logger.toolResponse("analyzeRepo", analysis);
 
+            // Exclude static dirs plus the repo's .gitignore entries, so build-output
+            // modules (e.g. Next.js `.next/`) from the SDK walker are filtered out.
+            const excludedDirs = await getEffectiveExcludedDirs(folderPath);
+
             const modules: ModuleAnalysisResult[] = (analysis.modules || [])
                 .filter((module) => {
-                    if (isExcludedModulePath(module.modulePath, folderPath)) {
+                    if (isExcludedModulePath(module.modulePath, folderPath, excludedDirs)) {
                         logger.info(`Skipping module in excluded directory: ${module.modulePath}`);
                         return false;
                     }

--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -84,6 +84,16 @@ const EXCLUDED_DIRS = new Set([
 /** Maximum directory depth for Dockerfile and manifest scanning. */
 const SCAN_MAX_DEPTH = 3;
 
+export function isExcludedModulePath(modulePath: string, rootPath: string): boolean {
+    const relative = path.relative(rootPath, modulePath);
+
+    if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+        return false;
+    }
+
+    return relative.split(path.sep).some((segment) => EXCLUDED_DIRS.has(segment));
+}
+
 /**
  * Searches recursively (up to 3 levels deep) for Dockerfiles under rootPath.
  * Returns absolute paths sorted shallowest-first; excluded dirs are skipped.

--- a/src/commands/aksContainerAssist/fileOperations.ts
+++ b/src/commands/aksContainerAssist/fileOperations.ts
@@ -57,7 +57,7 @@ export async function checkExistingFiles(folderPath: string): Promise<ExistingFi
 }
 
 /** Directories to skip during recursive scans (build artifacts, dependencies, etc.) */
-const EXCLUDED_DIRS = new Set([
+export const EXCLUDED_DIRS = new Set([
     "node_modules",
     ".git",
     "dist",
@@ -84,14 +84,62 @@ const EXCLUDED_DIRS = new Set([
 /** Maximum directory depth for Dockerfile and manifest scanning. */
 const SCAN_MAX_DEPTH = 3;
 
-export function isExcludedModulePath(modulePath: string, rootPath: string): boolean {
+/**
+ * Parses `<rootPath>/.gitignore` and returns the plain, single-segment directory
+ * names it lists (e.g. `dist/`, `/build`, `.next`). Globs, negations, comments, and
+ * nested paths are ignored, matching the basename-based `EXCLUDED_DIRS` model.
+ * A missing or unreadable `.gitignore` yields an empty set.
+ */
+export async function loadGitignoreDirs(rootPath: string): Promise<Set<string>> {
+    const dirs = new Set<string>();
+
+    try {
+        const content = await fs.readFile(path.join(rootPath, ".gitignore"), "utf-8");
+
+        for (const raw of content.split(/\r?\n/)) {
+            const line = raw.trim();
+
+            // Skip blanks, comments, and negations.
+            if (line === "" || line.startsWith("#") || line.startsWith("!")) {
+                continue;
+            }
+
+            // Skip glob patterns.
+            if (/[*?[\]]/.test(line)) {
+                continue;
+            }
+
+            // Strip anchoring/trailing slashes; keep single-segment names only.
+            const name = line.replace(/^\/+/, "").replace(/\/+$/, "");
+            if (name !== "" && !name.includes("/")) {
+                dirs.add(name);
+            }
+        }
+    } catch {
+        // No/unreadable .gitignore: fall back to the static set.
+    }
+
+    return dirs;
+}
+
+/** Static {@link EXCLUDED_DIRS} plus any plain directory entries in the root's `.gitignore`. */
+export async function getEffectiveExcludedDirs(rootPath: string): Promise<Set<string>> {
+    const gitignoreDirs = await loadGitignoreDirs(rootPath);
+    return new Set([...EXCLUDED_DIRS, ...gitignoreDirs]);
+}
+
+export function isExcludedModulePath(
+    modulePath: string,
+    rootPath: string,
+    excluded: Set<string> = EXCLUDED_DIRS,
+): boolean {
     const relative = path.relative(rootPath, modulePath);
 
     if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
         return false;
     }
 
-    return relative.split(path.sep).some((segment) => EXCLUDED_DIRS.has(segment));
+    return relative.split(path.sep).some((segment) => excluded.has(segment));
 }
 
 /**
@@ -100,14 +148,21 @@ export function isExcludedModulePath(modulePath: string, rootPath: string): bool
  */
 export async function scanForDockerfiles(rootPath: string): Promise<string[]> {
     const dockerfiles: string[] = [];
+    const excluded = await getEffectiveExcludedDirs(rootPath);
 
     const isDockerfile = (_filePath: string, fileName: string): boolean => fileName === "Dockerfile";
 
-    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, (filePath, fileName) => {
-        if (isDockerfile(filePath, fileName)) {
-            dockerfiles.push(filePath);
-        }
-    });
+    await walkDirectory(
+        rootPath,
+        SCAN_MAX_DEPTH,
+        0,
+        (filePath, fileName) => {
+            if (isDockerfile(filePath, fileName)) {
+                dockerfiles.push(filePath);
+            }
+        },
+        excluded,
+    );
 
     return dockerfiles.sort((left, right) => left.split(path.sep).length - right.split(path.sep).length);
 }
@@ -119,18 +174,25 @@ export async function scanForDockerfiles(rootPath: string): Promise<string[]> {
  */
 export async function scanForK8sManifests(rootPath: string): Promise<string[]> {
     const manifests: string[] = [];
+    const excluded = await getEffectiveExcludedDirs(rootPath);
 
     const isYamlFile = (fileName: string): boolean => fileName.endsWith(".yaml") || fileName.endsWith(".yml");
 
-    await walkDirectory(rootPath, SCAN_MAX_DEPTH, 0, async (filePath, fileName) => {
-        if (!isYamlFile(fileName)) {
-            return;
-        }
+    await walkDirectory(
+        rootPath,
+        SCAN_MAX_DEPTH,
+        0,
+        async (filePath, fileName) => {
+            if (!isYamlFile(fileName)) {
+                return;
+            }
 
-        if (await isKubernetesManifest(filePath)) {
-            manifests.push(filePath);
-        }
-    });
+            if (await isKubernetesManifest(filePath)) {
+                manifests.push(filePath);
+            }
+        },
+        excluded,
+    );
 
     return manifests;
 }
@@ -167,6 +229,7 @@ async function walkDirectory(
     maxDepth: number,
     currentDepth: number,
     onFile: (filePath: string, name: string) => void | Promise<void>,
+    excluded: Set<string> = EXCLUDED_DIRS,
 ): Promise<void> {
     if (currentDepth > maxDepth) {
         return;
@@ -180,8 +243,8 @@ async function walkDirectory(
 
             if (entry.isFile()) {
                 await onFile(fullPath, entry.name);
-            } else if (entry.isDirectory() && !EXCLUDED_DIRS.has(entry.name)) {
-                await walkDirectory(fullPath, maxDepth, currentDepth + 1, onFile);
+            } else if (entry.isDirectory() && !excluded.has(entry.name)) {
+                await walkDirectory(fullPath, maxDepth, currentDepth + 1, onFile, excluded);
             }
         }
     } catch {

--- a/src/commands/aksContainerAssist/tools.ts
+++ b/src/commands/aksContainerAssist/tools.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { logger } from "./logger";
+import { EXCLUDED_DIRS, getEffectiveExcludedDirs } from "./fileOperations";
 
 // --- Tool Definitions ---
 
@@ -90,22 +91,6 @@ function isPathTraversal(relativePath: string, workspaceRoot?: string): boolean 
     return false;
 }
 
-// --- Excluded directories for listDirectory ---
-
-const EXCLUDED_DIRS = new Set([
-    "node_modules",
-    ".git",
-    "dist",
-    "build",
-    "target",
-    "bin",
-    "obj",
-    "__pycache__",
-    "venv",
-    ".next",
-    ".nuxt",
-]);
-
 // --- Tool Handlers ---
 
 const DEFAULT_MAX_LINES = 150;
@@ -164,10 +149,11 @@ export async function handleListDirectory(
     const maxDepth = Math.min(input.maxDepth ?? DEFAULT_MAX_DEPTH, HARD_CAP_MAX_DEPTH);
     const absolutePath = path.join(workspaceRoot, relativePath);
     const dirUri = vscode.Uri.file(absolutePath);
+    const excluded = await getEffectiveExcludedDirs(workspaceRoot);
 
     try {
         const entries: string[] = [];
-        await walkDirectory(dirUri, "", maxDepth, 0, entries);
+        await walkDirectory(dirUri, "", maxDepth, 0, entries, excluded);
 
         if (entries.length === 0) {
             return `Directory: ${relativePath}\n(empty directory)`;
@@ -185,6 +171,7 @@ async function walkDirectory(
     maxDepth: number,
     currentDepth: number,
     entries: string[],
+    excluded: Set<string> = EXCLUDED_DIRS,
 ): Promise<void> {
     if (entries.length >= MAX_ENTRIES) {
         return;
@@ -207,13 +194,13 @@ async function walkDirectory(
         }
 
         if (type === vscode.FileType.Directory) {
-            if (EXCLUDED_DIRS.has(name)) {
+            if (excluded.has(name)) {
                 continue;
             }
             entries.push(`${prefix}${name}/`);
             if (currentDepth < maxDepth) {
                 const childUri = vscode.Uri.joinPath(dirUri, name);
-                await walkDirectory(childUri, `${prefix}  `, maxDepth, currentDepth + 1, entries);
+                await walkDirectory(childUri, `${prefix}  `, maxDepth, currentDepth + 1, entries, excluded);
             }
         } else {
             entries.push(`${prefix}${name}`);

--- a/src/tests/suite/containerAssist/fileOperations.test.ts
+++ b/src/tests/suite/containerAssist/fileOperations.test.ts
@@ -6,6 +6,9 @@ import {
     scanForDockerfiles,
     scanForK8sManifests,
     scanManifestsForModulePaths,
+    loadGitignoreDirs,
+    getEffectiveExcludedDirs,
+    isExcludedModulePath,
 } from "../../../commands/aksContainerAssist/fileOperations";
 
 describe("fileOperations", () => {
@@ -371,6 +374,125 @@ describe("fileOperations", () => {
             const rel = path.relative(workspaceRoot, hits[0]);
             assert.ok(!rel.startsWith(".."), `Manifest path should be inside workspace; got ${rel}`);
             assert.ok(rel.endsWith(path.join("services", "api", "k8s", "deployment.yaml")));
+        });
+    });
+
+    describe("loadGitignoreDirs", () => {
+        it("returns an empty set when no .gitignore exists", async () => {
+            const dir = path.join(tempDir, "gi-none");
+            fs.mkdirSync(dir);
+
+            const result = await loadGitignoreDirs(dir);
+
+            assert.strictEqual(result.size, 0);
+        });
+
+        it("extracts plain directory names, including anchored and trailing-slash forms", async () => {
+            const dir = path.join(tempDir, "gi-plain");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, ".gitignore"), ["mybuild/", "/generated", "cache"].join("\n"));
+
+            const result = await loadGitignoreDirs(dir);
+
+            assert.ok(result.has("mybuild"));
+            assert.ok(result.has("generated"));
+            assert.ok(result.has("cache"));
+        });
+
+        it("ignores blanks, comments, negations, globs, and nested paths", async () => {
+            const dir = path.join(tempDir, "gi-skip");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(
+                path.join(dir, ".gitignore"),
+                ["", "# a comment", "!keep", "*.log", "build/**", "nested/path/", "logs"].join("\n"),
+            );
+
+            const result = await loadGitignoreDirs(dir);
+
+            assert.ok(result.has("logs"));
+            assert.ok(!result.has("keep"));
+            assert.ok(!result.has("*.log"));
+            assert.ok(!result.has("build"));
+            assert.ok(!result.has("nested"));
+            assert.ok(!result.has("path"));
+        });
+    });
+
+    describe("getEffectiveExcludedDirs", () => {
+        it("merges the static exclusion set with .gitignore entries", async () => {
+            const dir = path.join(tempDir, "eff-merge");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, ".gitignore"), "mybuild/\n");
+
+            const result = await getEffectiveExcludedDirs(dir);
+
+            assert.ok(result.has("node_modules"), "static entry should be present");
+            assert.ok(result.has("mybuild"), "gitignore entry should be present");
+        });
+
+        it("falls back to the static set when no .gitignore exists", async () => {
+            const dir = path.join(tempDir, "eff-none");
+            fs.mkdirSync(dir);
+
+            const result = await getEffectiveExcludedDirs(dir);
+
+            assert.ok(result.has("node_modules"));
+        });
+    });
+
+    describe("scanForDockerfiles + .gitignore", () => {
+        it("skips a Dockerfile inside a directory listed in .gitignore", async () => {
+            const dir = path.join(tempDir, "gi-docker");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, ".gitignore"), "mybuild/\n");
+            fs.mkdirSync(path.join(dir, "mybuild"), { recursive: true });
+            fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "mybuild", "Dockerfile"), "FROM node:20");
+            fs.writeFileSync(path.join(dir, "src", "Dockerfile"), "FROM node:20");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].includes("src"));
+        });
+
+        it("finds the Dockerfile when the directory is not gitignored", async () => {
+            const dir = path.join(tempDir, "gi-docker-nomatch");
+            fs.mkdirSync(dir);
+            fs.writeFileSync(path.join(dir, ".gitignore"), "somethingelse/\n");
+            fs.mkdirSync(path.join(dir, "mybuild"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "mybuild", "Dockerfile"), "FROM node:20");
+
+            const result = await scanForDockerfiles(dir);
+
+            assert.strictEqual(result.length, 1);
+            assert.ok(result[0].includes("mybuild"));
+        });
+    });
+
+    describe("isExcludedModulePath", () => {
+        const root = path.join(path.sep, "repo");
+
+        it("returns false for the root itself", () => {
+            assert.strictEqual(isExcludedModulePath(root, root), false);
+        });
+
+        it("returns false for paths outside the root", () => {
+            assert.strictEqual(isExcludedModulePath(path.join(path.sep, "other", "app"), root), false);
+        });
+
+        it("matches a static excluded segment by default", () => {
+            assert.strictEqual(isExcludedModulePath(path.join(root, ".next", "standalone"), root), true);
+        });
+
+        it("does not match a non-excluded module by default", () => {
+            assert.strictEqual(isExcludedModulePath(path.join(root, "services", "api"), root), false);
+        });
+
+        it("honors an extra excluded set passed in (e.g. from .gitignore)", () => {
+            const excluded = new Set(["mybuild"]);
+            assert.strictEqual(isExcludedModulePath(path.join(root, "mybuild", "app"), root, excluded), true);
+            assert.strictEqual(isExcludedModulePath(path.join(root, "services"), root, excluded), false);
         });
     });
 });


### PR DESCRIPTION
Fixes #2319.

Manifest generation iterates over modules returned by the SDK's `analyzeRepo`, whose walker doesn't skip build-output dirs. For Next.js apps the `.next/` standalone output ships its own `package.json`, so it's reported as an extra module and a duplicate manifest set is written to `<root>/.next/k8s/` alongside `<root>/k8s/`.

Filter out modules whose path resolves inside an excluded directory (`.next/`, `dist/`, `node_modules/`, etc.) in `analyzeRepository`, so all downstream steps (Dockerfile, manifests, workflow) ignore them.