### PR TITLE
chore: raise minimum VS Code to 1.125.0 and split @types/vscode out of the npm-root group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       default-days: 7
     groups:
       npm-root:
+        # Excluded so it gets its own PR: bumping @types/vscode forces a
+        # matching engines.vscode bump, which raises the minimum VS Code
+        # version and needs a deliberate decision.
+        exclude-patterns:
+          - "@types/vscode"
         update-types:
           - "minor"
           - "patch"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
                 "@types/sinon": "^22.0.0",
                 "@types/tmp": "^0.2.6",
                 "@types/uuid": "^11.0.0",
-                "@types/vscode": "^1.110.0",
+                "@types/vscode": "^1.125.0",
                 "@typescript-eslint/eslint-plugin": "^8.67.0",
                 "@typescript-eslint/parser": "^8.32.1",
                 "@vscode/l10n-dev": "^0.0.35",
@@ -85,7 +85,7 @@
                 "webpack-cli": "^7.2.2"
             },
             "engines": {
-                "vscode": "^1.110.0"
+                "vscode": "^1.125.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "l10n": "./l10n",
     "icon": "resources/aks-tools.png",
     "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.125.0"
     },
     "capabilities": {
         "untrustedWorkspaces": {
@@ -1147,7 +1147,7 @@
         "@types/sinon": "^22.0.0",
         "@types/tmp": "^0.2.6",
         "@types/uuid": "^11.0.0",
-        "@types/vscode": "^1.110.0",
+        "@types/vscode": "^1.125.0",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.32.1",
         "@vscode/l10n-dev": "^0.0.35",


### PR DESCRIPTION
Unblocks #2398.

`vsce package` fails when `@types/vscode` is ahead of `engines.vscode` — the only reason #2398 is red:

```
@types/vscode ^1.134.0 greater than engines.vscode ^1.110.0
```

**Changes:**
1. `engines.vscode` + `@types/vscode` → `^1.125.0` — two published `@types/vscode` releases behind the newest (1.136.0, 1.134.0, 1.125.0). Already the resolved lockfile version, so nothing changes at build time; this only raises the advertised floor.
2. Exclude `@types/vscode` from the `npm-root` Dependabot group. Ungrouped deps get individual PRs, so it can be paired with a matching `engines.vscode` bump instead of blocking routine updates.

**Verified:** `tsc` clean · `eslint` clean · `vsce ls` exit 0 (the check failing on #2398) · `npm ci` consistent. Lockfile diff is only the two mirrored range lines.

Once merged I'll rebase #2398, which should regenerate without `@types/vscode` and go green.