### PR TITLE
Publish release 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-aks-tools",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-aks-tools",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-aks-tools",
     "displayName": "Azure Kubernetes Service (AKS)",
     "description": "Create, manage, deploy, and diagnose AKS clusters directly from VS Code",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-kubernetes-tools",
     "l10n": "./l10n",


### PR DESCRIPTION
## Release 2.5.0

Version bump to **2.5.0** for publishing to the marketplace. Headlined by the Argo CD Application rework, plus a round of release-pipeline hardening.

**VSIX to test:** 
[vscode-aks-tools-2.5.0-test.vsix.zip](https://github.com/user-attachments/files/31200969/vscode-aks-tools-2.5.0-test.vsix.zip)


### Highlights

**Argo CD: renamed to "Create Argo CD Application" and simplified flow** — #2353
Resolves #2322, #2323, #2324, #2325.

- **Correct terminology** — "Create Argo CD GitOps Pipeline" is now **"Create Argo CD Application"** across the command title, localized strings, setting description, Copilot chat button, and docs. Argo CD manages *Applications*; the old name conflated a GitOps controller with a CI pipeline.
- **No more "separate repo" prescription** — the generated template and README no longer insist manifests live in a standalone GitOps config repo. Manifests can live alongside the app or in a separate repo; the user decides via the repo URL and path. The redundant `aks-extension/source-repo` annotation is gone.
- **Simpler UX** — the dense blocking pre-generate modal is removed. The command goes straight to prompts, and a non-modal "Learn More" toast appears only *after* the manifest is created. Added explicit prompts for the manifest path (default `k8s`) and output path (default `argocd`) instead of assuming `apps/<name>/`. The separate "config repo" and "source repo" prompts collapsed into one. The README is now optional and off by default. Output is `<output>/<app-name>.yaml` (+ optional `<app-name>-README.md`).
- **Fixed dashboard launch on a non-default port** — the post-apply "Open UI" flow hard-coded a `localhost:8080` port-forward, which broke Entra ID SSO whenever Argo CD was served elsewhere (the app-registration redirect URI is tied to the configured port). The extension now reads the port from the `argocd-cm` ConfigMap (`url`, falling back to `global.domain`) and uses it for both the local side of the port-forward and the opened URL, defaulting to `8080`.
- Hardened the user-supplied output path against absolute paths and `..` traversal escaping the workspace, and fixed a CodeQL incomplete-URL-substring finding in tests.

### CI & infra

- **Install Azure CLI before the marketplace publish step** (#2374) — the pinned 1ES pool image (`1es-azlinux-3-amd64-custom-disk`) doesn't ship `az`, so the `AzureCLI@2` publish task failed. Installs via `tdnf`, no-ops when `az` is already present.
- **Route 1ES npm traffic through the CFS proxy** (#2383) — registry URLs from existing lockfiles are redirected at runtime without modifying them.
- **Fix CFS tarball routing and pin VSCE** (#2384) — preserves CFS-provided Azure Artifacts tarball URLs, and uses the lockfile-installed VSCE version instead of resolving `latest`.
- **Add task to extract service connection id** (#2375).
- **Dependabot on a 15-day cadence with grouping** (#2366) — moved from `monthly` to cron on the 1st and 15th at 08:00 UTC, and replaced the `typescript-eslint` group with a minor+patch group per ecosystem. Majors stay ungrouped for individual review.

### Dependencies

- `fast-uri` 3.1.4 → 3.1.5 (#2369).

### Notes

- Pinned CLI and GitHub Action versions are **unchanged** this release — they were fully refreshed in 2.4.0 (#2278). Generated workflows are unaffected.
- `CHANGELOG.md` is intentionally not updated (deprecated since 1.6.14). Release notes live in the GitHub Release.
- After merge, the internal 1ES signed pipeline publishes to the marketplace.

Thanks to @bosesuneha, @davidgamero, @pauldotyu and @Tatsinnit for contributions, testing, and reviews.
