### PR TITLE
chore(deps): combine non-major dependency updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,6 +81,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,7 +68,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
Combines the open Dependabot non-major GitHub Actions updates into a single PR:

**GitHub Actions**
- bump `github/codeql-action/autobuild` from 4.37.0 to 4.37.3 (#2351)
- bump `github/codeql-action/init` from 4.37.0 to 4.37.3 (#2349)
- bump `github/codeql-action/analyze` from 4.37.0 to 4.37.3 (#2347)

**Excluded (break CI, will be handled separately):**
- #2346 `react` 19.2.7 -> 19.2.8 — deterministically breaks the `Webview Styles > should contain css variables and rules` smoke test (webview renderer times out at 20s on ubuntu/macos). Reproduced across two CI runs.
- #2339 `@fortawesome/free-solid-svg-icons` 7.3.0 -> 7.3.1 — version skew with the rest of the FontAwesome family (`fontawesome-svg-core` / `react-fontawesome` still on 7.3.0) causes `TS2322: Type 'IconDefinition' is not assignable to type 'IconProp'`. Needs the whole family bumped together.

**Major-version bumps left for individual review:**
- #2348 `@azure/arm-resources` 7.0.0 -> 8.0.0
- #2342 `js-yaml` 4.3.0 -> 5.2.1

Each change was cherry-picked from the corresponding Dependabot PR head commit.

Note: `.github/dependabot.yml` already enforces a 7-day `cooldown` (`default-days: 7`) across all three ecosystems, so Dependabot only proposes versions that are at least a week old.