### PR TITLE
fix(deps): bump @azure/arm-resources-subscriptions to 3.0.0 and adapt to v3 type removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@azure/arm-msi": "^2.2.0",
                 "@azure/arm-resourcegraph": "^5.0.0-beta.5",
                 "@azure/arm-resources": "^8.0.0",
-                "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/arm-resources-subscriptions": "^3.0.0",
                 "@azure/arm-storage": "^20.1.0",
                 "@azure/arm-subscriptions": "^6.0.0",
                 "@azure/container-registry": "^1.1.2",
@@ -383,19 +383,20 @@
             }
         },
         "node_modules/@azure/arm-resources-subscriptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
-            "integrity": "sha512-vKiu/3Yh84IV3IuJJ+0Fgs/ZQpvuGzoZ3dAoBksIV++Uu/Qz9RcQVz7pj+APWYIuODuR9I0eGKswZvzynzekug==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-3.0.0.tgz",
+            "integrity": "sha512-Uu3i3HZ3nv69tVeNaXTr7KZ2qtcrJQiLvhREnZ0p5xNrV8Pmtrnx1o8A+z2T+OVQZlnySU5nPT4O4gJIJbfA5A==",
             "license": "MIT",
             "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.7.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure-rest/core-client": "^2.3.1",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-util": "^1.12.0",
+                "@azure/logger": "^1.2.0",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@azure/arm-storage": {

--- a/package.json
+++ b/package.json
@@ -1186,7 +1186,7 @@
         "@azure/arm-msi": "^2.2.0",
         "@azure/arm-resourcegraph": "^5.0.0-beta.5",
         "@azure/arm-resources": "^8.0.0",
-        "@azure/arm-resources-subscriptions": "^2.1.0",
+        "@azure/arm-resources-subscriptions": "^3.0.0",
         "@azure/arm-storage": "^20.1.0",
         "@azure/arm-subscriptions": "^6.0.0",
         "@azure/container-registry": "^1.1.2",

--- a/src/commands/utils/subscriptions.ts
+++ b/src/commands/utils/subscriptions.ts
@@ -1,4 +1,4 @@
-import { Subscription, SubscriptionsGetResponse } from "@azure/arm-resources-subscriptions";
+import { Subscription } from "@azure/arm-resources-subscriptions";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { getSubscriptionClient, listAll } from "./arm";
 import { getFilteredSubscriptions, SubscriptionFilter } from "./config";
@@ -45,17 +45,13 @@ function isDefinedSubscription(sub: Subscription): sub is DefinedSubscription {
     return sub.subscriptionId !== undefined && sub.displayName !== undefined;
 }
 
-function isDefinedSubscriptionGetResponse(sub: SubscriptionsGetResponse): sub is DefinedSubscription {
-    return sub.subscriptionId !== undefined && sub.displayName !== undefined;
-}
-
 export async function getSubscription(
     sessionProvider: ReadyAzureSessionProvider,
     subscriptionId: string,
 ): Promise<Errorable<DefinedSubscription>> {
     const client = getSubscriptionClient(sessionProvider);
-    const subResult: SubscriptionsGetResponse = await client.subscriptions.get(subscriptionId);
-    if (!isDefinedSubscriptionGetResponse(subResult)) {
+    const subResult: Subscription = await client.subscriptions.get(subscriptionId);
+    if (!isDefinedSubscription(subResult)) {
         return { succeeded: false, error: "Subscription is not found" };
     }
     return { succeeded: true, result: subResult };


### PR DESCRIPTION
Supersedes #2356, which fails CI.

### Problem

`@azure/arm-resources-subscriptions` 3.0.0 is the modular-SDK rewrite. It removes the `SubscriptionsGetResponse` type, breaking the build on #2356:

```
src/commands/utils/subscriptions.ts(1,24): error TS2305:
Module '"@azure/arm-resources-subscriptions"' has no exported member 'SubscriptionsGetResponse'.
```

This was the sole cause of both failing jobs on #2356 (`build (macos-latest)` and `fuzz (22.x)`); the Windows and Ubuntu builds were fail-fast collateral.

### Fix

`subscriptions.get()` now returns `Subscription` directly. In 2.1.0 the removed type was declared as `type SubscriptionsGetResponse = Subscription`, so switching to `Subscription` is behaviour-preserving. `isDefinedSubscriptionGetResponse` was byte-identical to `isDefinedSubscription`, so it collapses into the latter.

Net: +3 / -7 in one file.

### Notes on the rest of the v3 surface

- `SubscriptionClient`, its `(credential, options)` constructor, `Subscription` and `TenantIdDescription` are all unchanged, so `arm.ts` and `azureSessionProvider.ts` need no edits.
- v3 moved `endpoint` onto `ClientOptions`. `createSubscription` still resolves it first (`options.endpoint ?? getArmEndpoint(cloudSetting) ?? "https://management.azure.com"`), so the sovereign-cloud endpoint from `getArmEndpoint()` is still honoured.
- v3 defaults the auth scope to `https://management.azure.com/.default`, where 2.1.0 derived it from the endpoint. This is inert here: `getCredential()` returns a `TokenCredential` that ignores the requested scopes and returns the VS Code session token, so no sovereign-cloud regression.
- v3 declares `engines.node >= 22`. CI already runs Node 22.

### Verification

Run locally against this branch's lockfile with 3.0.0 installed:

| Check | Result |
|---|---|
| `tsc -p ./ --noEmit` | exit 0 |
| `npm run test-compile` (the step CI failed on) | exit 0 |
| `eslint` | exit 0 |
| `prettier --check` | clean |

The dependency bump commit retains dependabot's original authorship and its exact minimal lockfile edit.
