### PR TITLE
Route 1ES npm traffic through the CFS proxy

### DIFF
--- a/.azurepipelines/1es-pipeline.yml
+++ b/.azurepipelines/1es-pipeline.yml
@@ -37,6 +37,9 @@ extends:
             - stage: Stage
               jobs:
                   - job: HostJob
+                    variables:
+                        NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
+                        NPM_CONFIG_REPLACE_REGISTRY_HOST: always
                     templateContext:
                         outputs:
                             - output: pipelineArtifact
@@ -64,6 +67,13 @@ extends:
                         # =====================================================
                         # BUILD, PACKAGE, AND STAGE VSIX
                         # =====================================================
+
+                        # Confirm the job-level CFS settings are inherited by npm before dependency installation.
+                        - script: |
+                              set -e
+                              npm config get registry
+                              npm config get replace-registry-host
+                          displayName: Verify npm registry configuration
 
                         - script: npm run install:all
                           displayName: Install npm dependencies
@@ -130,56 +140,54 @@ extends:
                               PendingAnalysisWaitTimeoutMinutes: 5
 
                         # =====================================================
-                        # PUBLISH
+                        # PUBLISH (disabled while validating CFS npm routing)
                         # =====================================================
 
-                        # The 1ES Azure Linux 3 pool image does not ship the Azure CLI, but the
-                        # AzureCLI@2 task below requires `az` to already be on the PATH.
-                        - script: |
-                              set -e
-                              if ! command -v az >/dev/null 2>&1; then
-                                echo "Azure CLI not found on the agent image. Installing..."
-                                sudo tdnf install -y azure-cli || tdnf install -y azure-cli
-                              fi
-                              az version
-                          displayName: "Install Azure CLI"
-                          retryCountOnTaskFailure: 3
+                        # - script: |
+                        #       set -e
+                        #       if ! command -v az >/dev/null 2>&1; then
+                        #         echo "Azure CLI not found on the agent image. Installing..."
+                        #         sudo tdnf install -y azure-cli || tdnf install -y azure-cli
+                        #       fi
+                        #       az version
+                        #   displayName: "Install Azure CLI"
+                        #   retryCountOnTaskFailure: 3
 
-                        - task: AzureCLI@2
-                          displayName: "Get AzDO User ID"
-                          inputs:
-                              azureSubscription: AKS-VsCode-Release
-                              scriptType: pscore
-                              scriptLocation: inlineScript
-                              inlineScript: |
-                                  az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+                        # - task: AzureCLI@2
+                        #   displayName: "Get AzDO User ID"
+                        #   inputs:
+                        #       azureSubscription: AKS-VsCode-Release
+                        #       scriptType: pscore
+                        #       scriptLocation: inlineScript
+                        #       inlineScript: |
+                        #           az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
 
-                        - task: AzureCLI@2
-                          displayName: "Publish VSIX to Marketplace"
-                          inputs:
-                              azureSubscription: AKS-VsCode-Release
-                              scriptType: bash
-                              scriptLocation: inlineScript
-                              inlineScript: |
-                                  set -e
-                                  VSIX_PATH=$(find "$(Pipeline.Workspace)/vscode-extension-signed/" -type f -name "*.vsix" -print -quit)
-                                  echo "Publishing VSIX package: $VSIX_PATH"
-                                  MANIFEST_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.manifest"
-                                  SIGNATURE_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.signature.p7s"
-                                  npx @vscode/vsce@latest publish --azure-credential --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
-                          env:
-                              VSCE_AZURE_CREDENTIAL_TIMEOUT: 60000
+                        # - task: AzureCLI@2
+                        #   displayName: "Publish VSIX to Marketplace"
+                        #   inputs:
+                        #       azureSubscription: AKS-VsCode-Release
+                        #       scriptType: bash
+                        #       scriptLocation: inlineScript
+                        #       inlineScript: |
+                        #           set -e
+                        #           VSIX_PATH=$(find "$(Pipeline.Workspace)/vscode-extension-signed/" -type f -name "*.vsix" -print -quit)
+                        #           echo "Publishing VSIX package: $VSIX_PATH"
+                        #           MANIFEST_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.manifest"
+                        #           SIGNATURE_PATH="$(Pipeline.Workspace)/vscode-extension-signed/extension.signature.p7s"
+                        #           npx @vscode/vsce@latest publish --azure-credential --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
+                        #   env:
+                        #       VSCE_AZURE_CREDENTIAL_TIMEOUT: 60000
 
-                        - task: GithubRelease@1
-                          displayName: "Create GitHub Release"
-                          inputs:
-                              gitHubConnection: AKS-VsCode-Release-GH-SVC
-                              repositoryName: Azure/vscode-aks-tools
-                              action: create
-                              title: ${{ parameters.publishVersion }}
-                              tagSource: userSpecifiedTag
-                              tag: ${{ parameters.publishVersion }}
-                              assets: |
-                                  $(Pipeline.Workspace)/vscode-extension-signed/vscode-aks-tools-*.vsix
-                                  $(Pipeline.Workspace)/vscode-extension-signed/extension.manifest
-                                  $(Pipeline.Workspace)/vscode-extension-signed/extension.signature.p7s
+                        # - task: GithubRelease@1
+                        #   displayName: "Create GitHub Release"
+                        #   inputs:
+                        #       gitHubConnection: AKS-VsCode-Release-GH-SVC
+                        #       repositoryName: Azure/vscode-aks-tools
+                        #       action: create
+                        #       title: ${{ parameters.publishVersion }}
+                        #       tagSource: userSpecifiedTag
+                        #       tag: ${{ parameters.publishVersion }}
+                        #       assets: |
+                        #           $(Pipeline.Workspace)/vscode-extension-signed/vscode-aks-tools-*.vsix
+                        #           $(Pipeline.Workspace)/vscode-extension-signed/extension.manifest
+                        #           $(Pipeline.Workspace)/vscode-extension-signed/extension.signature.p7s


### PR DESCRIPTION
## Summary
- configure the 1ES job to use the CFS npm proxy
- redirect registry URLs from existing lockfiles at runtime without modifying them