### PR TITLE
chore(deps): bump @azure/arm-monitor from 7.0.0 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@azure/arm-containerservice": "25.4.0",
                 "@azure/arm-containerservicefleet": "^2.1.0",
                 "@azure/arm-features": "^3.1.0",
-                "@azure/arm-monitor": "^7.0.0",
+                "@azure/arm-monitor": "^8.0.0",
                 "@azure/arm-msi": "^2.2.0",
                 "@azure/arm-resourcegraph": "^5.0.0",
                 "@azure/arm-resources": "^8.0.0",
@@ -274,60 +274,22 @@
             }
         },
         "node_modules/@azure/arm-monitor": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-monitor/-/arm-monitor-7.0.0.tgz",
-            "integrity": "sha512-RtCLRc/29bqaaf5iuUOmJvc5XDolN/icFhlKC/rXXKTtmwB3sKymaOZbNHnOM4P0nJYpS5QIo7Nzvh4M3Wj+FA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-monitor/-/arm-monitor-8.0.0.tgz",
+            "integrity": "sha512-TmKqx0n7J0Hl9zrHbw0cRol98+MPQqsPdQULfZ768hh+ez7+eSajcIcW3NYyMLuezdZEhPDsEEQDedMt2pxgZg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
-                "@azure/core-lro": "^2.2.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
-                "tslib": "^2.2.0"
+                "@azure-rest/core-client": "^2.7.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-lro": "^3.1.0",
+                "@azure/core-rest-pipeline": "^1.24.0",
+                "@azure/core-util": "^1.12.0",
+                "@azure/logger": "^1.2.0",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/arm-monitor/node_modules/@azure/abort-controller": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-            "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/arm-monitor/node_modules/@azure/core-lro": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
-            "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-util": "^1.2.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@azure/arm-monitor/node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@azure/arm-msi": {
@@ -792,7 +754,7 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -811,7 +773,7 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -841,7 +803,7 @@
             "version": "0.23.5",
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
             "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^3.0.5",
@@ -856,7 +818,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -866,7 +828,7 @@
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -879,7 +841,7 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -895,7 +857,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
             "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.1"
@@ -1025,7 +987,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
             "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1035,7 +997,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
             "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.1",
@@ -1156,7 +1118,7 @@
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
             "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/types": "^0.15.0"
@@ -1169,7 +1131,7 @@
             "version": "0.16.8",
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
             "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.2",
@@ -1184,7 +1146,7 @@
             "version": "0.15.0",
             "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
             "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
@@ -1194,7 +1156,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.22"
@@ -1208,7 +1170,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -2485,14 +2447,14 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/js-yaml": {
@@ -3477,7 +3439,7 @@
             "version": "8.17.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3490,7 +3452,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4858,7 +4820,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/deepmerge": {
@@ -5654,7 +5616,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -5667,7 +5629,7 @@
             "version": "10.8.1",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
             "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "workspaces": [
                 "packages/*"
@@ -5726,7 +5688,7 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
@@ -5745,7 +5707,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5782,7 +5744,7 @@
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5799,7 +5761,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -5809,7 +5771,7 @@
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -5822,7 +5784,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -5835,7 +5797,7 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.16.0",
@@ -5853,14 +5815,14 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "devOptional": true,
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -5907,7 +5869,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -5920,7 +5882,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -5933,7 +5895,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -5943,7 +5905,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -6153,14 +6115,14 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
@@ -6288,7 +6250,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flat-cache": "^4.0.0"
@@ -6335,7 +6297,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
@@ -6362,7 +6324,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -6376,7 +6338,7 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/foreground-child": {
@@ -6591,7 +6553,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
@@ -6959,7 +6921,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -7013,7 +6975,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -7130,7 +7092,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7140,7 +7102,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -7409,7 +7371,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
@@ -7428,7 +7390,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-with-bigint": {
@@ -7601,7 +7563,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
@@ -7655,7 +7617,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -7753,7 +7715,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
@@ -8346,7 +8308,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nearley": {
@@ -8699,7 +8661,7 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -8822,7 +8784,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -8838,7 +8800,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
@@ -9015,7 +8977,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9346,7 +9308,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
@@ -11176,7 +11138,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -11714,7 +11676,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -12061,7 +12023,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -1190,7 +1190,7 @@
         "@azure/arm-containerservice": "25.4.0",
         "@azure/arm-containerservicefleet": "^2.1.0",
         "@azure/arm-features": "^3.1.0",
-        "@azure/arm-monitor": "^7.0.0",
+        "@azure/arm-monitor": "^8.0.0",
         "@azure/arm-msi": "^2.2.0",
         "@azure/arm-resourcegraph": "^5.0.0",
         "@azure/arm-resources": "^8.0.0",

--- a/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
+++ b/src/commands/aksRetinaCapture/aksUploadRetinaCapture.ts
@@ -45,7 +45,7 @@ export async function aksUploadRetinaCapture(_context: IActionContext, target: u
 
     // Get diagnostic settings for the cluster
     const clusterDiagnosticSettings = await getClusterDiagnosticSettings(sessionProvider, clusterNode.result);
-    if (!clusterDiagnosticSettings || !clusterDiagnosticSettings.value?.length) {
+    if (!clusterDiagnosticSettings || clusterDiagnosticSettings.length === 0) {
         vscode.window.showErrorMessage(
             "No storage account is found. Please attach a storage account in the Diagnostic settings of your cluster under the Monitoring blade in the portal.",
         );

--- a/src/commands/utils/clusters.ts
+++ b/src/commands/utils/clusters.ts
@@ -26,7 +26,7 @@ import { invokeKubectlCommand } from "./kubectl";
 import { withOptionalTempFile } from "./tempfile";
 import { getResources } from "./azureResources";
 import { ClusterFilter } from "./config";
-import { DiagnosticSettingsResourceCollection } from "@azure/arm-monitor";
+import { DiagnosticSettingsResource } from "@azure/arm-monitor";
 import { parseResource } from "../../azure-api-utils";
 import * as k8s from "vscode-kubernetes-tools-api";
 
@@ -940,11 +940,14 @@ export async function getClusters(
 export async function getClusterDiagnosticSettings(
     sessionProvider: ReadyAzureSessionProvider,
     clusterNode: AksClusterTreeNode,
-): Promise<DiagnosticSettingsResourceCollection | undefined> {
+): Promise<DiagnosticSettingsResource[] | undefined> {
     try {
         // Get diagnostic setting via diagnostic monitor
         const client = getMonitorClient(sessionProvider, clusterNode.subscriptionId);
-        const diagnosticSettings = await client.diagnosticSettings.list(clusterNode.armId);
+        const diagnosticSettings: DiagnosticSettingsResource[] = [];
+        for await (const diagnosticSetting of client.diagnosticSettings.list(clusterNode.armId)) {
+            diagnosticSettings.push(diagnosticSetting);
+        }
 
         return diagnosticSettings;
     } catch (e) {
@@ -954,7 +957,7 @@ export async function getClusterDiagnosticSettings(
 }
 
 export async function chooseStorageAccount(
-    diagnosticSettings: DiagnosticSettingsResourceCollection,
+    diagnosticSettings: DiagnosticSettingsResource[],
     placeholderText: string,
 ): Promise<string | void> {
     /*
@@ -962,11 +965,11 @@ export async function chooseStorageAccount(
           1. For the scenario of 1 storage account in diagnostic settings - Pick the storageId resource and get SAS.
           2. For the scenario for more than 1 then show VsCode quickPick to select and get SAS of selected.
     */
-    if (!diagnosticSettings || !diagnosticSettings.value) return undefined;
+    if (!diagnosticSettings || diagnosticSettings.length === 0) return undefined;
 
-    if (diagnosticSettings.value.length === 1) {
+    if (diagnosticSettings.length === 1) {
         // In case of only one storage account associated, use the one (1) as default storage account
-        const selectedStorageAccount = diagnosticSettings.value![0].storageAccountId!;
+        const selectedStorageAccount = diagnosticSettings[0].storageAccountId;
         if (!selectedStorageAccount) {
             vscode.window.showInformationMessage("Diagnostic setting does not have storage account associated.");
             return;
@@ -982,9 +985,9 @@ export async function chooseStorageAccount(
 
     const storageAccountNameToStorageIdArray: { id: string; label: string }[] = [];
 
-    diagnosticSettings.value?.forEach((item) => {
+    diagnosticSettings.forEach((item) => {
         if (item.storageAccountId) {
-            const { name } = parseResource(item.storageAccountId!);
+            const { name } = parseResource(item.storageAccountId);
             if (!name) {
                 vscode.window.showInformationMessage(`Storage Id is malformed: ${item.storageAccountId}`);
                 return;


### PR DESCRIPTION
Supersedes #2399.

Dependabot proposed `@azure/arm-monitor` 7.0.0 → 8.0.0 in #2399, but v8 is a breaking rewrite of the client surface and the bump alone does not compile:

```
src/commands/utils/clusters.ts(29,10): error TS2724: '"@azure/arm-monitor"' has no exported member named 'DiagnosticSettingsResourceCollection'. Did you mean 'DiagnosticSettingsResource'?
src/commands/utils/clusters.ts(985,40): error TS7006: Parameter 'item' implicitly has an 'any' type.
```

This PR carries the same version bump plus the migration.

## What changed in v8

Two things affect this repo:

1. `DiagnosticSettingsResourceCollection` no longer exists. The individual `DiagnosticSettingsResource` type is still exported.
2. `diagnosticSettings.list()` now returns a `PagedAsyncIterableIterator<DiagnosticSettingsResource>` instead of a collection object with a `.value` array.

## The migration

- `getClusterDiagnosticSettings` drains the pager into a `DiagnosticSettingsResource[]`.
- `chooseStorageAccount` accepts that array directly rather than reaching through `.value`.
- `aksUploadRetinaCapture` checks `.length === 0` instead of `.value?.length`.
- Removing `.value` also removed several non-null assertions (`!`) that were only there to get past the old optional-array typing.

## Sovereign clouds

`getMonitorClient` passes `{ endpoint: getArmEndpoint() }`. I checked v8's client factory still honours it:

```js
const endpointUrl = options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
```

So non-public-cloud behaviour is unchanged.

## Verification

Run locally against this branch:

| Check | Result |
|---|---|
| `npx tsc -p ./ --noEmit` | 0 errors |
| `npx eslint .` | 0 errors |
| `npm run test:fuzz` | 28 passing |

`package.json` change is limited to the single version line; the `package-lock.json` diff only touches `@azure/arm-monitor` and its nested dependencies.