### PR TITLE
test(ci): raise extension-host heap ceiling to fix Windows smoke-test OOM

### DIFF
--- a/src/tests/runTests.ts
+++ b/src/tests/runTests.ts
@@ -11,8 +11,20 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-        // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        // Download VS Code, unzip it and run the integration test.
+        //
+        // The Windows CI runner is 20-40x slower on the webview/fs-heavy suite than Linux/macOS,
+        // so the extension host lingers in a high-memory state long enough to exhaust the default
+        // V8 heap and OOM-crash the renderer (reason: oom), failing the run. Raising the old-space
+        // ceiling for the extension-host process gives it the headroom to survive that stall.
+        // Applied on all platforms (harmless elsewhere; Windows is where it matters).
+        await runTests({
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            extensionTestsEnv: {
+                NODE_OPTIONS: "--max-old-space-size=8192",
+            },
+        });
     } catch (err) {
         console.error(`Failed to run tests:\n${err}`);
         if (err instanceof Error) {


### PR DESCRIPTION
## Summary

The `build (windows-latest)` smoke test intermittently fails with an extension-host OOM crash (`CodeWindow: renderer process gone (reason: oom)`), while `ubuntu-latest` and `macos-latest` always pass.

## Root cause

Profiling multiple runs (Windows vs Linux/macOS, passing vs failing) shows:

| OS | Test-suite span | Worst inter-test stall | OOM |
|---|---|---|---|
| Linux | ~17-29s | ~8-17s | no |
| macOS | ~21-24s | ~12-13s | no |
| Windows (pass) | 202-612s | 158-577s | no (survived) |
| Windows (fail) | — | multi-minute | **yes** |

The Windows runner is **20-40x slower** on the webview/fs-heavy extension-host RPC suite. The host lingers in a high-memory, GC-thrashing state (repeated `Extension host is unresponsive` cycles) for several minutes. When it tips over the default V8 heap ceiling, the renderer OOM-crashes and the run fails. Notably, the failing run's stall (410s) was *shorter* than passing runs (577s, 435s) — so this is **memory pressure, not a timeout**.

A headless-display approach (`xvfb`-style) is not applicable: `xvfb` is Linux/X11-only, and `@vscode/test-electron` exposes no headless flag for Windows/macOS (per VS Code CI docs + vscode-test API). Windows already renders offscreen.

## Fix

Raise the extension-host V8 old-space ceiling via `extensionTestsEnv: { NODE_OPTIONS: "--max-old-space-size=8192" }` in `runTests.ts`, giving the host headroom to survive the Windows stall. No-op on Linux/macOS, which finish the same suite in ~25s.

## Evaluation

Opening this to observe whether the Windows smoke test passes reliably with the raised heap ceiling.