### PR TITLE
chore(pipeline): install Azure CLI before the marketplace publish step

### DIFF
--- a/.azurepipelines/1es-pipeline.yml
+++ b/.azurepipelines/1es-pipeline.yml
@@ -133,6 +133,18 @@ extends:
                         # PUBLISH
                         # =====================================================
 
+                        # The 1ES Azure Linux 3 pool image does not ship the Azure CLI, but the
+                        # AzureCLI@2 task below requires `az` to already be on the PATH.
+                        - script: |
+                              set -e
+                              if ! command -v az >/dev/null 2>&1; then
+                                echo "Azure CLI not found on the agent image. Installing..."
+                                sudo tdnf install -y azure-cli || tdnf install -y azure-cli
+                              fi
+                              az version
+                          displayName: "Install Azure CLI"
+                          retryCountOnTaskFailure: 3
+
                         - task: AzureCLI@2
                           displayName: "Publish VSIX to Marketplace"
                           inputs:


### PR DESCRIPTION
## Problem

The release pipeline fails at **Publish VSIX to Marketplace**. That step uses `AzureCLI@2`, which requires `az` to already be on the agent's PATH, but the pinned 1ES pool image (`1es-azlinux-3-amd64-custom-disk`) does not ship the Azure CLI.

## Fix

Add an `Install Azure CLI` step immediately before the `AzureCLI@2` task:

- No-ops when `az` is already present, so it costs nothing if the image later includes it.
- Installs via `tdnf`, the package manager on Azure Linux 3, matching the pool image pinned in this same file.
- Falls back to a non-`sudo` invocation to cover the run-as-root case.
- `retryCountOnTaskFailure: 3` to absorb transient package feed errors.
- Prints `az version` so the resolved CLI version is visible in the log.

## Testing

- YAML parses cleanly and the embedded script passes `bash -n`.
- Prettier formatting check passes.
- End-to-end verification requires a release pipeline run.