### PR TITLE
Bump CI to Node 22 and package the webpack bundle without node_modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 20
+        node-version: 22
     - name: Build Extension
       run: |
         npm run install:all

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     permissions:
       actions: read
       contents: read
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1106,7 +1106,7 @@
         "dev:webview": "cd webview-ui && npm run dev",
         "build:webview": "cd webview-ui && npm run build",
         "vscode:prepublish": "npm run webpack",
-        "package": "vsce package",
+        "package": "vsce package --no-dependencies",
         "webpack": "npm run build:webview && webpack --mode production",
         "webpack-dev": "npm run build:webview && webpack --mode development --watch",
         "test-compile": "npm run build:webview && tsc -p ./ && cp resources/yaml/aks-deploy.template.yaml out/src/commands/aksContainerAssist/",


### PR DESCRIPTION
## Summary

This PR bumps the CI workflows (build, prettier, fuzzing) from Node 20 to Node 22, and adds `--no-dependencies` to the `package` script.

Node 20 is EOL as of April 2026. Node 22 is supported LTS and already the default in the publish pipeline, so this just aligns CI with it. 

The extension is also webpack-bundled meaning all deps are inlined into `dist/extension.js`, so shipping `node_modules` in the VSIX is redundant. `--no-dependencies` skips it, yielding a smaller VSIX and making packaging independent of npm's tree validation. (npm 11 on Node 24+ flags the tree as "invalid" and aborts `vsce package`, causing npm run build to fail, so this fixes build behavior for local devs on 24+ as well.)
