### PR TITLE
ci: run the documentation checks on pull requests

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,64 @@
+name: Docs Check
+
+# The documentation restates package.json in prose: command titles, menu paths,
+# setting defaults, pinned tool versions. Nothing verified those restatements
+# before merge, so they drifted. These checks run whenever either side changes.
+#
+# The scripts have no npm dependencies, so there is no install step.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "scripts/**"
+      - "package.json"
+      - "package.nls.json"
+      - "resources/**"
+      - ".github/workflows/docs-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "scripts/**"
+      - "package.json"
+      - "package.nls.json"
+      - "resources/**"
+      - ".github/workflows/docs-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  docs-check:
+    name: Documentation checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # Fails if package.json changed without regenerating docs/book/src/reference/.
+      # Fix with: npm run docs:reference
+      - name: Generated reference is up to date
+        run: npm run docs:reference:check
+
+      # Command IDs that do not exist, and menu breadcrumbs that do not match the
+      # menu package.json actually declares. Warnings do not fail the run.
+      - name: Documentation checks
+        run: npm run docs:check


### PR DESCRIPTION
`docs:check` and `docs:reference` are not invoked by anything. `website.yaml` only builds the book, and only on push to `main`. So the drift they exist to prevent can recur on the next PR, and did: the Draft page named a command that had been renamed months earlier, and a clean `docs:check` run never said so.

Two steps, no install (the scripts use only node builtins):

| Step | Fails when |
|---|---|
| `npm run docs:reference:check` | `package.json` changed without regenerating `docs/book/src/reference/` |
| `npm run docs:check` | unknown command IDs or names, or menu breadcrumbs that do not match the menu `package.json` declares |

Triggers on `docs/**`, `scripts/**`, `package.json`, `package.nls.json` and `resources/**`, which is every input the checks read.

## Why now

This was blocked until #2373 merged. `docs:check` failed on `main` with 2 `menu-syntax` errors in `merge-save-kubeconfig.md`; #2373 fixed both. `main` is green as of 8a4367f2, so this can go in without turning it red.

Verified against `main` at 834195f3:

```
[ok] identifiers   [ok] orphans   [ok] menu-paths   [ok] menu-syntax
0 error(s), 15 warning(s)
generated reference is up to date
```

Warnings do not fail the run. The 15 are `coverage` — commands with no prose yet.

Also aligns the `harden-runner` pin with the other five workflows (v2.20.0 → v2.20.1).

## Ordering

Independent of #2382, but they complement each other: #2382 documents these as commands to run by hand and adds a `titles` check. If both land, the CONTRIBUTING line saying neither runs in CI should be dropped — happy to do that in whichever merges second.
