### PR TITLE
Publish release 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service (AKS)",
     "description": "Create, manage, deploy, and diagnose AKS clusters directly from VS Code",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
## Release 2.4.0

Version bump to **2.4.0** for publishing to the marketplace. Headlined by Container Assist flexibility work (optional ACR, per-artifact generation), Kickstart region/cost improvements, and a large refresh of pinned tool and GitHub Action versions.

**VSIX to test**: [vscode-aks-tools-2.4.0-test.vsix.zip](https://github.com/user-attachments/files/30722876/vscode-aks-tools-2.4.0-test.vsix.zip)

### Highlights

**Container Assist: optional ACR and per-artifact selection** — #2330
ACR is now optional when generating manifests — point at any existing image reference (GHCR, Docker Hub, etc.). The action picker became a 3-item multi-select so Dockerfile, Kubernetes manifests, and GitHub workflow can be generated independently. ACR remains required for workflow generation.

**Kickstart: open-capacity regions and base cost estimate** — #2327
Region recommendation now prefers regions with open AKS Automatic system-pool capacity, scanned through a bounded 5-at-a-time worker window instead of flooding ARM. The cost panel drops misleading node-derived line items and is now a flat "base cost estimate (excludes workloads)".

**Pinned tool and action version refresh** — #2278
Downloaded CLIs: kubelogin `v0.0.31`→`v0.2.19`, Draft `v0.0.38`→`v0.17.14`, Retina `v0.0.26`→`v1.2.2`, Inspektor Gadget `v0.51.0`→`v0.53.2`, aks-mcp `v0.0.17`→`v0.0.19`. Workflow templates: `actions/checkout` v4→v7, `azure/login` v2→v3, `azure/aks-set-context` v4→v5, `Azure/k8s-deploy` v5→v6. Generated workflows will change accordingly.

**Fixes**
- **container-assist**: Draft validate now surfaces policy findings in the results panel instead of failing on Draft's non-zero exit; also quotes paths with spaces and guards empty selections (#2312).
- **container-assist**: skip build-output directories when generating manifests, so Next.js apps no longer get a duplicate manifest set written to `.next/k8s/` (#2329, fixes #2319).

**CI & infra**
- Bump CI to Node 22 (Node 20 is EOL) and package the VSIX with `--no-dependencies` — smaller artifact, and unblocks local builds on npm 11 / Node 24+ (#2334).
- Fix the Windows smoke-test renderer OOM: dispose the leaked webview panel, await previously-floating assertions, and recurse into CSS `@layer` grouping rules. Windows step drops 680–718s → 58s (#2337, supersedes #2336).
- VSIX publishing moved to a service connection, dropping the token parameter (#2280).
- Dependabot moved from a weekly to a monthly schedule with a 7-day cooldown (#2297).

**Dependencies**
- ~27 Dependabot bumps across root and `webview-ui`, including a combined non-major GitHub Actions PR (#2354).

### Notes
- `CHANGELOG.md` is intentionally not updated (deprecated since 1.6.14). Release notes live in the GitHub Release.
- After merge, the internal 1ES signed pipeline publishes to the marketplace.

Thanks to @bosesuneha, @davidgamero, @pauldotyu , @tejhan and @Tatsinnit,  for contributions, testing, and reviews.


